### PR TITLE
refactor(exporters): batch sweep — remove check_deps, get_aws_regions, direct boto3, fix setup_logging placement

### DIFF
--- a/scripts/access-analyzer-export.py
+++ b/scripts/access-analyzer-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("access-analyzer-export")
-utils.log_script_start("access-analyzer-export.py", "AWS IAM Access Analyzer Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Access Analyzers from region", default_return=[])
 def collect_analyzers_from_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -550,7 +528,7 @@ def export_access_analyzer_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -660,7 +638,11 @@ def export_access_analyzer_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("access-analyzer-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("access-analyzer-export.py", "AWS IAM Access Analyzer Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/acm-export.py
+++ b/scripts/acm-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("acm-export")
-utils.log_script_start("acm-export.py", "AWS ACM Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -82,23 +77,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_acm_certificates_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan ACM certificates in a single region.
@@ -416,7 +394,7 @@ def export_acm_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -516,7 +494,11 @@ def export_acm_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("acm-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("acm-export.py", "AWS ACM Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/acm-privateca-export.py
+++ b/scripts/acm-privateca-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_private_cas_region(region: str) -> List[Dict[str, Any]]:
     """Scan Private CAs in a single region."""
     regional_cas = []
@@ -618,7 +584,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/ami-export.py
+++ b/scripts/ami-export.py
@@ -51,11 +51,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("ami-export")
-utils.log_script_start("ami-export.py", "AWS AMI Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -88,23 +83,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting AMIs from region", default_return=[])
 def collect_amis_in_region(region: str, account_id: str) -> List[Dict[str, Any]]:
     """
@@ -272,7 +250,7 @@ def export_ami_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -379,7 +357,11 @@ def export_ami_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("ami-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("ami-export.py", "AWS AMI Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/api-gateway-export.py
+++ b/scripts/api-gateway-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("api-gateway-export")
-utils.log_script_start("api-gateway-export.py", "AWS API Gateway Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_rest_apis_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan REST APIs in a single AWS region.
@@ -448,7 +426,7 @@ def export_api_gateway_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -567,7 +545,11 @@ def export_api_gateway_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("api-gateway-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("api-gateway-export.py", "AWS API Gateway Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/autoscaling-export.py
+++ b/scripts/autoscaling-export.py
@@ -49,11 +49,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("autoscaling-export")
-utils.log_script_start("autoscaling-export.py", "AWS Auto Scaling Groups Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -86,23 +81,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Auto Scaling Groups", default_return=[])
 def collect_autoscaling_groups(regions: List[str]) -> List[Dict[str, Any]]:
     """
@@ -410,7 +388,7 @@ def export_autoscaling_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -542,7 +520,11 @@ def export_autoscaling_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("autoscaling-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("autoscaling-export.py", "AWS Auto Scaling Groups Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/backup-export.py
+++ b/scripts/backup-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("backup-export")
-utils.log_script_start("backup-export.py", "AWS Backup Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def _scan_backup_vaults_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for backup vaults."""
     vaults_data = []
@@ -376,7 +354,7 @@ def export_backup_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -481,7 +459,11 @@ def export_backup_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("backup-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("backup-export.py", "AWS Backup Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/bedrock-export.py
+++ b/scripts/bedrock-export.py
@@ -34,40 +34,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting Bedrock foundation models", default_return=[])
 def collect_foundation_models(regions: List[str]) -> List[Dict[str, Any]]:
     """Collect available Bedrock foundation models from AWS regions."""
@@ -539,7 +505,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/billing-export.py
+++ b/scripts/billing-export.py
@@ -49,43 +49,6 @@ except ImportError:
 
 # Setup logging
 logger = utils.setup_logging('billing-export')
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-    """
-    required_packages = ['boto3', 'pandas', 'openpyxl', 'python-dateutil']
-    missing_packages = []
-    
-    for package in required_packages:
-        try:
-            __import__(package)
-            print(f"✓ {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-    
-    if missing_packages:
-        print(f"\nPackages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower()
-        
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                print(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    print(f"✓ Successfully installed {package}")
-                except Exception as e:
-                    print(f"Error installing {package}: {e}")
-                    print("Please install it manually with: pip install " + package)
-                    return False
-            return True
-        else:
-            print("Cannot proceed without required dependencies.")
-            return False
-    
-    return True
-
 def print_title():
     """
     Print the script title banner and get account info.
@@ -456,7 +419,7 @@ def main():
         account_id, account_name = print_title()
         
         # Check dependencies
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl', 'python-dateutil'):
             sys.exit(1)
         
         # Get user input for date range

--- a/scripts/budgets-export.py
+++ b/scripts/budgets-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("budgets-export")
-utils.log_script_start("budgets-export.py", "AWS Budgets Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -375,7 +370,11 @@ def export_budgets_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("budgets-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("budgets-export.py", "AWS Budgets Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/cloudfront-export.py
+++ b/scripts/cloudfront-export.py
@@ -47,11 +47,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("cloudfront-export")
-utils.log_script_start("cloudfront-export.py", "AWS CloudFront Distribution Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -520,7 +515,11 @@ def export_cloudfront_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("cloudfront-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("cloudfront-export.py", "AWS CloudFront Distribution Export Tool")
+
     try:
         # Check if running in GovCloud partition
         partition = utils.detect_partition()

--- a/scripts/cloudmap-export.py
+++ b/scripts/cloudmap-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_namespaces_region(region: str) -> List[Dict[str, Any]]:
     """Scan Cloud Map namespaces in a single region."""
     regional_namespaces = []
@@ -345,7 +311,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/cloudtrail-export.py
+++ b/scripts/cloudtrail-export.py
@@ -46,11 +46,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("cloudtrail-export")
-utils.log_script_start("cloudtrail-export.py", "AWS CloudTrail Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -83,23 +78,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting CloudTrail trails from region", default_return=[])
 def collect_trails_from_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -599,7 +577,11 @@ def export_cloudtrail_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("cloudtrail-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("cloudtrail-export.py", "AWS CloudTrail Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/cloudwatch-export.py
+++ b/scripts/cloudwatch-export.py
@@ -42,11 +42,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("cloudwatch-export")
-utils.log_script_start("cloudwatch-export.py", "AWS CloudWatch Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -79,23 +74,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def _scan_cloudwatch_alarms_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for CloudWatch alarms."""
     alarms_data = []
@@ -450,7 +428,11 @@ def export_cloudwatch_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("cloudwatch-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("cloudwatch-export.py", "AWS CloudWatch Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/codebuild-export.py
+++ b/scripts/codebuild-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_projects_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for CodeBuild projects."""
     projects_data = []
@@ -369,7 +335,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/codecommit-export.py
+++ b/scripts/codecommit-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting CodeCommit repositories", default_return=[])
 def collect_repositories(regions: List[str]) -> List[Dict[str, Any]]:
     """Collect CodeCommit repository information from AWS regions."""
@@ -396,7 +362,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/codedeploy-export.py
+++ b/scripts/codedeploy-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting CodeDeploy applications", default_return=[])
 def collect_applications(regions: List[str]) -> List[Dict[str, Any]]:
     """Collect CodeDeploy application information from AWS regions."""
@@ -433,7 +399,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/codepipeline-export.py
+++ b/scripts/codepipeline-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_pipelines_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for CodePipeline pipelines."""
     pipelines_data = []
@@ -418,7 +384,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/cognito-export.py
+++ b/scripts/cognito-export.py
@@ -33,40 +33,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def scan_user_pools_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan Cognito user pools in a single region.
@@ -795,7 +761,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/comprehend-export.py
+++ b/scripts/comprehend-export.py
@@ -34,40 +34,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting Comprehend entity recognizers", default_return=[])
 def collect_entity_recognizers(regions: List[str]) -> List[Dict[str, Any]]:
     """Collect custom entity recognizer information from AWS regions."""
@@ -540,7 +506,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/compute-optimizer-export.py
+++ b/scripts/compute-optimizer-export.py
@@ -17,7 +17,6 @@ The data is exported to an Excel file with separate tabs for each recommendation
 
 import os
 import sys
-import boto3
 import datetime
 import json
 import pandas as pd
@@ -46,43 +45,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-    """
-    required_packages = ['pandas', 'openpyxl', 'boto3']
-    missing_packages = []
-    
-    for package in required_packages:
-        try:
-            __import__(package)
-            print(f"✓ {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-    
-    if missing_packages:
-        print(f"\nPackages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower()
-        
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                print(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    print(f"✓ Successfully installed {package}")
-                except Exception as e:
-                    print(f"Error installing {package}: {e}")
-                    print("Please install it manually with: pip install " + package)
-                    return False
-            return True
-        else:
-            print("Cannot proceed without required dependencies.")
-            return False
-    
-    return True
-
 def print_title():
     """
     Print the script title banner and get account info.
@@ -610,7 +572,7 @@ def main():
     """
     try:
         # Check dependencies
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             sys.exit(1)
 
         # Print title and get account info

--- a/scripts/compute-resources.py
+++ b/scripts/compute-resources.py
@@ -25,7 +25,6 @@ Collected information includes:
 
 import os
 import sys
-import boto3
 import datetime
 import time
 import json
@@ -66,45 +65,6 @@ logger = utils.setup_logging('compute-resources')
 # ============================================================================
 # DEPENDENCY CHECKING AND INITIALIZATION
 # ============================================================================
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl', 'boto3']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -1461,7 +1421,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Import pandas after dependency check

--- a/scripts/config-export.py
+++ b/scripts/config-export.py
@@ -46,11 +46,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("config-export")
-utils.log_script_start("config-export.py", "AWS Config Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -83,23 +78,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Config recorders from region", default_return=[])
 def collect_configuration_recorders_from_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -683,7 +661,11 @@ def export_config_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("config-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("config-export.py", "AWS Config Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/connect-export.py
+++ b/scripts/connect-export.py
@@ -33,40 +33,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_instances_region(region: str) -> List[Dict[str, Any]]:
     """Scan Connect instances in a single region."""
     regional_instances = []
@@ -259,7 +225,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/controltower-export.py
+++ b/scripts/controltower-export.py
@@ -39,40 +39,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting landing zone information", default_return={})
 def collect_landing_zone() -> Dict[str, Any]:
     """Collect AWS Control Tower landing zone information (global service)."""
@@ -509,7 +475,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/cost-optimization-hub-export.py
+++ b/scripts/cost-optimization-hub-export.py
@@ -21,7 +21,6 @@ import os
 import sys
 import subprocess
 import datetime
-import boto3
 from botocore.exceptions import ClientError
 from pathlib import Path
 

--- a/scripts/detective-export.py
+++ b/scripts/detective-export.py
@@ -30,7 +30,6 @@ Prerequisites:
 
 import os
 import sys
-import boto3
 import datetime
 import time
 from pathlib import Path

--- a/scripts/directconnect-export.py
+++ b/scripts/directconnect-export.py
@@ -51,11 +51,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("directconnect-export")
-utils.log_script_start("directconnect-export.py", "AWS Direct Connect Export Tool")
-
 
 def _scan_connections_region(region: str) -> List[Dict[str, Any]]:
     """Scan Direct Connect connections in a single region."""
@@ -815,7 +810,11 @@ def export_directconnect_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("directconnect-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("directconnect-export.py", "AWS Direct Connect Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/dynamodb-export.py
+++ b/scripts/dynamodb-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("dynamodb-export")
-utils.log_script_start("dynamodb-export.py", "AWS DynamoDB Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_dynamodb_tables_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan DynamoDB tables in a single region.
@@ -509,7 +487,7 @@ def export_dynamodb_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -654,7 +632,11 @@ def export_dynamodb_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("dynamodb-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("dynamodb-export.py", "AWS DynamoDB Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/ebs-snapshots-export.py
+++ b/scripts/ebs-snapshots-export.py
@@ -73,21 +73,6 @@ def print_title():
     print(f"Account Name: {account_name}")
     print("====================================================================")
     return account_id, account_name
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.
@@ -282,7 +267,7 @@ def main():
                 print("Please enter a valid number (1-3).")
 
         # Get regions based on selection
-        all_available_regions = get_aws_regions()
+        all_available_regions = utils.get_aws_regions()
         default_regions = utils.get_partition_regions(partition, all_regions=False)
 
         # Process selection

--- a/scripts/ebs-volumes-export.py
+++ b/scripts/ebs-volumes-export.py
@@ -54,22 +54,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.
@@ -395,7 +379,7 @@ def main():
         
         # Get AWS regions
         utils.log_info("Getting list of AWS regions...")
-        all_regions = get_aws_regions()
+        all_regions = utils.get_aws_regions()
 
         if not all_regions:
             utils.log_error("No AWS regions found. Please check your AWS credentials and permissions.")

--- a/scripts/ec2-export.py
+++ b/scripts/ec2-export.py
@@ -445,21 +445,6 @@ def calculate_storage_cost(root_size, root_type, attached_volume_info, storage_p
 # Dependency checking handled by utils.ensure_dependencies()
 
 # Account info retrieval handled by utils.get_account_info()
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """Check if a region name is a valid AWS region"""
     return utils.is_aws_region(region_name)
@@ -758,7 +743,7 @@ def main():
                 print("Please enter a valid number (1-3).")
 
         # Get regions based on selection
-        all_available_regions = get_aws_regions()
+        all_available_regions = utils.get_aws_regions()
         default_regions = utils.get_partition_regions(partition, all_regions=False)
 
         # Process selection

--- a/scripts/ecr-export.py
+++ b/scripts/ecr-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("ecr-export")
-utils.log_script_start("ecr-export.py", "AWS Elastic Container Registry Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -82,23 +77,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_ecr_repositories_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan ECR repositories in a single region.
@@ -461,7 +439,7 @@ def export_ecr_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -566,7 +544,11 @@ def export_ecr_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("ecr-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("ecr-export.py", "AWS Elastic Container Registry Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/ecs-export.py
+++ b/scripts/ecs-export.py
@@ -28,7 +28,6 @@ ELB Target Group, Network Mode, Subnet IDs, Security Groups, IAM Role, and Creat
 
 import os
 import sys
-import boto3
 import datetime
 import time
 from pathlib import Path
@@ -57,46 +56,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-    
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-    
-    for package in required_packages:
-        try:
-            __import__(package)
-            print(f"✓ {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-    
-    if missing_packages:
-        print(f"\nPackages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower()
-        
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                print(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    print(f"✓ Successfully installed {package}")
-                except Exception as e:
-                    print(f"Error installing {package}: {e}")
-                    print("Please install it manually with: pip install " + package)
-                    return False
-            return True
-        else:
-            print("Cannot proceed without required dependencies.")
-            return False
-    
-    return True
-
 def print_title():
     """
     Print the script title and header, and return account information.
@@ -497,7 +456,7 @@ def main():
         account_id, account_name = print_title()
         
         # Check dependencies
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             sys.exit(1)
         
         # Import pandas after checking dependencies

--- a/scripts/efs-export.py
+++ b/scripts/efs-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("efs-export")
-utils.log_script_start("efs-export.py", "AWS EFS Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -82,23 +77,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_efs_file_systems_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan EFS file systems in a single region.
@@ -438,7 +416,7 @@ def export_efs_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -543,7 +521,11 @@ def export_efs_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("efs-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("efs-export.py", "AWS EFS Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/eks-export.py
+++ b/scripts/eks-export.py
@@ -27,7 +27,6 @@ Collected information includes:
 
 import os
 import sys
-import boto3
 import datetime
 import time
 import json
@@ -56,44 +55,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -653,7 +614,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Import pandas after dependency check

--- a/scripts/elasticache-export.py
+++ b/scripts/elasticache-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("elasticache-export")
-utils.log_script_start("elasticache-export.py", "AWS ElastiCache Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_replication_groups_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan ElastiCache replication groups (Redis) in a single region.
@@ -472,7 +450,7 @@ def export_elasticache_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -607,7 +585,11 @@ def export_elasticache_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("elasticache-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("elasticache-export.py", "AWS ElastiCache Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/eventbridge-export.py
+++ b/scripts/eventbridge-export.py
@@ -43,11 +43,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("eventbridge-export")
-utils.log_script_start("eventbridge-export.py", "AWS EventBridge Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -80,23 +75,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def _scan_event_buses_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for EventBridge event buses."""
     buses_data = []
@@ -299,7 +277,7 @@ def export_eventbridge_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -430,7 +408,11 @@ def export_eventbridge_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("eventbridge-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("eventbridge-export.py", "AWS EventBridge Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/fsx-export.py
+++ b/scripts/fsx-export.py
@@ -44,11 +44,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("fsx-export")
-utils.log_script_start("fsx-export.py", "AWS FSx Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -81,23 +76,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def _scan_fsx_file_systems_region(region: str) -> List[Dict[str, Any]]:
     """Scan a single region for FSx file systems."""
     file_systems_data = []
@@ -351,7 +329,7 @@ def export_fsx_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -451,7 +429,11 @@ def export_fsx_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("fsx-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("fsx-export.py", "AWS FSx Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/glacier-export.py
+++ b/scripts/glacier-export.py
@@ -33,40 +33,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_vaults_region(region: str) -> List[Dict[str, Any]]:
     """Scan Glacier vaults in a single region."""
     regional_vaults = []
@@ -244,7 +210,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/globalaccelerator-export.py
+++ b/scripts/globalaccelerator-export.py
@@ -56,11 +56,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("globalaccelerator-export")
-utils.log_script_start("globalaccelerator-export.py", "AWS Global Accelerator Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -773,7 +768,11 @@ def export_globalaccelerator_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("globalaccelerator-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("globalaccelerator-export.py", "AWS Global Accelerator Export Tool")
+
     try:
         # Check if running in GovCloud partition
         partition = utils.detect_partition()

--- a/scripts/guardduty-export.py
+++ b/scripts/guardduty-export.py
@@ -46,11 +46,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("guardduty-export")
-utils.log_script_start("guardduty-export.py", "AWS GuardDuty Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -83,23 +78,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting GuardDuty detectors from region", default_return=[])
 def collect_detectors_from_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -606,7 +584,7 @@ def export_guardduty_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -716,7 +694,11 @@ def export_guardduty_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("guardduty-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("guardduty-export.py", "AWS GuardDuty Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/iam-export.py
+++ b/scripts/iam-export.py
@@ -21,7 +21,6 @@ Access Key ID, Active Key Age, Access Key Last Used, Creation Date, Console Acce
 
 import os
 import sys
-import boto3
 import datetime
 import time
 from pathlib import Path
@@ -49,44 +48,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-    
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-    
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-    
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-        
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-    
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -483,7 +444,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
         
         # Import pandas after dependency check

--- a/scripts/iam-identity-providers-export.py
+++ b/scripts/iam-identity-providers-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting SAML providers", default_return=[])
 def collect_saml_providers() -> List[Dict[str, Any]]:
     """Collect IAM SAML provider information."""
@@ -467,7 +433,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/image-builder-export.py
+++ b/scripts/image-builder-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("image-builder-export")
-utils.log_script_start("image-builder-export.py", "AWS EC2 Image Builder Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -82,23 +77,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Image Builder pipelines", default_return=[])
 def collect_image_pipelines(regions: List[str]) -> List[Dict[str, Any]]:
     """
@@ -507,7 +485,7 @@ def export_image_builder_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -617,7 +595,11 @@ def export_image_builder_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("image-builder-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("image-builder-export.py", "AWS EC2 Image Builder Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/kms-export.py
+++ b/scripts/kms-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("kms-export")
-utils.log_script_start("kms-export.py", "AWS KMS Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -82,23 +77,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_kms_keys_in_region(region: str, account_id: str) -> List[Dict[str, Any]]:
     """
     Scan KMS keys in a single region.
@@ -474,7 +452,7 @@ def export_kms_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -579,7 +557,11 @@ def export_kms_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("kms-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("kms-export.py", "AWS KMS Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/lambda-export.py
+++ b/scripts/lambda-export.py
@@ -50,11 +50,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("lambda-export")
-utils.log_script_start("lambda-export.py", "AWS Lambda Functions Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -87,23 +82,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Lambda functions for region", default_return=[])
 def collect_lambda_functions_for_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -502,7 +480,7 @@ def export_lambda_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -613,7 +591,11 @@ def export_lambda_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("lambda-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("lambda-export.py", "AWS Lambda Functions Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/marketplace-export.py
+++ b/scripts/marketplace-export.py
@@ -31,40 +31,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting Marketplace agreements", default_return=[])
 def collect_agreements() -> List[Dict[str, Any]]:
     """Collect AWS Marketplace agreement information (global service)."""
@@ -284,7 +250,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/nacl-export.py
+++ b/scripts/nacl-export.py
@@ -74,21 +74,6 @@ def print_title():
     
     print("====================================================================")
     return account_id, account_name
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.
@@ -296,7 +281,7 @@ def main():
                 print("Please enter a valid number (1-3).")
 
         # Get regions based on selection
-        all_available_regions = get_aws_regions()
+        all_available_regions = utils.get_aws_regions()
         default_regions = utils.get_partition_regions(partition, all_regions=False)
 
         # Process selection

--- a/scripts/network-firewall-export.py
+++ b/scripts/network-firewall-export.py
@@ -46,11 +46,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("network-firewall-export")
-utils.log_script_start("network-firewall-export.py", "AWS Network Firewall Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -83,23 +78,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting Network Firewalls from region", default_return=[])
 def collect_network_firewalls_from_region(region: str) -> List[Dict[str, Any]]:
     """
@@ -590,7 +568,7 @@ def export_network_firewall_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -699,7 +677,11 @@ def export_network_firewall_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("network-firewall-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("network-firewall-export.py", "AWS Network Firewall Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/network-resources.py
+++ b/scripts/network-resources.py
@@ -58,44 +58,6 @@ except ImportError:
 
 # Setup logging
 logger = utils.setup_logging('network-resources')
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -412,7 +374,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Print title and get account info

--- a/scripts/organizations-export.py
+++ b/scripts/organizations-export.py
@@ -27,7 +27,6 @@ Collected information includes:
 
 import os
 import sys
-import boto3
 import datetime
 import time
 import json
@@ -83,44 +82,6 @@ def convert_datetime_to_string(dt_obj):
             return str(dt_obj)
     except Exception:
         return 'N/A'
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -834,7 +795,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Import pandas after dependency check

--- a/scripts/rds-export.py
+++ b/scripts/rds-export.py
@@ -91,21 +91,6 @@ def print_title():
     return account_id, account_name
 
 # Dependency checking handled by utils.ensure_dependencies()
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.
@@ -652,7 +637,7 @@ def main():
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection

--- a/scripts/rekognition-export.py
+++ b/scripts/rekognition-export.py
@@ -32,40 +32,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 @utils.aws_error_handler("Collecting Rekognition projects", default_return=[])
 def collect_projects(regions: List[str]) -> List[Dict[str, Any]]:
     """Collect Rekognition custom model projects from AWS regions."""
@@ -425,7 +391,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/route-tables-export.py
+++ b/scripts/route-tables-export.py
@@ -22,7 +22,6 @@ Phase 4B Update:
 import os
 import sys
 import datetime
-import boto3
 from botocore.exceptions import ClientError
 from pathlib import Path
 
@@ -48,43 +47,6 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-    
-    for package in required_packages:
-        try:
-            __import__(package)
-            print(f"✓ {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-    
-    if missing_packages:
-        print(f"\nPackages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower()
-        
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                print(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    print(f"✓ Successfully installed {package}")
-                except Exception as e:
-                    print(f"Error installing {package}: {e}")
-                    print("Please install it manually with: pip install " + package)
-                    return False
-            return True
-        else:
-            print("Cannot proceed without required dependencies.")
-            return False
-    
-    return True
-
 def print_title():
     """
     Print the script title banner and get account info.
@@ -434,7 +396,7 @@ def main():
         account_id, account_name = print_title()
         
         # Check for required dependencies
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             sys.exit(1)
         
         # Import pandas now that we've checked dependencies

--- a/scripts/route53-export.py
+++ b/scripts/route53-export.py
@@ -49,11 +49,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("route53-export")
-utils.log_script_start("route53-export.py", "AWS Route 53 DNS Service Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -795,7 +790,11 @@ def export_route53_data(account_id: str, account_name: str, regions: List[str]):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("route53-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("route53-export.py", "AWS Route 53 DNS Service Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/s3-export.py
+++ b/scripts/s3-export.py
@@ -77,21 +77,6 @@ def print_title():
     print("====================================================================")
 
     return account_id, account_name
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region
@@ -297,7 +282,7 @@ def get_latest_storage_lens_data(account_id):
             return region_data
 
         # Use concurrent region scanning for CloudWatch metrics (Phase 4B)
-        aws_regions = utils.get_aws_regions()
+        aws_regions = utils.utils.get_aws_regions()
         region_results = utils.scan_regions_concurrent(
             regions=aws_regions,
             scan_function=collect_cloudwatch_metrics_for_region,

--- a/scripts/sagemaker-export.py
+++ b/scripts/sagemaker-export.py
@@ -34,40 +34,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_notebook_instances_region(region: str) -> List[Dict[str, Any]]:
     """Scan SageMaker notebook instances in a single region."""
     regional_notebooks = []
@@ -644,7 +610,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/savings-plans-export.py
+++ b/scripts/savings-plans-export.py
@@ -45,11 +45,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("savings-plans-export")
-utils.log_script_start("savings-plans-export.py", "AWS Savings Plans Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -301,7 +296,11 @@ def export_savings_plans_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("savings-plans-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("savings-plans-export.py", "AWS Savings Plans Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/secrets-manager-export.py
+++ b/scripts/secrets-manager-export.py
@@ -49,11 +49,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("secrets-manager-export")
-utils.log_script_start("secrets-manager-export.py", "AWS Secrets Manager Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -88,23 +83,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_secrets_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan Secrets Manager secrets in a single region.
@@ -476,7 +454,7 @@ def export_secrets_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -582,7 +560,11 @@ def export_secrets_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("secrets-manager-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("secrets-manager-export.py", "AWS Secrets Manager Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/security-groups-export.py
+++ b/scripts/security-groups-export.py
@@ -74,21 +74,6 @@ def print_title():
     print("====================================================================")
     
     return account_id, account_name
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.
@@ -722,7 +707,7 @@ def main():
                 print("Please enter a valid number (1-3).")
 
         # Get regions based on selection
-        all_available_regions = get_aws_regions()
+        all_available_regions = utils.get_aws_regions()
         default_regions = utils.get_partition_regions(partition, all_regions=False)
 
         # Process selection

--- a/scripts/security-hub-export.py
+++ b/scripts/security-hub-export.py
@@ -51,44 +51,6 @@ except ImportError:
 
 # Setup logging
 logger = utils.setup_logging('security-hub-export')
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -550,7 +512,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Import pandas after dependency check

--- a/scripts/services-in-use-export.py
+++ b/scripts/services-in-use-export.py
@@ -42,40 +42,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 # Service detection configuration - maps to your export scripts
 SERVICE_CHECKS = {
     'Compute Resources': {
@@ -824,7 +790,7 @@ Examples:
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/ses-export.py
+++ b/scripts/ses-export.py
@@ -36,40 +36,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_email_identities_region(region: str) -> List[Dict[str, Any]]:
     """Scan email identities in a single region."""
     regional_identities = []
@@ -429,7 +395,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()

--- a/scripts/shield-export.py
+++ b/scripts/shield-export.py
@@ -36,7 +36,6 @@ Prerequisites:
 
 import os
 import sys
-import boto3
 import datetime
 import time
 from pathlib import Path

--- a/scripts/sqs-sns-export.py
+++ b/scripts/sqs-sns-export.py
@@ -43,11 +43,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("sqs-sns-export")
-utils.log_script_start("sqs-sns-export.py", "AWS SQS/SNS Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -440,7 +435,11 @@ def export_sqs_sns_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("sqs-sns-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("sqs-sns-export.py", "AWS SQS/SNS Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/ssm-fleet-export.py
+++ b/scripts/ssm-fleet-export.py
@@ -43,11 +43,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("ssm-fleet-export")
-utils.log_script_start("ssm-fleet-export.py", "AWS Systems Manager Fleet Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -562,7 +557,11 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("ssm-fleet-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("ssm-fleet-export.py", "AWS Systems Manager Fleet Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/storage-resources.py
+++ b/scripts/storage-resources.py
@@ -57,44 +57,6 @@ except ImportError:
 
 # Setup logging
 logger = utils.setup_logging('storage-resources')
-
-def check_dependencies():
-    """
-    Check if required dependencies are installed and offer to install them if missing.
-
-    Returns:
-        bool: True if all dependencies are satisfied, False otherwise
-    """
-    required_packages = ['pandas', 'openpyxl']
-    missing_packages = []
-
-    for package in required_packages:
-        try:
-            __import__(package)
-            utils.log_info(f"[OK] {package} is already installed")
-        except ImportError:
-            missing_packages.append(package)
-
-    if missing_packages:
-        utils.log_warning(f"Packages required but not installed: {', '.join(missing_packages)}")
-        response = input("Would you like to install these packages now? (y/n): ").lower().strip()
-
-        if response == 'y':
-            import subprocess
-            for package in missing_packages:
-                utils.log_info(f"Installing {package}...")
-                try:
-                    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-                    utils.log_success(f"{package} installed successfully")
-                except subprocess.CalledProcessError as e:
-                    utils.log_error(f"Error installing {package}", e)
-                    return False
-        else:
-            print("Cannot continue without required packages. Exiting.")
-            return False
-
-    return True
-
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """
@@ -424,7 +386,7 @@ def main():
     """
     try:
         # Check dependencies first
-        if not check_dependencies():
+        if not utils.ensure_dependencies('pandas', 'openpyxl'):
             return
 
         # Print title and get account info

--- a/scripts/storagegateway-export.py
+++ b/scripts/storagegateway-export.py
@@ -37,30 +37,6 @@ from botocore.exceptions import ClientError
 # ============================================================================
 # DEPENDENCY CHECKING
 # ============================================================================
-
-def check_dependencies() -> bool:
-    """Check if required packages are installed."""
-    required_packages = {
-        'boto3': 'boto3',
-        'pandas': 'pandas',
-        'openpyxl': 'openpyxl'
-    }
-
-    missing_packages = []
-    for package_name, pip_name in required_packages.items():
-        try:
-            __import__(package_name)
-        except ImportError:
-            missing_packages.append(pip_name)
-
-    if missing_packages:
-        utils.log_error(f"Missing required packages: {', '.join(missing_packages)}")
-        utils.log_error(f"Install with: pip install {' '.join(missing_packages)}")
-        return False
-
-    return True
-
-
 # ============================================================================
 # DATA COLLECTION FUNCTIONS
 # ============================================================================
@@ -684,7 +660,7 @@ def main():
     utils.log_info("=" * 80)
 
     # Check dependencies
-    if not check_dependencies():
+    if not utils.ensure_dependencies('pandas', 'openpyxl'):
         utils.log_error("Missing required dependencies. Please install them and try again.")
         sys.exit(1)
 

--- a/scripts/transit-gateway-export.py
+++ b/scripts/transit-gateway-export.py
@@ -46,11 +46,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("transit-gateway-export")
-utils.log_script_start("transit-gateway-export.py", "AWS Transit Gateway Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -83,23 +78,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 def scan_transit_gateways_in_region(region: str) -> List[Dict[str, Any]]:
     """
     Scan Transit Gateways in a single AWS region.
@@ -574,7 +552,7 @@ def export_transit_gateway_data(account_id: str, account_name: str):
             print("Please enter a valid number (1-3).")
 
     # Get regions based on selection
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection
@@ -684,7 +662,11 @@ def export_transit_gateway_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("transit-gateway-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("transit-gateway-export.py", "AWS Transit Gateway Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/vpc-data-export.py
+++ b/scripts/vpc-data-export.py
@@ -83,22 +83,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of all available AWS regions for the current partition."""
-    try:
-        # Detect partition and get ALL regions for that partition
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
 @utils.aws_error_handler("Collecting VPC data for region", default_return=[])
 def collect_vpc_data_for_region(region):
     """
@@ -854,7 +838,7 @@ def export_vpc_subnet_natgw_peering_info(account_id, account_name):
             print("Please enter a valid number (1-3).")
 
     # Get all available AWS regions
-    all_available_regions = get_aws_regions()
+    all_available_regions = utils.get_aws_regions()
     default_regions = utils.get_partition_regions(partition, all_regions=False)
 
     # Process selection

--- a/scripts/vpn-export.py
+++ b/scripts/vpn-export.py
@@ -49,11 +49,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("vpn-export")
-utils.log_script_start("vpn-export.py", "AWS VPN Connectivity Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -873,7 +868,11 @@ def export_vpn_data(account_id: str, account_name: str, regions: List[str]):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("vpn-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("vpn-export.py", "AWS VPN Connectivity Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/waf-export.py
+++ b/scripts/waf-export.py
@@ -47,11 +47,6 @@ except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
 
-# Initialize logging
-SCRIPT_START_TIME = datetime.datetime.now()
-utils.setup_logging("waf-export")
-utils.log_script_start("waf-export.py", "AWS WAF Export Tool")
-
 
 def print_title():
     """Print the title and header of the script to the console."""
@@ -84,23 +79,6 @@ def print_title():
 
     print("====================================================================")
     return account_id, account_name
-
-
-def get_aws_regions():
-    """Get a list of available AWS regions for the current partition."""
-    try:
-        # Get partition-aware regions
-        partition = utils.detect_partition()
-        regions = utils.get_partition_regions(partition, all_regions=True)
-        utils.log_info(f"Retrieved {len(regions)} regions for partition {partition}")
-        return regions
-    except Exception as e:
-        utils.log_error("Error getting AWS regions", e)
-        # Fallback to default regions for the partition
-        partition = utils.detect_partition()
-        return utils.get_partition_regions(partition, all_regions=False)
-
-
 @utils.aws_error_handler("Collecting WAF web ACLs from region", default_return=[])
 def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> List[Dict[str, Any]]:
     """
@@ -658,7 +636,11 @@ def export_waf_data(account_id: str, account_name: str):
 
 
 def main():
-    """Main function to execute the script."""
+    # Initialize logging
+    utils.setup_logging("waf-export")
+    SCRIPT_START_TIME = datetime.datetime.now()
+    utils.log_script_start("waf-export.py", "AWS WAF Export Tool")
+
     try:
         # Print title and get account information
         account_id, account_name = print_title()

--- a/scripts/xray-export.py
+++ b/scripts/xray-export.py
@@ -33,40 +33,6 @@ try:
 except ImportError:
     print("Error: pandas is not installed. Please install it using 'pip install pandas'")
     sys.exit(1)
-
-
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    utils.log_info("Checking dependencies...")
-
-    missing = []
-
-    try:
-        import pandas
-        utils.log_info("✓ pandas is installed")
-    except ImportError:
-        missing.append("pandas")
-
-    try:
-        import openpyxl
-        utils.log_info("✓ openpyxl is installed")
-    except ImportError:
-        missing.append("openpyxl")
-
-    try:
-        import boto3
-        utils.log_info("✓ boto3 is installed")
-    except ImportError:
-        missing.append("boto3")
-
-    if missing:
-        utils.log_error(f"Missing dependencies: {', '.join(missing)}")
-        utils.log_error("Please install using: pip install " + " ".join(missing))
-        sys.exit(1)
-
-    utils.log_success("All dependencies are installed")
-
-
 def _scan_sampling_rules_region(region: str) -> List[Dict[str, Any]]:
     """Scan X-Ray sampling rules in a single region."""
     regional_rules = []
@@ -297,7 +263,7 @@ def main():
     print("="*60)
 
     # Check dependencies
-    check_dependencies()
+    utils.ensure_dependencies('pandas', 'openpyxl')
 
     # Get AWS account information
     account_id, account_name = utils.get_account_info()


### PR DESCRIPTION
## Summary
- Removes 32 duplicate `check_dependencies()` definitions; replaced with `utils.ensure_dependencies()`
- Removes 32 duplicate `get_aws_regions()` definitions; replaced with `utils.get_aws_regions()`
- Removes direct `import boto3` from all exporter scripts; FIPS-aware `utils.get_boto3_client()` is now the universal entry point
- Moves 32 module-level `utils.setup_logging()` calls into `main()` to eliminate import-time side effects

Closes #18, #19, #21, #22

## Test plan
- [ ] `grep -rn "def check_dependencies" scripts/` returns empty
- [ ] `grep -rn "def get_aws_regions" scripts/` returns empty
- [ ] `grep -rn "import boto3" scripts/` returns empty
- [ ] `ruff check scripts/` passes
- [ ] Representative scripts run successfully with `python3 scripts/iam-export.py --help` or similar

🤖 Generated with [Claude Code](https://claude.com/claude-code)