### PR TITLE
fix(core-engine): replace direct logger.* calls with log_*() wrappers

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -307,8 +307,8 @@ def validate_aws_region(region: str) -> bool:
         return True
 
     if not is_aws_region(region):
-        logger.error(f"Invalid AWS region: {region}")
-        logger.error(f"Valid AWS regions include: us-east-1, us-west-1, us-west-2, eu-west-1, ap-southeast-1")
+        log_error(f"Invalid AWS region: {region}")
+        log_error("Valid AWS regions include: us-east-1, us-west-1, us-west-2, eu-west-1, ap-southeast-1")
         return False
 
     return True
@@ -525,7 +525,7 @@ def config_value(key: str, default: Any = None, section: Optional[str] = None) -
             if key in cfg:
                 return cfg[key]
     except Exception as e:
-        logger.warning(f"Error reading config value '{key}': {e}")
+        log_warning(f"Error reading config value '{key}': {e}")
 
     return default
 


### PR DESCRIPTION
## Summary

- Replaces two `logger.error()` calls in `validate_aws_region()` with `log_error()` wrapper
- Replaces one `logger.warning()` call in `config_value()` with `log_warning()` wrapper
- Removes unnecessary `f`-string from a static string literal (no interpolation needed)

The module-level `logger` is initialized to `None` at line 42 and only assigned by `setup_logging()`. Any call to `validate_aws_region()` or `config_value()` before `setup_logging()` is invoked would raise `AttributeError: 'NoneType' object has no attribute 'error'`. The `log_error()` and `log_warning()` wrapper functions already guard for this case.

## Test plan

- [ ] Confirm `utils.py` passes `python3 -m py_compile`
- [ ] Run `pytest tests/test_utils.py -v` and confirm no regressions
- [ ] Verify `validate_aws_region("bad-region")` and `config_value("missing_key")` do not raise when called before `setup_logging()`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)