### PR TITLE
fix(security): replace direct boto3.client() calls with utils.get_boto3_client() in configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -54,6 +54,13 @@ except ImportError:
     class NoCredentialsError(Exception):
         pass
 
+# Import shared utilities (provides FIPS-aware get_boto3_client and detect_partition)
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent))
+    import utils
+
 # ============================================================================
 # GLOBAL STATE (for background checks)
 # ============================================================================
@@ -74,21 +81,9 @@ def detect_aws_partition() -> Tuple[str, str]:
     Returns:
         tuple: (partition, default_region) - e.g., ('aws', 'us-east-1') or ('aws-us-gov', 'us-gov-west-1')
     """
-    if not BOTO3_AVAILABLE:
-        return 'aws', 'us-east-1'
-
-    try:
-        sts = boto3.client('sts')
-        identity = sts.get_caller_identity()
-        arn = identity.get('Arn', '')
-
-        if 'aws-us-gov' in arn:
-            return 'aws-us-gov', 'us-gov-west-1'
-        else:
-            return 'aws', 'us-east-1'
-    except Exception:
-        # Default to commercial if detection fails (e.g., no credentials configured)
-        return 'aws', 'us-east-1'
+    partition = utils.detect_partition()
+    default_region = 'us-gov-west-1' if partition == 'aws-us-gov' else 'us-east-1'
+    return partition, default_region
 
 def get_aws_identity() -> Optional[Dict]:
     """
@@ -106,9 +101,9 @@ def get_aws_identity() -> Optional[Dict]:
         return None
 
     try:
-        sts = boto3.client('sts')
-        identity = sts.get_caller_identity()
         partition, default_region = detect_aws_partition()
+        sts = utils.get_boto3_client('sts', default_region)
+        identity = sts.get_caller_identity()
 
         _aws_identity = {
             'arn': identity.get('Arn', 'Unknown'),
@@ -220,19 +215,19 @@ def check_permissions_silent() -> Dict:
     # Simplified permission tests (subset for speed)
     permission_tests = {
         'sts:GetCallerIdentity': {
-            'test_function': lambda: boto3.client('sts').get_caller_identity(),
+            'test_function': lambda: utils.get_boto3_client('sts', test_region).get_caller_identity(),
             'required': True
         },
         'ec2:DescribeInstances': {
-            'test_function': lambda: boto3.client('ec2', region_name=test_region).describe_instances(MaxResults=5),
+            'test_function': lambda: utils.get_boto3_client('ec2', test_region).describe_instances(MaxResults=5),
             'required': True
         },
         's3:ListBuckets': {
-            'test_function': lambda: boto3.client('s3').list_buckets(),
+            'test_function': lambda: utils.get_boto3_client('s3', test_region).list_buckets(),
             'required': True
         },
         'iam:ListUsers': {
-            'test_function': lambda: boto3.client('iam').list_users(MaxItems=5),
+            'test_function': lambda: utils.get_boto3_client('iam', test_region).list_users(MaxItems=5),
             'required': True
         }
     }


### PR DESCRIPTION
## Summary

- Adds `import utils` (with path fallback) so `configure.py` can use the shared library
- Replaces `detect_aws_partition()` body with a thin wrapper around `utils.detect_partition()`, removing duplicate partition-detection logic
- `get_aws_identity()`: calls `detect_aws_partition()` first to obtain `default_region`, then creates the STS client via `utils.get_boto3_client('sts', default_region)` — FIPS endpoint is now injected for GovCloud
- `check_permissions_silent()`: replaces all four `boto3.client()` lambdas with `utils.get_boto3_client(service, test_region)` equivalents

**No direct `boto3.client()` calls remain in `configure.py`.**

## Security Impact

Direct `boto3.client()` bypasses the FIPS endpoint injection in `utils.get_boto3_client()`. In a GovCloud FedRAMP environment, STS, EC2, S3, and IAM calls were connecting to non-FIPS endpoints — a compliance violation. All six call sites are now FIPS-aware.

## Test plan

- [ ] `python3 -m py_compile configure.py` passes (verified locally)
- [ ] `python configure.py --validate` completes without errors against a real AWS profile
- [ ] `python configure.py --perms` completes without errors
- [ ] Verify no `boto3.client()` references remain: `grep -n "boto3\.client" configure.py` returns empty

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)