### PR TITLE
fix(exporters): add GovCloud partition guards to 7 unavailable-service scripts (#20)

### DIFF
--- a/scripts/billing-export.py
+++ b/scripts/billing-export.py
@@ -413,6 +413,12 @@ def main():
     Main function to run the script.
     """
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("ce", partition):
+            utils.log_warning("Cost Explorer (billing) is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         # Print title and get account info
         account_id, account_name = print_title()
         

--- a/scripts/compute-optimizer-export.py
+++ b/scripts/compute-optimizer-export.py
@@ -569,6 +569,12 @@ def main():
     Main function to run the script.
     """
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("compute-optimizer", partition):
+            utils.log_warning("Compute Optimizer is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         # Check dependencies
         if not utils.ensure_dependencies('pandas', 'openpyxl'):
             sys.exit(1)

--- a/scripts/cost-anomaly-detection-export.py
+++ b/scripts/cost-anomaly-detection-export.py
@@ -200,6 +200,12 @@ def classify_impact(impact: Dict) -> str:
 def main():
     """Main execution function."""
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("ce", partition):
+            utils.log_warning("Cost Anomaly Detection (Cost Explorer) is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         # Get account information
         account_id, account_name = utils.get_account_info()
         utils.log_info(f"Exporting Cost Anomaly Detection data for account: {account_name} ({account_id})")

--- a/scripts/cost-categories-export.py
+++ b/scripts/cost-categories-export.py
@@ -132,6 +132,12 @@ def describe_cost_category(cost_category_arn: str) -> Dict[str, Any]:
 def main():
     """Main execution function."""
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("ce", partition):
+            utils.log_warning("Cost Categories (Cost Explorer) is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         # Get account information
         account_id, account_name = utils.get_account_info()
         utils.log_info(f"Exporting Cost Categories for account: {account_name} ({account_id})")

--- a/scripts/cost-optimization-hub-export.py
+++ b/scripts/cost-optimization-hub-export.py
@@ -311,6 +311,12 @@ def main():
     Main function to execute the script.
     """
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("cost-optimization-hub", partition):
+            utils.log_warning("Cost Optimization Hub is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         check_and_install_dependencies()
 
         import pandas as pd

--- a/scripts/globalaccelerator-export.py
+++ b/scripts/globalaccelerator-export.py
@@ -771,13 +771,11 @@ def main():
     utils.log_script_start("globalaccelerator-export.py", "AWS Global Accelerator Export Tool")
 
     try:
-        # Check if running in GovCloud partition
+        # Check partition availability
         partition = utils.detect_partition()
-        if partition == 'aws-us-gov':
-            print(f"\nERROR: Global Accelerator is not available in AWS GovCloud")
-            print("This service operates outside the GovCloud boundary")
-            utils.log_error(f"Global Accelerator is not supported in GovCloud partition")
-            sys.exit(1)
+        if not utils.is_service_available_in_partition("globalaccelerator", partition):
+            utils.log_warning("Global Accelerator is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
 
         account_id, account_name = print_title()
 

--- a/scripts/trusted-advisor-cost-optimization-export.py
+++ b/scripts/trusted-advisor-cost-optimization-export.py
@@ -398,6 +398,12 @@ def main():
     Main function to execute the script.
     """
     try:
+        # Check partition availability
+        partition = utils.detect_partition()
+        if not utils.is_service_available_in_partition("trustedadvisor", partition):
+            utils.log_warning("Trusted Advisor is not available in AWS GovCloud. Skipping.")
+            sys.exit(0)
+
         # Check and install dependencies
         check_and_install_dependencies()
 

--- a/utils.py
+++ b/utils.py
@@ -572,14 +572,16 @@ def is_service_available_in_partition(service: str, partition: str = 'aws') -> b
     """
     # Services NOT available in GovCloud (partial list)
     govcloud_unavailable = {
-        'ce',              # Cost Explorer - Not available in GovCloud
-        'globalaccelerator',  # Global Accelerator - Not available in GovCloud
-        'trustedadvisor',  # Not available in GovCloud
-        'appstream',       # Not available in GovCloud
-        'chime',          # Not available in GovCloud
-        'sumerian',       # Not available in GovCloud
-        'gamelift',       # Not available in GovCloud
-        'robomaker',      # Not available in GovCloud
+        'ce',                    # Cost Explorer - Not available in GovCloud
+        'globalaccelerator',     # Global Accelerator - Not available in GovCloud
+        'trustedadvisor',        # Trusted Advisor - Not available in GovCloud
+        'compute-optimizer',     # Compute Optimizer - Not available in GovCloud
+        'cost-optimization-hub', # Cost Optimization Hub - Not available in GovCloud
+        'appstream',             # Not available in GovCloud
+        'chime',                 # Not available in GovCloud
+        'sumerian',              # Not available in GovCloud
+        'gamelift',              # Not available in GovCloud
+        'robomaker',             # Not available in GovCloud
     }
 
     # Services with limited availability in GovCloud


### PR DESCRIPTION
## Summary

- Adds canonical `is_service_available_in_partition()` guards to 7 exporter scripts that target AWS services unavailable in GovCloud
- Extends `utils.py` `govcloud_unavailable` set with `compute-optimizer` and `cost-optimization-hub`
- Replaces the non-canonical manual check in `globalaccelerator-export.py` with the standard pattern
- Deletes `_region_replace.py` leftover temp file from prior session

## Scripts updated

| Script | Service key | Previously had guard? |
|---|---|---|
| `globalaccelerator-export.py` | `globalaccelerator` | Manual check (non-canonical, `sys.exit(1)`) |
| `trusted-advisor-cost-optimization-export.py` | `trustedadvisor` | No |
| `billing-export.py` | `ce` | No |
| `compute-optimizer-export.py` | `compute-optimizer` | No |
| `cost-anomaly-detection-export.py` | `ce` | No |
| `cost-categories-export.py` | `ce` | No |
| `cost-optimization-hub-export.py` | `cost-optimization-hub` | No |

## utils.py change

Added two entries to `govcloud_unavailable` in `is_service_available_in_partition()`:
- `'compute-optimizer'`
- `'cost-optimization-hub'`

## Test plan

- [ ] AST parse passes for all 8 modified files (verified pre-commit: 8/8 clean)
- [ ] `grep -r "is_service_available_in_partition" scripts/` confirms all 7 scripts contain the guard
- [ ] `_region_replace.py` no longer present at repo root

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)