### PR TITLE
fix(core-engine): replace lowercase any with Any in smart_scan type annotations

### DIFF
--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 # Add parent directory to path for utils import
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -345,7 +345,7 @@ class ScriptExecutor:
         print("=" * 80)
         print()
 
-    def execute_all(self, show_progress: bool = True) -> Dict[str, any]:
+    def execute_all(self, show_progress: bool = True) -> Dict[str, Any]:
         """
         Execute all scripts in sequence.
 
@@ -483,7 +483,7 @@ class ScriptExecutor:
 
 def execute_scripts(
     scripts: Set[str], show_progress: bool = True, save_log: bool = False
-) -> Dict[str, any]:
+) -> Dict[str, Any]:
     """
     Execute multiple scripts in batch.
 

--- a/scripts/smart_scan/selector.py
+++ b/scripts/smart_scan/selector.py
@@ -7,7 +7,7 @@ Uses questionary library for rich checkbox/menu navigation.
 
 import os
 import sys
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 # Add parent directory to path for utils import
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -47,7 +47,7 @@ from .mapping import SCRIPT_CATEGORIES, ALWAYS_RUN_SCRIPTS
 class SmartScanSelector:
     """Interactive selector for Smart Scan script recommendations."""
 
-    def __init__(self, recommendations: Dict[str, any]):
+    def __init__(self, recommendations: Dict[str, Any]):
         """
         Initialize the selector with recommendations.
 
@@ -455,7 +455,7 @@ class SmartScanSelector:
                 return None
 
 
-def interactive_select(recommendations: Dict[str, any]) -> Optional[Set[str]]:
+def interactive_select(recommendations: Dict[str, Any]) -> Optional[Set[str]]:
     """
     Run interactive script selection.
 


### PR DESCRIPTION
## Summary

- Adds `Any` to `from typing import` in both `executor.py` and `selector.py`
- Replaces all 4 occurrences of `Dict[str, any]` with `Dict[str, Any]`

`any` (lowercase) is Python's built-in function, not a type. Using it as a type hint is silently accepted by the interpreter but produces no useful type information for mypy, pyright, or IDEs. The correct annotation is `typing.Any`.

**Affected signatures:**
| File | Location | Before | After |
|------|----------|--------|-------|
| `executor.py` | `execute_all()` return | `Dict[str, any]` | `Dict[str, Any]` |
| `executor.py` | `execute_scripts()` return | `Dict[str, any]` | `Dict[str, Any]` |
| `selector.py` | `SmartScanSelector.__init__()` param | `Dict[str, any]` | `Dict[str, Any]` |
| `selector.py` | `interactive_select()` param | `Dict[str, any]` | `Dict[str, Any]` |

## Test plan

- [ ] `python3 -m py_compile` passes on both files (verified locally)
- [ ] `pytest tests/smart_scan/ -v` passes with no regressions
- [ ] `mypy scripts/smart_scan/` reports no new errors on these annotations

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)