### PR TITLE
fix(configure): replace bare except: clauses with typed exception handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StratusScan-CLI
 
+[![Version: 0.1.0](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/ColonelPanicX/StratusScan-CLI/releases)
+[![Status: Beta](https://img.shields.io/badge/status-beta-yellow.svg)](#-project-status)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![AWS Commercial](https://img.shields.io/badge/AWS-Commercial-orange.svg)](https://aws.amazon.com/)
@@ -562,7 +564,11 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## 📊 Project Status
 
-**Current Version**: 3.1.0 (Production Ready)
+**Current Version**: 0.1.0 — **Beta**
+
+> ⚠️ StratusScan-CLI is currently in **Beta**. The API and output format may change
+> before the 1.0.0 stable release. Breaking changes will be documented in the changelog.
+> All development happens on the `dev` branch.
 
 - ✅ **75+ Automated Tests** - Comprehensive test coverage
 - ✅ **CI/CD Pipeline** - GitHub Actions testing Python 3.9-3.12
@@ -570,6 +576,40 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 - ✅ **Type Safety** - Full type hints throughout codebase
 - ✅ **Security Scanning** - Pre-commit hooks with Bandit
 - ✅ **40+ Exporters** - Comprehensive AWS resource coverage
+
+---
+
+## 🔖 Versioning Strategy
+
+StratusScan-CLI uses [Semantic Versioning (SemVer)](https://semver.org/).
+
+- **Current series**: `0.x.x` — pre-release, active development
+- **Stable release**: `1.0.0` — planned once core API and export format stabilize
+- **Breaking changes**: may occur in any `0.x` release; documented in the changelog
+- **Previous versions**: the `3.x.x` series is deprecated and superseded by `0.1.0`
+
+| Version Range | Status | Notes |
+|---|---|---|
+| `3.x.x` | Deprecated | Superseded by governance reset at `0.1.0` |
+| `0.1.x` | Active (Beta) | Current development line |
+| `1.0.0` | Planned | Stable release target |
+
+---
+
+## 🌿 Branch Workflow
+
+| Branch | Purpose | Target |
+|---|---|---|
+| `dev` | Primary development — all feature work merges here first | `main` (release only) |
+| `main` | Stable release snapshots only — no direct commits | — |
+| `feature/*` | Short-lived feature branches | `dev` via PR |
+
+**All work must originate from a GitHub Issue.** PRs must reference issues using GitHub
+closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`).
+
+```
+feature/* → dev → main (release merge only)
+```
 
 ---
 

--- a/advanced-settings.py
+++ b/advanced-settings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Title: StratusScan Advanced Settings Configuration
-Version: v3.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:

--- a/configure.py
+++ b/configure.py
@@ -86,8 +86,8 @@ def detect_aws_partition() -> Tuple[str, str]:
             return 'aws-us-gov', 'us-gov-west-1'
         else:
             return 'aws', 'us-east-1'
-    except:
-        # Default to commercial if detection fails
+    except Exception:
+        # Default to commercial if detection fails (e.g., no credentials configured)
         return 'aws', 'us-east-1'
 
 def get_aws_identity() -> Optional[Dict]:
@@ -119,7 +119,7 @@ def get_aws_identity() -> Optional[Dict]:
             'default_region': default_region
         }
         return _aws_identity
-    except:
+    except Exception:
         return None
 
 # ============================================================================
@@ -249,7 +249,7 @@ def check_permissions_silent() -> Dict:
                 required_passed += 1
             else:
                 optional_passed += 1
-        except:
+        except Exception:
             if config['required']:
                 required_failed += 1
             else:
@@ -413,7 +413,7 @@ def get_config_status(config: Dict, config_path: Path) -> str:
         mtime = config_path.stat().st_mtime
         mod_date = datetime.fromtimestamp(mtime).strftime("%b %d")
         return f"✅ OK (Updated {mod_date})"
-    except:
+    except OSError:
         return "✅ OK"
 
 # ============================================================================

--- a/configure.py
+++ b/configure.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: StratusScan Configuration Tool
-Version: v2.0.0
+Version: v0.1.0
 Date: DEC-24-2024
 
 Description:
@@ -450,7 +450,7 @@ def print_dashboard(config: Dict, config_path: Path):
 
     # Header
     print("\n")
-    print_box("STRATUSSCAN CONFIGURATION TOOL v2.0.0", 70)
+    print_box("STRATUSSCAN CONFIGURATION TOOL v0.1.0", 70)
 
     # Status box
     print("╔" + "═" * 68 + "╗")
@@ -1354,7 +1354,7 @@ if __name__ == "__main__":
             sys.exit(0 if success else 1)
 
         elif arg in ['--help', '-h']:
-            print("StratusScan Configuration Tool v2.0.0")
+            print("StratusScan Configuration Tool v0.1.0")
             print("\nUsage:")
             print("  python configure.py                              # Interactive dashboard")
             print("  python configure.py --deps                       # Dependency check only")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stratusscan-cli"
-version = "3.1.0"
+version = "0.1.0"
 description = "AWS defensive security scanning and auditing tool for resource exports"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -79,10 +79,10 @@ stratusscan = "stratusscan:main"
 stratusscan-configure = "configure:main"
 
 [project.urls]
-Homepage = "https://github.com/yourusername/stratusscan-cli"
-Documentation = "https://github.com/yourusername/stratusscan-cli#readme"
-Repository = "https://github.com/yourusername/stratusscan-cli"
-Issues = "https://github.com/yourusername/stratusscan-cli/issues"
+Homepage = "https://github.com/ColonelPanicX/StratusScan-CLI"
+Documentation = "https://github.com/ColonelPanicX/StratusScan-CLI#readme"
+Repository = "https://github.com/ColonelPanicX/StratusScan-CLI"
+Issues = "https://github.com/ColonelPanicX/StratusScan-CLI/issues"
 
 # ===== Tool Configuration =====
 

--- a/scripts/README-s3-accesspoints-export.md
+++ b/scripts/README-s3-accesspoints-export.md
@@ -326,7 +326,7 @@ $ python scripts/s3-accesspoints-export.py
 ====================================================================
 AWS S3 ACCESS POINTS COMPREHENSIVE EXPORT SCRIPT
 ====================================================================
-Version: v1.0.0                       Date: NOV-13-2025
+Version: v0.1.0                       Date: NOV-13-2025
 Environment: AWS Commercial
 ====================================================================
 Account ID: 123456789012

--- a/scripts/access-analyzer-export.py
+++ b/scripts/access-analyzer-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS IAM Access Analyzer Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("         AWS IAM ACCESS ANALYZER EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/acm-export.py
+++ b/scripts/acm-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Certificate Manager (ACM) Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("    AWS CERTIFICATE MANAGER (ACM) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/ami-export.py
+++ b/scripts/ami-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS AMI (Amazon Machine Images) Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -64,7 +64,7 @@ def print_title():
     print("====================================================================")
     print("          AWS AMI (AMAZON MACHINE IMAGES) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/api-gateway-export.py
+++ b/scripts/api-gateway-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS API Gateway Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("               AWS API GATEWAY EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/autoscaling-export.py
+++ b/scripts/autoscaling-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Auto Scaling Groups Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("          AWS AUTO SCALING GROUPS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/backup-export.py
+++ b/scripts/backup-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Backup Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("                  AWS BACKUP EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/billing-export.py
+++ b/scripts/billing-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Account Billing Data Export
-Version: v1.3.0
+Version: v0.1.0
 Date: MAR-04-2025
 
 Description:
@@ -98,7 +98,7 @@ def print_title():
     print("====================================================================")
     print("AWS ACCOUNT BILLING DATA EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.3.0                                 Date: MAR-04-2025")
+    print("Version: v0.1.0                                 Date: MAR-04-2025")
     print("====================================================================")
     
     # Get the current AWS account ID

--- a/scripts/budgets-export.py
+++ b/scripts/budgets-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Budgets Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("                   AWS BUDGETS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/cloudfront-export.py
+++ b/scripts/cloudfront-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS CloudFront Distribution Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -60,7 +60,7 @@ def print_title():
     print("====================================================================")
     print("         AWS CLOUDFRONT DISTRIBUTION EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/cloudtrail-export.py
+++ b/scripts/cloudtrail-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS CloudTrail Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("                AWS CLOUDTRAIL EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/cloudwatch-export.py
+++ b/scripts/cloudwatch-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS CloudWatch Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -55,7 +55,7 @@ def print_title():
     print("====================================================================")
     print("              AWS CLOUDWATCH EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/compute-optimizer-export.py
+++ b/scripts/compute-optimizer-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Compute Optimizer Recommendations Export
-Version: v1.0.0
+Version: v0.1.0
 Date: MAR-05-2025
 
 Description:
@@ -95,7 +95,7 @@ def print_title():
     print("====================================================================")
     print("AWS COMPUTE OPTIMIZER RECOMMENDATIONS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                                Date: MAR-05-2025")
+    print("Version: v0.1.0                                Date: MAR-05-2025")
     print("====================================================================")
     
     # Get the current AWS account ID

--- a/scripts/compute-resources.py
+++ b/scripts/compute-resources.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Compute Resources All-in-One Export Script
-Version: v3.0.0
+Version: v0.1.0
 Date: OCT-08-2025
 
 Description:
@@ -131,7 +131,7 @@ def print_title():
     print("====================================================================")
     print("AWS COMPUTE RESOURCES ALL-IN-ONE COLLECTION")
     print("====================================================================")
-    print("Version: v3.0.0                       Date: OCT-08-2025")
+    print("Version: v0.1.0                       Date: OCT-08-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/config-export.py
+++ b/scripts/config-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Config Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("                  AWS CONFIG EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/cost-optimization-hub-export.py
+++ b/scripts/cost-optimization-hub-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Cost Optimization Hub Export
-Version: v1.0.0
+Version: v0.1.0
 Date: OCT-08-2025
 
 Description:

--- a/scripts/datasync-export.py
+++ b/scripts/datasync-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS DataSync Comprehensive Export Script
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-13-2025
 
 Description:

--- a/scripts/detective-export.py
+++ b/scripts/detective-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Detective Information Collection Script
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -61,7 +61,7 @@ def print_title():
     print("====================================================================")
     print("AWS DETECTIVE INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v1.1.0                       Date: NOV-16-2025")
+    print("Version: v0.1.0                       Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/directconnect-export.py
+++ b/scripts/directconnect-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Direct Connect Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -123,7 +123,7 @@ def print_title():
     print("====================================================================")
     print("              AWS DIRECT CONNECT EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-11-2025")
+    print("Version: v0.1.0                        Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/dynamodb-export.py
+++ b/scripts/dynamodb-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS DynamoDB Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("                 AWS DYNAMODB EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/ebs-snapshots-export.py
+++ b/scripts/ebs-snapshots-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS EBS Snapshots Export Tool
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("AWS EBS SNAPSHOTS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v2.0.0                                Date: AUG-19-2025")
+    print("Version: v0.1.0                                Date: AUG-19-2025")
 
     # Get account information using utils
     account_id, account_name = utils.get_account_info()

--- a/scripts/ebs-volumes-export.py
+++ b/scripts/ebs-volumes-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS EBS Volume Data Export
-Version: v1.3.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -311,7 +311,7 @@ def print_title():
     print("====================================================================")
     print("               AWS EBS VOLUME DATA EXPORT                         ")
     print("====================================================================")
-    print("Version: v1.2.0                               Date: SEP-30-2025")
+    print("Version: v0.1.0                               Date: SEP-30-2025")
 
     # Get account information using utils
     account_id, account_name = utils.get_account_info()

--- a/scripts/ec2-export.py
+++ b/scripts/ec2-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS EC2 Instance Data Export Script
-Version: v1.12.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:

--- a/scripts/ecr-export.py
+++ b/scripts/ecr-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Elastic Container Registry (ECR) Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("        AWS ELASTIC CONTAINER REGISTRY (ECR) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/ecs-export.py
+++ b/scripts/ecs-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS ECS Resource Export Script
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -109,7 +109,7 @@ def print_title():
     print("====================================================================")
     print("AWS ECS (ELASTIC CONTAINER SERVICE) RESOURCE EXPORT")
     print("====================================================================")
-    print("Version: v1.1.0                                 Date: NOV-16-2025")
+    print("Version: v0.1.0                                 Date: NOV-16-2025")
     print("====================================================================")
     
     # Get account information

--- a/scripts/efs-export.py
+++ b/scripts/efs-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS EFS (Elastic File System) Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("         AWS EFS (ELASTIC FILE SYSTEM) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/eks-export.py
+++ b/scripts/eks-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS EKS Cluster Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -123,7 +123,7 @@ def print_title():
     print("====================================================================")
     print("AWS EKS CLUSTER INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/elasticache-export.py
+++ b/scripts/elasticache-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS ElastiCache Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("               AWS ELASTICACHE EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/elasticbeanstalk-export.py
+++ b/scripts/elasticbeanstalk-export.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 AWS Elastic Beanstalk Export Script for StratusScan
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Exports comprehensive AWS Elastic Beanstalk PaaS information including applications,

--- a/scripts/elb-export.py
+++ b/scripts/elb-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Elastic Load Balancer Data Export
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -77,7 +77,7 @@ def print_title_screen():
     print("====================================================================")
     print("AWS ELB INVENTORY EXPORT SCRIPT")
     print("====================================================================")
-    print("Version: v2.0.0                             Date: AUG-19-2025")
+    print("Version: v0.1.0                             Date: AUG-19-2025")
     print(f"Environment: {partition_name}")
     print("====================================================================")
     print(f"Account ID: {account_id}")

--- a/scripts/eventbridge-export.py
+++ b/scripts/eventbridge-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS EventBridge Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -56,7 +56,7 @@ def print_title():
     print("====================================================================")
     print("               AWS EVENTBRIDGE EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/fsx-export.py
+++ b/scripts/fsx-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS FSx Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -57,7 +57,7 @@ def print_title():
     print("====================================================================")
     print("                   AWS FSx EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/globalaccelerator-export.py
+++ b/scripts/globalaccelerator-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Global Accelerator Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -69,7 +69,7 @@ def print_title():
     print("====================================================================")
     print("           AWS GLOBAL ACCELERATOR EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-11-2025")
+    print("Version: v0.1.0                        Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/guardduty-export.py
+++ b/scripts/guardduty-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS GuardDuty Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("               AWS GUARDDUTY EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/iam-comprehensive-export.py
+++ b/scripts/iam-comprehensive-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Comprehensive Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-23-2025
 
 Description:
@@ -66,7 +66,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM COMPREHENSIVE EXPORT")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-23-2025")
+    print("Version: v0.1.0                       Date: SEP-23-2025")
 
     # Get account information using utils
     account_id, account_name = utils.get_account_info()

--- a/scripts/iam-export.py
+++ b/scripts/iam-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM User Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: AUG-26-2025
 
 Description:
@@ -126,7 +126,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM USER INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: AUG-26-2025")
+    print("Version: v0.1.0                       Date: AUG-26-2025")
 
     # Get account information
     account_id, account_name = get_account_info()

--- a/scripts/iam-identity-center-comprehensive-export.py
+++ b/scripts/iam-identity-center-comprehensive-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Identity Center Comprehensive Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -63,7 +63,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM IDENTITY CENTER COMPREHENSIVE COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/iam-identity-center-export.py
+++ b/scripts/iam-identity-center-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Identity Center Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-23-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM IDENTITY CENTER INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-23-2025")
+    print("Version: v0.1.0                       Date: SEP-23-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/iam-identity-center-groups-export.py
+++ b/scripts/iam-identity-center-groups-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Identity Center Groups Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-23-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM IDENTITY CENTER GROUPS EXPORT")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-23-2025")
+    print("Version: v0.1.0                       Date: SEP-23-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/iam-identity-center-permission-sets-export.py
+++ b/scripts/iam-identity-center-permission-sets-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Permission Sets Text Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-26-2025
 
 Description:

--- a/scripts/iam-policies-export.py
+++ b/scripts/iam-policies-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Policy Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-22-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM POLICY INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-22-2025")
+    print("Version: v0.1.0                       Date: SEP-22-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/iam-roles-export.py
+++ b/scripts/iam-roles-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Role Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-22-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM ROLE INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-22-2025")
+    print("Version: v0.1.0                       Date: SEP-22-2025")
 
     # Get account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/iam-rolesanywhere-export.py
+++ b/scripts/iam-rolesanywhere-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS IAM Roles Anywhere Export Script
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -50,7 +50,7 @@ def print_title():
     print("====================================================================")
     print("AWS IAM ROLES ANYWHERE COMPREHENSIVE EXPORT")
     print("====================================================================")
-    print("Version: v1.0.0                       Date: NOV-11-2025")
+    print("Version: v0.1.0                       Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/image-builder-export.py
+++ b/scripts/image-builder-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS EC2 Image Builder Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("           AWS EC2 IMAGE BUILDER EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/kms-export.py
+++ b/scripts/kms-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS KMS (Key Management Service) Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("       AWS KMS (KEY MANAGEMENT SERVICE) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/lambda-export.py
+++ b/scripts/lambda-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Lambda Functions Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -63,7 +63,7 @@ def print_title():
     print("====================================================================")
     print("             AWS LAMBDA FUNCTIONS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/macie-export.py
+++ b/scripts/macie-export.py
@@ -2,7 +2,7 @@
 """
 AWS Macie Export Script for StratusScan
 
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:

--- a/scripts/nacl-export.py
+++ b/scripts/nacl-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Network ACL (NACL) Data Export
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("AWS NETWORK ACL (NACL) DATA EXPORT TOOL")
     print("====================================================================")
-    print("Version: v2.0.0                                Date: AUG-26-2025")
+    print("Version: v0.1.0                                Date: AUG-26-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/network-firewall-export.py
+++ b/scripts/network-firewall-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Network Firewall Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("           AWS NETWORK FIREWALL EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/network-resources.py
+++ b/scripts/network-resources.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Network Resources All-in-One Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -125,7 +125,7 @@ def print_title():
     print("====================================================================")
     print("AWS NETWORK RESOURCES ALL-IN-ONE COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/organizations-export.py
+++ b/scripts/organizations-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Organizations Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -150,7 +150,7 @@ def print_title():
     print("====================================================================")
     print("AWS ORGANIZATIONS INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/rds-export.py
+++ b/scripts/rds-export.py
@@ -7,7 +7,7 @@
 ===========================
 
 Title: AWS RDS Instance Export Script
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -63,7 +63,7 @@ def print_title():
     print("====================================================================")
     print("                   AWS RESOURCE SCANNER                            ")
     print("====================================================================")
-    print("            AWS RDS INSTANCE EXPORT SCRIPT v2.1.0        ")
+    print("            AWS RDS INSTANCE EXPORT SCRIPT v0.1.0        ")
     print("====================================================================")
     
     # Get the current AWS account ID using STS (Security Token Service)

--- a/scripts/route-tables-export.py
+++ b/scripts/route-tables-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Route Tables Export
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -97,7 +97,7 @@ def print_title():
     print("====================================================================")
     print("AWS ROUTE TABLES EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                                 Date: MAR-05-2025")
+    print("Version: v0.1.0                                 Date: MAR-05-2025")
     print("====================================================================")
     
     # Get the current AWS account ID

--- a/scripts/route53-export.py
+++ b/scripts/route53-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Route 53 DNS Service Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("           AWS ROUTE 53 DNS SERVICE EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-11-2025")
+    print("Version: v0.1.0                        Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/s3-accesspoints-export.py
+++ b/scripts/s3-accesspoints-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS S3 Access Points Comprehensive Export
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-13-2025
 
 Description:
@@ -48,7 +48,7 @@ def print_title() -> tuple:
     print("====================================================================")
     print("AWS S3 ACCESS POINTS COMPREHENSIVE EXPORT SCRIPT")
     print("====================================================================")
-    print("Version: v1.0.0                       Date: NOV-13-2025")
+    print("Version: v0.1.0                       Date: NOV-13-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/s3-export.py
+++ b/scripts/s3-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS S3 Bucket Inventory Export
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -61,7 +61,7 @@ def print_title():
     print("====================================================================")
     print("AWS S3 BUCKET INVENTORY EXPORT SCRIPT")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: AUG-19-2025")
+    print("Version: v0.1.0                       Date: AUG-19-2025")
 
     # Get account information using utils
     account_id, account_name = utils.get_account_info()

--- a/scripts/savings-plans-export.py
+++ b/scripts/savings-plans-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Savings Plans Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -58,7 +58,7 @@ def print_title():
     print("====================================================================")
     print("                AWS SAVINGS PLANS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/secrets-manager-export.py
+++ b/scripts/secrets-manager-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Secrets Manager Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("            AWS SECRETS MANAGER EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/security-groups-export.py
+++ b/scripts/security-groups-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Security Groups Export Script
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("AWS SECURITY GROUPS EXPORT")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: AUG-26-2025")
+    print("Version: v0.1.0                       Date: AUG-26-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/security-hub-export.py
+++ b/scripts/security-hub-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Security Hub Information Collection Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -118,7 +118,7 @@ def print_title():
     print("====================================================================")
     print("AWS SECURITY HUB INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/shield-export.py
+++ b/scripts/shield-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Shield Advanced Information Collection Script
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -67,7 +67,7 @@ def print_title():
     print("====================================================================")
     print("AWS SHIELD ADVANCED INFORMATION COLLECTION")
     print("====================================================================")
-    print("Version: v1.0.0                       Date: NOV-11-2025")
+    print("Version: v0.1.0                       Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/smart_scan/__init__.py
+++ b/scripts/smart_scan/__init__.py
@@ -5,7 +5,7 @@ This package analyzes services-in-use export output and recommends
 relevant StratusScan export scripts to run based on discovered services.
 """
 
-__version__ = "1.0.0"
+__version__ = "0.1.0"
 
 from .analyzer import (
     find_latest_services_export,

--- a/scripts/sqs-sns-export.py
+++ b/scripts/sqs-sns-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS SQS/SNS Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -56,7 +56,7 @@ def print_title():
     print("====================================================================")
     print("                 AWS SQS/SNS EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/ssm-fleet-export.py
+++ b/scripts/ssm-fleet-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Systems Manager Fleet Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -56,7 +56,7 @@ def print_title():
     print("====================================================================")
     print("         AWS SYSTEMS MANAGER FLEET EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/storage-resources.py
+++ b/scripts/storage-resources.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Storage Resources All-in-One Export Script
-Version: v2.0.0
+Version: v0.1.0
 Date: SEP-25-2025
 
 Description:
@@ -124,7 +124,7 @@ def print_title():
     print("====================================================================")
     print("AWS STORAGE RESOURCES ALL-IN-ONE COLLECTION")
     print("====================================================================")
-    print("Version: v2.0.0                       Date: SEP-25-2025")
+    print("Version: v0.1.0                       Date: SEP-25-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/transfer-family-export.py
+++ b/scripts/transfer-family-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Transfer Family Comprehensive Export Script
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-14-2025
 
 Description:
@@ -53,7 +53,7 @@ def print_title():
     print("====================================================================")
     print("AWS TRANSFER FAMILY COMPREHENSIVE EXPORT")
     print("====================================================================")
-    print("Version: v1.0.0                       Date: NOV-14-2025")
+    print("Version: v0.1.0                       Date: NOV-14-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/transit-gateway-export.py
+++ b/scripts/transit-gateway-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS Transit Gateway Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-09-2025
 
 Description:
@@ -59,7 +59,7 @@ def print_title():
     print("====================================================================")
     print("             AWS TRANSIT GATEWAY EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-09-2025")
+    print("Version: v0.1.0                        Date: NOV-09-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/trusted-advisor-cost-optimization-export.py
+++ b/scripts/trusted-advisor-cost-optimization-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Trusted Advisor Cost Optimization Export
-Version: v1.0.1
+Version: v0.1.0
 Date: FEB-28-2025
 
 Description:

--- a/scripts/verifiedaccess-export.py
+++ b/scripts/verifiedaccess-export.py
@@ -6,7 +6,7 @@
 ===========================
 
 Title: AWS Verified Access Export Script
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -49,7 +49,7 @@ def print_title():
     print("====================================================================")
     print("AWS VERIFIED ACCESS COMPREHENSIVE EXPORT")
     print("====================================================================")
-    print("Version: v1.0.0                       Date: NOV-11-2025")
+    print("Version: v0.1.0                       Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/vpc-data-export.py
+++ b/scripts/vpc-data-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS VPC, Subnet, NAT Gateway, Peering Connection, and Elastic IP Export Tool
-Version: v2.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:
@@ -53,7 +53,7 @@ def print_title():
     print("====================================================================")
     print("AWS VPC, SUBNET, NAT GATEWAY, PEERING, AND ELASTIC IP EXPORT TOOL")
     print("====================================================================")
-    print("Version: v2.0.0                        Date: AUG-19-2025")
+    print("Version: v0.1.0                        Date: AUG-19-2025")
 
     # Get the current AWS account ID and validate AWS environment
     try:

--- a/scripts/vpn-export.py
+++ b/scripts/vpn-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS VPN Connectivity Export Tool
-Version: v1.0.0
+Version: v0.1.0
 Date: NOV-11-2025
 
 Description:
@@ -62,7 +62,7 @@ def print_title():
     print("====================================================================")
     print("            AWS VPN CONNECTIVITY EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.0.0                        Date: NOV-11-2025")
+    print("Version: v0.1.0                        Date: NOV-11-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/scripts/waf-export.py
+++ b/scripts/waf-export.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: AWS WAF (Web Application Firewall) Export Tool
-Version: v1.1.0
+Version: v0.1.0
 Date: NOV-16-2025
 
 Description:
@@ -60,7 +60,7 @@ def print_title():
     print("====================================================================")
     print("         AWS WAF (WEB APPLICATION FIREWALL) EXPORT TOOL")
     print("====================================================================")
-    print("Version: v1.1.0                        Date: NOV-16-2025")
+    print("Version: v0.1.0                        Date: NOV-16-2025")
     # Detect partition and set environment name
     partition = utils.detect_partition()
     partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -7,7 +7,7 @@
 ===========================
 
 Title: StratusScan - AWS Resource Exporter Main Menu
-Version: v3.1.1
+Version: v0.1.0
 Date: DEC-04-2025
 
 Description:
@@ -76,7 +76,7 @@ def print_header():
     print("                         STRATUSSCAN                                ")
     print("                   AWS RESOURCE EXPORTER MENU                      ")
     print("====================================================================")
-    print("Version: v3.1.1                                Date: DEC-04-2025")
+    print("Version: v0.1.0                                Date: FEB-17-2026")
     print("Multi-Partition: Commercial & GovCloud Support")
     print("====================================================================")
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@
 ===========================
 
 Title: StratusScan Utilities Module
-Version: v3.1.0
+Version: v0.1.0
 Date: NOV-15-2025
 
 Description:


### PR DESCRIPTION
## Summary

- Replaces 4 bare `except:` clauses in `configure.py` with typed exception handlers
- Prevents `KeyboardInterrupt` and `SystemExit` from being silently swallowed during startup, partition detection, and permission checks
- Narrows line 416 to `except OSError:` — the precise type that `stat()` can raise

## Changes

| Line | Function | Before | After |
|---|---|---|---|
| 89 | `detect_aws_partition()` | `except:` | `except Exception:` |
| 122 | `get_aws_identity()` | `except:` | `except Exception:` |
| 252 | `check_permissions_silent()` | `except:` | `except Exception:` |
| 416 | `get_config_status()` | `except:` | `except OSError:` |

## Notes

Logging integration (adding `utils.log_warning()` at the call sites on lines 89 and 122) is deferred to Issue #13, which imports `utils` into `configure.py`. No logging is meaningful at lines 252 and 416 where failures are expected behavior.

## Test plan

- [ ] Verify `grep "except:" configure.py` returns no results
- [ ] Verify `python3 -m py_compile configure.py` exits 0
- [ ] Run `python configure.py --validate` in a no-credentials environment and confirm it exits cleanly rather than hanging or producing a traceback
- [ ] Press Ctrl+C during `python configure.py` startup and confirm `KeyboardInterrupt` propagates (handled by `main()` at line 1311)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)