### PR TITLE
fix(tests): replace direct ACCOUNT_MAPPINGS mutation with patch.object (#27)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,51 +25,21 @@ class TestAccountMapping:
 
     def test_get_account_name_with_mapping(self):
         """Test retrieval of account name when mapping exists."""
-        # Setup
-        original_mappings = utils.ACCOUNT_MAPPINGS.copy()
-        utils.ACCOUNT_MAPPINGS = {'123456789012': 'PROD-ACCOUNT'}
-
-        try:
-            # Test
+        with patch.object(utils, 'ACCOUNT_MAPPINGS', {'123456789012': 'PROD-ACCOUNT'}):
             result = utils.get_account_name('123456789012')
-
-            # Verify
             assert result == 'PROD-ACCOUNT'
-        finally:
-            # Cleanup
-            utils.ACCOUNT_MAPPINGS = original_mappings
 
     def test_get_account_name_with_default(self):
         """Test fallback to default when no mapping exists."""
-        # Setup
-        original_mappings = utils.ACCOUNT_MAPPINGS.copy()
-        utils.ACCOUNT_MAPPINGS = {}
-
-        try:
-            # Test
+        with patch.object(utils, 'ACCOUNT_MAPPINGS', {}):
             result = utils.get_account_name('999999999999', default='TEST-DEFAULT')
-
-            # Verify
             assert result == 'TEST-DEFAULT'
-        finally:
-            # Cleanup
-            utils.ACCOUNT_MAPPINGS = original_mappings
 
     def test_get_account_name_default_fallback(self):
         """Test default fallback value is used."""
-        # Setup
-        original_mappings = utils.ACCOUNT_MAPPINGS.copy()
-        utils.ACCOUNT_MAPPINGS = {}
-
-        try:
-            # Test
+        with patch.object(utils, 'ACCOUNT_MAPPINGS', {}):
             result = utils.get_account_name('999999999999')
-
-            # Verify - should use built-in default
             assert result == 'UNKNOWN-ACCOUNT'
-        finally:
-            # Cleanup
-            utils.ACCOUNT_MAPPINGS = original_mappings
 
 
 class TestFileNaming:
@@ -147,7 +117,6 @@ class TestAccountInfo:
     @patch('utils.get_boto3_client')
     def test_get_account_info_success(self, mock_get_client):
         """Test successful account info retrieval."""
-        # Setup mock
         mock_sts = Mock()
         mock_sts.get_caller_identity.return_value = {
             'Account': '123456789012',
@@ -155,26 +124,16 @@ class TestAccountInfo:
         }
         mock_get_client.return_value = mock_sts
 
-        # Setup account mappings
-        original_mappings = utils.ACCOUNT_MAPPINGS.copy()
-        utils.ACCOUNT_MAPPINGS = {'123456789012': 'TEST-ACCOUNT'}
-
-        try:
-            # Test
+        with patch.object(utils, '_account_info_cache', None), \
+             patch.object(utils, 'ACCOUNT_MAPPINGS', {'123456789012': 'TEST-ACCOUNT'}):
             account_id, account_name = utils.get_account_info()
-
-            # Verify
             assert account_id == '123456789012'
             assert account_name == 'TEST-ACCOUNT'
             mock_sts.get_caller_identity.assert_called_once()
-        finally:
-            # Cleanup
-            utils.ACCOUNT_MAPPINGS = original_mappings
 
     @patch('utils.get_boto3_client')
     def test_get_account_info_with_fallback(self, mock_get_client):
         """Test account info with fallback for unmapped account."""
-        # Setup mock
         mock_sts = Mock()
         mock_sts.get_caller_identity.return_value = {
             'Account': '999999999999',
@@ -182,21 +141,11 @@ class TestAccountInfo:
         }
         mock_get_client.return_value = mock_sts
 
-        # Setup account mappings (empty)
-        original_mappings = utils.ACCOUNT_MAPPINGS.copy()
-        utils.ACCOUNT_MAPPINGS = {}
-
-        try:
-            # Test
+        with patch.object(utils, '_account_info_cache', None), \
+             patch.object(utils, 'ACCOUNT_MAPPINGS', {}):
             account_id, account_name = utils.get_account_info()
-
-            # Verify
             assert account_id == '999999999999'
-            # Should create account name from ID
             assert '999999999999' in account_name
-        finally:
-            # Cleanup
-            utils.ACCOUNT_MAPPINGS = original_mappings
 
 
 class TestBoto3ClientCreation:


### PR DESCRIPTION
## Summary

- Closes #27
- Replaces all 5 unsafe `utils.ACCOUNT_MAPPINGS = ...` / `try-finally` / `restore` patterns with `patch.object(utils, 'ACCOUNT_MAPPINGS', {...})` context managers in `tests/test_utils.py`
- Also adds `patch.object(utils, '_account_info_cache', None)` to both `TestAccountInfo` tests to clear the module-level STS result cache between tests — fixes a cross-test cache-pollution failure that surfaced during this fix

**Classes changed:** `TestAccountMapping` (3 tests), `TestAccountInfo` (2 tests)

**Why `patch.object` over try/finally:**
- Guaranteed restoration even on assertion failure
- Safe under `pytest-xdist` parallel execution (no shared module-level writes)
- Idiomatic unittest.mock pattern, signals intent clearly

## Test plan
- [x] All 5 changed tests pass individually
- [x] All 5 changed tests pass in sequence
- [x] Full `pytest tests/test_utils.py` run — 18 pass (up from 17), 3 fail (all pre-existing, out of scope for this issue)
  - `test_is_aws_region_invalid` — permissive regex in `is_aws_region()`, pre-existing
  - `test_get_boto3_client_basic` / `_with_retries` — `@patch('utils.boto3.Session')` invalid because boto3 is not a direct attribute of utils, pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)