### PR TITLE
fix(ci-cd): correct package declaration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ Issues = "https://github.com/ColonelPanicX/StratusScan-CLI/issues"
 
 # Setuptools configuration
 [tool.setuptools]
-packages = ["scripts"]
+packages = ["scripts.smart_scan"]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary

- Changes `packages = ["scripts"]` to `packages = ["scripts.smart_scan"]`

`scripts/` has no `__init__.py` and is not a Python package — it is a directory of standalone exporter scripts. Declaring it as a package caused `pip install .` to emit warnings and behave unexpectedly. `scripts/smart_scan/` is the only true sub-package (it has `__init__.py`) and is the correct target for installation.

Individual exporter scripts (`python scripts/ec2-export.py`, etc.) are unaffected — they run directly and are not imported as a package.

## Test plan

- [ ] `pip install -e .` completes without `__init__.py` warnings
- [ ] `python -c "from scripts.smart_scan import executor"` succeeds after install
- [ ] `python scripts/ec2-export.py` still runnable directly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)