### PR TITLE
feat(tests): add moto-based exporter tests for 5 AWS service categories (#26)

### DIFF
--- a/tests/test_exporters/test_ec2_export.py
+++ b/tests/test_exporters/test_ec2_export.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ec2-export.py.
+
+Covers:
+- get_instance_data()
+"""
+
+import importlib.util
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Load exporter module
+# ---------------------------------------------------------------------------
+
+_scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "ec2_export", _scripts_dir / "ec2-export.py"
+)
+_ec2_export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ec2_export)
+
+get_instance_data = _ec2_export.get_instance_data
+
+REGION = "us-east-1"
+AMI_ID = "ami-12345678"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetInstanceData:
+    """Tests for get_instance_data()."""
+
+    @mock_aws
+    def test_launched_instance_appears_in_results(self):
+        """A running EC2 instance is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        response = ec2.run_instances(
+            ImageId=AMI_ID,
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t3.micro",
+        )
+        instance_id = response["Instances"][0]["InstanceId"]
+
+        result = get_instance_data(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        instance_ids = [row["Instance ID"] for row in result]
+        assert instance_id in instance_ids
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the core expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        ec2.run_instances(
+            ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t3.micro"
+        )
+
+        result = get_instance_data(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Instance ID", "State", "Instance Type", "Region", "Private IPv4"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_instance_type_is_preserved(self):
+        """The instance type from launch is reflected in the results."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        ec2.run_instances(
+            ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t3.small"
+        )
+
+        result = get_instance_data(REGION)
+
+        assert len(result) >= 1
+        assert result[0]["Instance Type"] == "t3.small"
+
+    @mock_aws
+    def test_region_field_matches_requested_region(self):
+        """The Region field on every returned row matches the requested region."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        ec2.run_instances(
+            ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t3.micro"
+        )
+
+        result = get_instance_data(REGION)
+
+        assert all(row["Region"] == REGION for row in result)
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no EC2 instances returns an empty list."""
+        result = get_instance_data(REGION)
+        assert result == []

--- a/tests/test_exporters/test_iam_export.py
+++ b/tests/test_exporters/test_iam_export.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for iam-export.py.
+
+Covers utils.py IAM data-collection path:
+- collect_iam_user_information()
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Load exporter module
+# ---------------------------------------------------------------------------
+
+_scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "iam_export", _scripts_dir / "iam-export.py"
+)
+_iam_export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_iam_export)
+
+collect_iam_user_information = _iam_export.collect_iam_user_information
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    """Prevent any accidental real AWS calls."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectIamUserInformation:
+    """Tests for collect_iam_user_information()."""
+
+    @mock_aws
+    def test_created_user_appears_in_results(self):
+        """A newly created IAM user is returned by the collector."""
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="test-user")
+
+        result = collect_iam_user_information()
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        usernames = [row["User Name"] for row in result]
+        assert "test-user" in usernames
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="col-check-user")
+
+        result = collect_iam_user_information()
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("User Name", "MFA", "Console Access", "Creation Date"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_user_with_access_key_reflects_key_data(self):
+        """Access key metadata is captured for users that have keys."""
+        iam = boto3.client("iam", region_name="us-east-1")
+        iam.create_user(UserName="key-user")
+        iam.create_access_key(UserName="key-user")
+
+        result = collect_iam_user_information()
+
+        assert any(row["User Name"] == "key-user" for row in result)
+
+    @mock_aws
+    def test_empty_account_returns_empty_list(self):
+        """Account with no IAM users returns an empty list."""
+        result = collect_iam_user_information()
+        assert result == []

--- a/tests/test_exporters/test_rds_export.py
+++ b/tests/test_exporters/test_rds_export.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for rds-export.py.
+
+Covers:
+- get_rds_instances()
+"""
+
+import importlib.util
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Load exporter module
+# ---------------------------------------------------------------------------
+
+_scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "rds_export", _scripts_dir / "rds-export.py"
+)
+_rds_export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rds_export)
+
+get_rds_instances = _rds_export.get_rds_instances
+
+REGION = "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetRdsInstances:
+    """Tests for get_rds_instances()."""
+
+    @mock_aws
+    def test_created_instance_appears_in_results(self):
+        """A newly created RDS instance is returned by the collector."""
+        rds = boto3.client("rds", region_name=REGION)
+        rds.create_db_instance(
+            DBInstanceIdentifier="test-db-instance",
+            DBInstanceClass="db.t3.micro",
+            Engine="mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            AllocatedStorage=20,
+        )
+
+        result = get_rds_instances(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        db_ids = [row["DB Identifier"] for row in result]
+        assert "test-db-instance" in db_ids
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        rds = boto3.client("rds", region_name=REGION)
+        rds.create_db_instance(
+            DBInstanceIdentifier="col-check-db",
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            AllocatedStorage=20,
+        )
+
+        result = get_rds_instances(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("DB Identifier", "Engine", "Region", "Size"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_engine_is_preserved(self):
+        """The engine name from the created instance appears in results."""
+        rds = boto3.client("rds", region_name=REGION)
+        rds.create_db_instance(
+            DBInstanceIdentifier="engine-check-db",
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            AllocatedStorage=20,
+        )
+
+        result = get_rds_instances(REGION)
+
+        row = next(r for r in result if r["DB Identifier"] == "engine-check-db")
+        assert "postgres" in row["Engine"].lower()
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no RDS instances returns an empty list."""
+        result = get_rds_instances(REGION)
+        assert result == []

--- a/tests/test_exporters/test_s3_export.py
+++ b/tests/test_exporters/test_s3_export.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for s3-export.py.
+
+Covers:
+- get_s3_buckets_info()
+"""
+
+import importlib.util
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Load exporter module
+# ---------------------------------------------------------------------------
+
+_scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "s3_export", _scripts_dir / "s3-export.py"
+)
+_s3_export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_s3_export)
+
+get_s3_buckets_info = _s3_export.get_s3_buckets_info
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetS3BucketsInfo:
+    """Tests for get_s3_buckets_info()."""
+
+    @mock_aws
+    def test_created_bucket_appears_in_results(self):
+        """A newly created S3 bucket is returned by the collector."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="my-test-bucket-abc123")
+
+        result = get_s3_buckets_info()
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        bucket_names = [row["Bucket Name"] for row in result]
+        assert "my-test-bucket-abc123" in bucket_names
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="col-check-bucket-xyz")
+
+        result = get_s3_buckets_info()
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Bucket Name", "Region", "Creation Date"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_bucket_with_objects_counted(self):
+        """A bucket with objects has a non-zero object count."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="objects-bucket-test1")
+        s3.put_object(Bucket="objects-bucket-test1", Key="file.txt", Body=b"hello")
+
+        result = get_s3_buckets_info()
+
+        bucket_row = next(
+            (r for r in result if r["Bucket Name"] == "objects-bucket-test1"), None
+        )
+        assert bucket_row is not None
+
+    @mock_aws
+    def test_empty_account_returns_empty_list(self):
+        """Account with no S3 buckets returns an empty list."""
+        result = get_s3_buckets_info()
+        assert result == []

--- a/tests/test_exporters/test_vpc_export.py
+++ b/tests/test_exporters/test_vpc_export.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for vpc-data-export.py.
+
+Covers:
+- collect_vpc_subnet_data_for_region()  (uses describe_vpcs + describe_subnets +
+  describe_route_tables — all well-supported by moto)
+"""
+
+import importlib.util
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Load exporter module
+# ---------------------------------------------------------------------------
+
+_scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "vpc_data_export", _scripts_dir / "vpc-data-export.py"
+)
+_vpc_export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_vpc_export)
+
+collect_vpc_subnet_data_for_region = _vpc_export.collect_vpc_subnet_data_for_region
+
+REGION = "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectVpcSubnetDataForRegion:
+    """Tests for collect_vpc_subnet_data_for_region()."""
+
+    @mock_aws
+    def test_created_subnet_appears_in_results(self):
+        """A subnet created inside a custom VPC is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc_resp = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        vpc_id = vpc_resp["Vpc"]["VpcId"]
+        subnet_resp = ec2.create_subnet(
+            VpcId=vpc_id, CidrBlock="10.0.1.0/24", AvailabilityZone=f"{REGION}a"
+        )
+        subnet_id = subnet_resp["Subnet"]["SubnetId"]
+
+        result = collect_vpc_subnet_data_for_region(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        subnet_ids = [row["Subnet ID"] for row in result]
+        assert subnet_id in subnet_ids
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc_resp = ec2.create_vpc(CidrBlock="10.1.0.0/16")
+        vpc_id = vpc_resp["Vpc"]["VpcId"]
+        ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.1.1.0/24")
+
+        result = collect_vpc_subnet_data_for_region(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Region", "VPC ID", "Subnet ID", "IPv4 CIDR Block", "Availability Zone"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_subnet_cidr_matches_created_subnet(self):
+        """The CIDR block of the created subnet is preserved in results."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc_resp = ec2.create_vpc(CidrBlock="10.2.0.0/16")
+        vpc_id = vpc_resp["Vpc"]["VpcId"]
+        ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.2.1.0/24")
+
+        result = collect_vpc_subnet_data_for_region(REGION)
+
+        cidrs = [row["IPv4 CIDR Block"] for row in result]
+        assert "10.2.1.0/24" in cidrs
+
+    @mock_aws
+    def test_region_field_is_set(self):
+        """The Region field on every returned row matches the requested region."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc_resp = ec2.create_vpc(CidrBlock="10.3.0.0/16")
+        vpc_id = vpc_resp["Vpc"]["VpcId"]
+        ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.3.1.0/24")
+
+        result = collect_vpc_subnet_data_for_region(REGION)
+
+        assert all(row["Region"] == REGION for row in result)


### PR DESCRIPTION
## Summary

- Closes #26
- Creates `tests/test_exporters/` with **21 moto-based tests** covering the primary data-collection function of each target exporter — all passing without real AWS credentials

| File | Class | Function tested | Tests |
|---|---|---|---|
| `test_ec2_export.py` | `TestGetInstanceData` | `get_instance_data(region)` | 5 |
| `test_s3_export.py` | `TestGetS3BucketsInfo` | `get_s3_buckets_info()` | 4 |
| `test_rds_export.py` | `TestGetRdsInstances` | `get_rds_instances(region)` | 4 |
| `test_iam_export.py` | `TestCollectIamUserInformation` | `collect_iam_user_information()` | 4 |
| `test_vpc_export.py` | `TestCollectVpcSubnetDataForRegion` | `collect_vpc_subnet_data_for_region(region)` | 4 |

**Design choices:**
- Each test file uses `importlib.util` to load the hyphenated script filename (`ec2-export.py` → importable module)
- `fake_aws_credentials` `autouse` fixture sets env vars to prevent accidental real-credential calls
- `@mock_aws` on each method keeps mocks isolated between tests
- VPC test covers `collect_vpc_subnet_data_for_region` (not `collect_vpc_data_for_region`) — avoids `describe_vpc_block_public_access_options`, a newer API with limited moto coverage
- Confirms Sprint 1 fix (#19/#22): `setup_logging()` is inside `main()` so all 5 scripts are importable without side effects

**Coverage gains (from 0%):** `ec2-export.py` 44%, `iam-export.py` 44%, `rds-export.py` 42%, `s3-export.py` 23%, `vpc-data-export.py` 17%

## Test plan
- [x] `pytest tests/test_exporters/ -v` → 21 passed, 0 failed, no real AWS credentials required
- [x] All tests isolated — each `@mock_aws` context starts with a clean AWS state

🤖 Generated with [Claude Code](https://claude.com/claude-code)