### PR TITLE
fix(core-engine): surface swallowed exceptions in smart_scan executor.py

### DIFF
--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -163,8 +163,7 @@ class ScriptExecutor:
                 )
             else:
                 utils.log_error(
-                    f"✗ {script_name} failed with code {result.returncode}",
-                    Exception(error_message or "Script execution failed"),
+                    f"✗ {script_name} failed with code {result.returncode}: {error_message or 'Script execution failed'}",
                 )
 
             return execution_result
@@ -213,7 +212,8 @@ class ScriptExecutor:
             output_dir = utils.get_output_dir()
             snapshot_time = _time.time()
             return ({str(p) for p in output_dir.glob("*.xlsx")}, snapshot_time)
-        except Exception:
+        except Exception as e:
+            utils.log_debug(f"Output snapshot failed: {e}")
             return (set(), 0.0)
 
     def _find_output_file(self, script_name: str, pre_run_files=None) -> Optional[str]:
@@ -261,7 +261,8 @@ class ScriptExecutor:
             xlsx_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
             return str(xlsx_files[0])
 
-        except Exception:
+        except Exception as e:
+            utils.log_debug(f"Output detection failed: {e}")
             return None
 
     def _show_progress_header(self) -> None:


### PR DESCRIPTION
## Summary

Three silent failure points in `ScriptExecutor` fixed:

- **`_execute_script()`**: removed `Exception(error_message or "...")` construction — a synthetic exception object built from a truncated string loses the original type and traceback. Error detail is now folded into the log message string; `error_obj` omitted since no live exception exists at that call site.
- **`_snapshot_output_files()`**: bare `except Exception:` silently returned `(set(), 0.0)`. Now logs at DEBUG level before returning the fallback so `PermissionError`/`OSError` on the output directory is visible.
- **`_find_output_file()`**: bare `except Exception:` silently returned `None`. Same fix — `log_debug()` before the fallback return.

## Test plan

- [ ] `python3 -m py_compile scripts/smart_scan/executor.py` passes (verified locally)
- [ ] `pytest tests/smart_scan/ -v` passes with no regressions
- [ ] Confirm a simulated `PermissionError` on the output dir produces a DEBUG log entry rather than disappearing silently

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)