### PR TITLE
feat(ux): EC2 gold standard + utils UX foundation — closes #72

### DIFF
--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -640,131 +640,152 @@ def get_instance_data(region, instance_filter=None):
     
     return instances
 
+def _prompt_instance_filter():
+    """Prompt user to choose an instance state filter.
+
+    Returns:
+        tuple (instance_filter, filter_desc) on valid choice,
+        'back' if user pressed b,
+        'exit' if user pressed x.
+    """
+    choice = utils.prompt_menu(
+        "INSTANCE FILTER",
+        [
+            "All instances",
+            "Running instances only",
+            "Stopped instances only",
+        ],
+    )
+    if choice in ('back', 'exit'):
+        return choice
+    filters = {
+        1: (None, "all"),
+        2: ("running", "running"),
+        3: ("stopped", "stopped"),
+    }
+    return filters[choice]
+
+
+def _run_export(account_id, account_name, regions, instance_filter, filter_desc):
+    """Collect EC2 data and write the Excel export."""
+    import pandas as pd
+
+    utils.log_info(f"Scanning {len(regions)} region(s) for EC2 instances...")
+
+    def scan_region(region):
+        utils.log_info(f"Collecting data from AWS region: {region}")
+        instances = get_instance_data(region, instance_filter)
+        utils.log_info(f"Found {len(instances)} instances in {region}")
+        return instances
+
+    region_results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=scan_region,
+        show_progress=True,
+    )
+
+    all_instances = []
+    for instances in region_results:
+        all_instances.extend(instances)
+
+    total_instances = len(all_instances)
+
+    if not all_instances:
+        utils.log_warning("No instances found in any AWS region. Exiting...")
+        sys.exit(0)
+
+    utils.log_success(f"Total EC2 Instances found across all AWS regions: {total_instances}")
+
+    utils.log_info("Preparing data for export to Excel format...")
+    df = pd.DataFrame(all_instances)
+    df = utils.sanitize_for_export(utils.prepare_dataframe_for_export(df))
+
+    region_desc = regions[0] if len(regions) == 1 else 'all'
+    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+    filename = utils.create_export_filename(
+        account_name,
+        "ec2",
+        f"{filter_desc}-{region_desc}",
+        current_date,
+    )
+
+    output_path = utils.save_dataframe_to_excel(df, filename)
+
+    if output_path:
+        utils.log_success("AWS EC2 data exported successfully!")
+        utils.log_info(f"File location: {output_path}")
+        utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+        utils.log_info(f"Total instances exported: {total_instances}")
+        print("\nScript execution completed.")
+    else:
+        utils.log_error("Error exporting data. Please check the logs.")
+        sys.exit(1)
+
+
 def main():
-    """Main function to execute the script"""
+    """Main function — 4-step state machine with b/x navigation."""
     try:
-        # Check for required dependencies using utils function
         if not utils.ensure_dependencies('pandas', 'openpyxl', 'boto3'):
             return
 
-        # Import pandas after dependency check
-        import pandas as pd
+        utils.setup_logging("ec2-export")
+        account_id, account_name = utils.print_script_banner("AWS EC2 INSTANCES DATA EXPORT")
 
-        # Get account information using utils function
-        utils.log_info("Getting AWS account information...")
-        account_id, account_name = utils.get_account_info()
-
-        # Detect partition and set environment name
-        partition = utils.detect_partition()
-        partition_name = "AWS GovCloud (US)" if partition == 'aws-us-gov' else "AWS Commercial"
-
-        # Print script header
-        print("\n====================================================================")
-        print("                   AWS RESOURCE SCANNER                            ")
-        print("====================================================================")
-        print("                  AWS EC2 INSTANCES DATA EXPORT                   ")
-        print("====================================================================")
-        print(f"Account ID: {account_id}")
-        print(f"Account Name: {account_name}")
-        print(f"Environment: {partition_name}")
-        print("====================================================================\n")
-        
         if account_name == "UNKNOWN-ACCOUNT":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            if not utils.prompt_for_confirmation(
+                "Unable to determine account name. Proceed anyway?", default=False
+            ):
                 print("Exiting script...")
                 sys.exit(0)
-        
-        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-        
-        # Get instance state filter preference
-        print("Choose one of the following (enter the corresponding number):")
-        print("1. Export all instances")
-        print("2. Export only running instances")
-        print("3. Export only stopped instances")
-        
-        while True:
-            filter_choice = input("Enter your choice (1-3): ")
-            if filter_choice in ["1", "2", "3"]:
-                break
-            print("Invalid choice. Please enter 1, 2, or 3.")
-        
-        # Set instance filter based on user choice
+
+        step = 1
+        regions = None
         instance_filter = None
-        filter_desc = "all"  # Default for filename
-        if filter_choice == "2":
-            instance_filter = "running"
-            filter_desc = "running"
-        elif filter_choice == "3":
-            instance_filter = "stopped"
-            filter_desc = "stopped"
-        
-        regions = utils.prompt_region_selection()
-        
-        # Collect instance data from specified AWS regions (Phase 4B: concurrent scanning)
-        utils.log_info(f"Scanning {len(regions)} region(s) for EC2 instances...")
+        filter_desc = "all"
 
-        # Define region scan function that wraps get_instance_data
-        def scan_region(region):
-            utils.log_info(f"Collecting data from AWS region: {region}")
-            instances = get_instance_data(region, instance_filter)
-            utils.log_info(f"Found {len(instances)} instances in {region}")
-            return instances
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="EC2")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
 
-        # Use concurrent region scanning (with automatic fallback to sequential on errors)
-        region_results = utils.scan_regions_concurrent(
-            regions=regions,
-            scan_function=scan_region,
-            show_progress=True
-        )
+            elif step == 2:
+                result = _prompt_instance_filter()
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                instance_filter, filter_desc = result
+                step = 3
 
-        # Flatten results
-        all_instances = []
-        total_instances = 0
-        for instances in region_results:
-            instance_count = len(instances)
-            total_instances += instance_count
-            all_instances.extend(instances)
+            elif step == 3:
+                if len(regions) <= 3:
+                    region_str = ', '.join(regions)
+                else:
+                    region_str = f"{len(regions)} regions"
+                msg = f"Ready to export EC2 data ({filter_desc}, {region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 2
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 4
 
-        if not all_instances:
-            utils.log_warning("No instances found in any AWS region. Exiting...")
-            sys.exit(0)
+            elif step == 4:
+                _run_export(account_id, account_name, regions, instance_filter, filter_desc)
+                break
 
-        utils.log_success(f"Total EC2 Instances found across all AWS regions: {total_instances}")
-
-        # Create DataFrame and prepare for export
-        utils.log_info("Preparing data for export to Excel format...")
-        df = pd.DataFrame(all_instances)
-
-        # Sanitize and prepare EC2 data (tags may contain sensitive data)
-        df = utils.sanitize_for_export(utils.prepare_dataframe_for_export(df))
-
-        # Generate filename with filter and region info
-        region_desc = regions[0] if len(regions) == 1 else 'all'
-
-        # Use utils module to generate filename and save data
-        filename = utils.create_export_filename(
-            account_name,
-            "ec2",
-            f"{filter_desc}-{region_desc}",
-            current_date
-        )
-        
-        # Save data using the utility function
-        output_path = utils.save_dataframe_to_excel(df, filename)
-        
-        if output_path:
-            utils.log_success(f"AWS EC2 data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-            utils.log_info(f"Total instances exported: {total_instances}")
-            print("\nScript execution completed.")
-        else:
-            utils.log_error("Error exporting data. Please check the logs.")
-            sys.exit(1)
-    
     except KeyboardInterrupt:
         print("\n\nScript interrupted by user. Exiting...")
         sys.exit(0)
+    except SystemExit:
+        raise
     except Exception as e:
         utils.log_error("Unexpected error occurred", e)
         sys.exit(1)

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -307,6 +307,10 @@ def execute_script(script_path):
             return False
 
     except subprocess.CalledProcessError as e:
+        if e.returncode == 10:
+            raise BackSignal
+        if e.returncode == 11:
+            raise ExitToMainSignal
         print(f"Error executing script: {e}")
         utils.log_error(f"Script execution error: {script_name}", e)
         return False

--- a/tests/test_duplicate_code_refactoring.py
+++ b/tests/test_duplicate_code_refactoring.py
@@ -170,99 +170,87 @@ class TestGetAccountInfo(unittest.TestCase):
         self.assertEqual(account_name, 'UNKNOWN-ACCOUNT')
 
 
-@unittest.skip(
-    "STABILIZATION-SKIP: TestPromptRegionSelection tests were written for a direct "
-    "region-name input API (e.g. 'all', 'us-east-1') but the implemented "
-    "prompt_region_selection() uses a numbered menu (choices '1'/'2'/'3'). "
-    "Mocking builtins.input with non-numeric values causes an infinite loop in the "
-    "'while not regions:' guard, hanging pytest non-interactively. "
-    "Additionally, test_custom_default_regions passes a 'default_regions' kwarg that "
-    "does not exist in the current function signature (TypeError before hang). "
-    "Resolution: these tests require a full rewrite to match the numbered-menu contract "
-    "or the function signature must be aligned with the original design intent. "
-    "Deferred to the next audit remediation cycle. Ref: audit t-011, u-001."
-)
 class TestPromptRegionSelection(unittest.TestCase):
-    """Test cases for prompt_region_selection() function.
+    """Test cases for prompt_region_selection() — numbered-menu API."""
 
-    NOTE: Entire class skipped — see class-level @unittest.skip decorator above.
-    Tests were written against a different API contract than the one implemented.
-    The actual function uses a numbered interactive menu (1/2/3), but the mocks
-    supply raw values ('all', 'us-east-1') that the while-loop never accepts,
-    causing an infinite hang when pytest is run non-interactively.
-    """
+    def setUp(self):
+        """Ensure auto-run mode is off for all interactive tests."""
+        import os
+        os.environ.pop("STRATUSSCAN_AUTO_RUN", None)
+        os.environ.pop("STRATUSSCAN_REGIONS", None)
 
-    @patch('builtins.input', return_value='all')
-    @patch('utils.get_default_regions')
-    @patch('utils.log_info')
-    def test_select_all_regions(self, mock_log_info, mock_get_regions, mock_input):
-        """Test selecting all regions."""
-        mock_get_regions.return_value = ['us-east-1', 'us-west-2', 'us-west-1', 'eu-west-1']
-
+    @patch('utils.prompt_menu', return_value=1)
+    @patch('utils.get_default_regions', return_value=['us-east-1', 'us-west-2'])
+    @patch('utils.detect_partition', return_value='aws')
+    def test_select_default_regions(self, mock_partition, mock_defaults, mock_menu):
+        """Choice 1 returns the configured default regions."""
         regions = utils.prompt_region_selection()
-
-        self.assertEqual(len(regions), 4)
-        self.assertIn('us-east-1', regions)
-        mock_log_info.assert_called()
-
-    @patch('builtins.input', return_value='us-east-1')
-    @patch('utils.validate_aws_region')
-    @patch('utils.log_info')
-    def test_select_single_valid_region(self, mock_log_info, mock_validate, mock_input):
-        """Test selecting a single valid region."""
-        mock_validate.return_value = True
-
-        regions = utils.prompt_region_selection()
-
-        self.assertEqual(regions, ['us-east-1'])
-        mock_validate.assert_called_once_with('us-east-1')
-
-    @patch('builtins.input', return_value='invalid-region')
-    @patch('utils.validate_aws_region')
-    @patch('utils.get_default_regions')
-    @patch('utils.log_warning')
-    def test_invalid_region_fallback(self, mock_log_warning, mock_get_regions,
-                                    mock_validate, mock_input):
-        """Test fallback to default regions when invalid region provided."""
-        mock_validate.return_value = False
-        mock_get_regions.return_value = ['us-east-1', 'us-west-2']
-
-        regions = utils.prompt_region_selection()
-
         self.assertEqual(regions, ['us-east-1', 'us-west-2'])
-        mock_log_warning.assert_called()
 
-    @patch('builtins.input', return_value='all')
-    def test_custom_default_regions(self, mock_input):
-        """Test using custom default regions."""
-        custom_regions = ['us-gov-west-1', 'us-gov-east-1']
+    @patch('utils.prompt_menu', return_value=2)
+    @patch('utils.get_default_regions', return_value=['us-east-1'])
+    @patch('utils.detect_partition', return_value='aws')
+    @patch('utils.get_partition_regions', return_value=['us-east-1', 'us-west-2', 'eu-west-1'])
+    def test_select_all_regions(self, mock_all, mock_partition, mock_defaults, mock_menu):
+        """Choice 2 returns all regions for the partition."""
+        regions = utils.prompt_region_selection()
+        self.assertIsInstance(regions, list)
+        self.assertGreater(len(regions), 0)
 
-        regions = utils.prompt_region_selection(default_regions=custom_regions)
+    @patch('utils.prompt_menu', return_value='back')
+    @patch('utils.get_default_regions', return_value=['us-east-1'])
+    @patch('utils.detect_partition', return_value='aws')
+    def test_back_returns_string(self, mock_partition, mock_defaults, mock_menu):
+        """'b' input returns the string 'back'."""
+        result = utils.prompt_region_selection()
+        self.assertEqual(result, 'back')
 
-        self.assertEqual(regions, custom_regions)
+    @patch('utils.prompt_menu', return_value='exit')
+    @patch('utils.get_default_regions', return_value=['us-east-1'])
+    @patch('utils.detect_partition', return_value='aws')
+    def test_exit_returns_string(self, mock_partition, mock_defaults, mock_menu):
+        """'x' input returns the string 'exit'."""
+        result = utils.prompt_region_selection()
+        self.assertEqual(result, 'exit')
 
-    @patch('builtins.input', return_value='us-west-2')
-    @patch('utils.validate_aws_region')
-    def test_disallow_all_option(self, mock_validate, mock_input):
-        """Test when allow_all is False."""
-        mock_validate.return_value = True
+    @patch('utils.prompt_menu', return_value=3)
+    @patch('utils.get_default_regions', return_value=['us-east-1'])
+    @patch('utils.detect_partition', return_value='aws')
+    @patch('utils.get_partition_regions', return_value=['us-east-1', 'us-west-2', 'eu-west-1'])
+    @patch('builtins.input', return_value='2')
+    def test_select_single_region_by_number(
+        self, mock_input, mock_all, mock_partition, mock_defaults, mock_menu
+    ):
+        """Choice 3 + single number returns a one-element list."""
+        result = utils.prompt_region_selection()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], 'us-west-2')
 
-        regions = utils.prompt_region_selection(allow_all=False)
+    @patch('utils.prompt_menu', return_value=3)
+    @patch('utils.get_default_regions', return_value=['us-east-1'])
+    @patch('utils.detect_partition', return_value='aws')
+    @patch('utils.get_partition_regions', return_value=['us-east-1', 'us-west-2', 'eu-west-1'])
+    @patch('builtins.input', return_value='1 3')
+    def test_select_multiple_regions(
+        self, mock_input, mock_all, mock_partition, mock_defaults, mock_menu
+    ):
+        """Choice 3 + multiple numbers returns the corresponding regions."""
+        result = utils.prompt_region_selection()
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, ['us-east-1', 'eu-west-1'])
 
-        self.assertEqual(regions, ['us-west-2'])
-
-    @patch('builtins.input', return_value='eu-west-1')
-    @patch('utils.validate_aws_region')
-    @patch('utils.log_info')
-    def test_custom_prompt_message(self, mock_log_info, mock_validate, mock_input):
-        """Test custom prompt message."""
-        mock_validate.return_value = True
-
-        regions = utils.prompt_region_selection(
-            prompt_message="Select region for RDS export:"
-        )
-
-        self.assertEqual(regions, ['eu-west-1'])
+    def test_auto_run_with_env_regions(self):
+        """STRATUSSCAN_AUTO_RUN + STRATUSSCAN_REGIONS bypasses the menu."""
+        import os
+        os.environ["STRATUSSCAN_AUTO_RUN"] = "1"
+        os.environ["STRATUSSCAN_REGIONS"] = "us-east-1,eu-west-1"
+        try:
+            result = utils.prompt_region_selection()
+            self.assertEqual(result, ['us-east-1', 'eu-west-1'])
+        finally:
+            os.environ.pop("STRATUSSCAN_AUTO_RUN", None)
+            os.environ.pop("STRATUSSCAN_REGIONS", None)
 
 
 class TestIntegration(unittest.TestCase):

--- a/utils.py
+++ b/utils.py
@@ -187,179 +187,179 @@ def get_logger() -> logging.Logger:
 DEFAULT_REGIONS = ['us-east-1', 'us-west-2', 'us-west-1', 'eu-west-1']
 AWS_PARTITION = 'aws'
 
-def prompt_region_selection(
-    service_name: Optional[str] = None,
-    prompt_message: Optional[str] = None,
-    default_to_all: bool = False,
-    allow_all: bool = True
-) -> List[str]:
+def prompt_menu(
+    title: str,
+    options: List[str],
+    allow_back: bool = True,
+    allow_exit: bool = True,
+) -> Union[int, str]:
     """
-    Prompt user for AWS region selection with standardized 3-option menu.
-
-    This function provides a consistent user experience across all export scripts
-    with partition-aware region examples and robust input validation.
+    Display a bordered numbered menu and return the user's choice.
 
     Args:
-        service_name: Name of the AWS service (e.g., "Lambda", "S3")
-                     Used to customize the prompt message if prompt_message not provided
-        prompt_message: Custom message to display before menu
-                       If provided, overrides service_name in message
-        default_to_all: If True, make "All Regions" the default choice
-                       If False, make "Default Regions" the default choice
-        allow_all: If True, include "All Regions" option (default: True)
+        title: Menu title displayed above the border
+        options: List of option strings (displayed as 1..N)
+        allow_back: If True, show and accept 'b' to go back (default: True)
+        allow_exit: If True, show and accept 'x' to exit (default: True)
 
     Returns:
-        list: List of selected AWS region names
+        int 1..N if the user picks a numbered option,
+        'back' if the user enters 'b' (and allow_back is True),
+        'exit' if the user enters 'x' (and allow_exit is True).
+    """
+    if is_auto_run():
+        return 1
 
-    Examples:
-        # Basic usage with service name
-        regions = utils.prompt_region_selection(service_name="Lambda")
+    print(f"\n{title}")
+    print("=" * 64)
+    for i, opt in enumerate(options, 1):
+        print(f"  {i}. {opt}")
+    print("-" * 64)
+    footer_parts = []
+    if allow_back:
+        footer_parts.append("b. Back")
+    if allow_exit:
+        footer_parts.append("x. Exit")
+    if footer_parts:
+        print("  " + "    ".join(footer_parts))
+    print("=" * 64)
 
-        # Custom prompt message
-        regions = utils.prompt_region_selection(
-            prompt_message="Select regions for DataSync export:",
-            allow_all=True
-        )
+    valid = set(str(i) for i in range(1, len(options) + 1))
+    if allow_back:
+        valid.add("b")
+    if allow_exit:
+        valid.add("x")
 
-        # Default to all regions
-        regions = utils.prompt_region_selection(
-            service_name="Detective",
-            default_to_all=False
-        )
+    while True:
+        try:
+            choice = input("Enter your choice: ").strip().lower()
+        except KeyboardInterrupt:
+            print()
+            if allow_exit:
+                return 'exit'
+            continue
+
+        if choice in valid:
+            if choice == 'b':
+                return 'back'
+            if choice == 'x':
+                return 'exit'
+            return int(choice)
+        print("Invalid choice. Please try again.")
+
+
+def prompt_region_selection(
+    service_name: Optional[str] = None,
+) -> Union[List[str], str]:
+    """
+    Prompt user for AWS region selection with a standardized 3-option menu.
+
+    Args:
+        service_name: Optional name of the AWS service (e.g. "EC2", "Lambda").
+                      Displayed as context before the menu.
+
+    Returns:
+        List[str] of selected region names, 'back', or 'exit'.
+        Never calls sys.exit() directly.
     """
     # Automation mode: bypass interactive prompts when STRATUSSCAN_AUTO_RUN is set
     if is_auto_run():
         auto_regions = get_auto_regions()
         if auto_regions:
             return auto_regions
-        # Fall through: return all regions when auto-run set but no STRATUSSCAN_REGIONS
         _partition = detect_partition()
         return get_partition_regions(_partition, all_regions=True)
 
-    # Detect partition for region examples
     partition = detect_partition()
-    if partition == 'aws-us-gov':
-        example_regions = "us-gov-west-1, us-gov-east-1"
-    else:
-        example_regions = "us-east-1, us-west-1, us-west-2, eu-west-1"
+    default_regions = get_default_regions()
+    default_str = ", ".join(default_regions[:4])
+    if len(default_regions) > 4:
+        default_str += ", ..."
 
-    # Build prompt message
-    if prompt_message:
-        print(f"\n{prompt_message}")
-    elif service_name:
-        print(f"\n{service_name} is a regional service.")
+    if service_name:
+        print(f"\n{service_name} region selection")
 
-    # Display standardized region selection menu
-    print("\n" + "=" * 68)
-    print("REGION SELECTION")
-    print("=" * 68)
-    print("\nPlease select an option for region selection:")
-    print("\n  1. Default Regions")
-    print(f"     ({example_regions})")
+    options = [
+        f"Default Regions    ({default_str})",
+        "All Regions        (scan every region in the partition)",
+        "Select Regions     (choose one or more from a list)",
+    ]
 
-    if allow_all:
-        print("\n  2. All Available Regions")
-        print("     (Scan all regions where the service is available)")
-        print("\n  3. Specific Region")
-        print("     (Enter a specific AWS region code)")
-    else:
-        print("\n  2. Specific Region")
-        print("     (Enter a specific AWS region code)")
+    while True:
+        choice = prompt_menu("REGION SELECTION", options)
+        if choice == 'back':
+            return 'back'
+        if choice == 'exit':
+            return 'exit'
 
-    print("\n" + "-" * 68)
+        if choice == 1:
+            return default_regions
 
-    # Get and validate region choice
-    regions = []
-    while not regions:
-        try:
-            if allow_all:
-                region_choice = input("\nEnter your choice (1, 2, or 3): ").strip()
-            else:
-                region_choice = input("\nEnter your choice (1 or 2): ").strip()
+        if choice == 2:
+            all_regions = get_partition_regions(partition, all_regions=True)
+            print(f"\nScanning all {len(all_regions)} available regions.")
+            return all_regions
 
-            if region_choice == '1':
-                # Default regions
-                regions = get_default_regions()
-                print(f"\nUsing default regions: {', '.join(regions)}")
-
-            elif region_choice == '2':
-                if allow_all:
-                    # All available regions
-                    regions = get_partition_regions(partition, all_regions=True)
-                    print(f"\nScanning all {len(regions)} available regions")
-                else:
-                    # Specific region (when allow_all=False, option 2 is specific region)
-                    available_regions = get_partition_regions(partition, all_regions=True)
-                    print("\n" + "=" * 68)
-                    print("AVAILABLE REGIONS")
-                    print("=" * 68)
-                    for idx, region in enumerate(available_regions, 1):
-                        print(f"  {idx:2d}. {region}")
-                    print("=" * 68)
-
-                    # Get region selection with validation
-                    region_selected = False
-                    while not region_selected:
-                        try:
-                            region_num = input(f"\nEnter region number (1-{len(available_regions)}): ").strip()
-                            region_idx = int(region_num) - 1
-
-                            if 0 <= region_idx < len(available_regions):
-                                selected_region = available_regions[region_idx]
-                                regions = [selected_region]
-                                print(f"\nSelected region: {selected_region}")
-                                region_selected = True
-                            else:
-                                print(f"Invalid selection. Please enter a number between 1 and {len(available_regions)}.")
-                        except ValueError:
-                            print("Invalid input. Please enter a number.")
-                        except KeyboardInterrupt:
-                            print("\n\nOperation cancelled by user.")
-                            sys.exit(0)
-
-            elif region_choice == '3' and allow_all:
-                # Specific region (when allow_all=True, option 3 is specific region)
-                available_regions = get_partition_regions(partition, all_regions=True)
-                print("\n" + "=" * 68)
-                print("AVAILABLE REGIONS")
-                print("=" * 68)
-                for idx, region in enumerate(available_regions, 1):
-                    print(f"  {idx:2d}. {region}")
-                print("=" * 68)
-
-                # Get region selection with validation
-                region_selected = False
-                while not region_selected:
-                    try:
-                        region_num = input(f"\nEnter region number (1-{len(available_regions)}): ").strip()
-                        region_idx = int(region_num) - 1
-
-                        if 0 <= region_idx < len(available_regions):
-                            selected_region = available_regions[region_idx]
-                            regions = [selected_region]
-                            print(f"\nSelected region: {selected_region}")
-                            region_selected = True
+        if choice == 3:
+            # Sub-list: let user pick one or more regions by number
+            available = get_partition_regions(partition, all_regions=True)
+            while True:
+                print("\nAVAILABLE REGIONS")
+                print("=" * 64)
+                # 2-column layout when > 8 regions
+                if len(available) > 8:
+                    half = (len(available) + 1) // 2
+                    for i in range(half):
+                        left = f"  {i + 1:2d}. {available[i]}"
+                        if i + half < len(available):
+                            right = f"  {i + half + 1:2d}. {available[i + half]}"
+                            print(f"{left:<34}{right}")
                         else:
-                            print(f"Invalid selection. Please enter a number between 1 and {len(available_regions)}.")
-                    except ValueError:
-                        print("Invalid input. Please enter a number.")
-                    except KeyboardInterrupt:
-                        print("\n\nOperation cancelled by user.")
-                        sys.exit(0)
-            else:
-                if allow_all:
-                    print("\nInvalid choice. Please enter 1, 2, or 3.")
+                            print(left)
                 else:
-                    print("\nInvalid choice. Please enter 1 or 2.")
+                    for i, r in enumerate(available, 1):
+                        print(f"  {i:2d}. {r}")
+                print("=" * 64)
+                print("  b. Back    x. Exit")
+                print("=" * 64)
 
-        except KeyboardInterrupt:
-            print("\n\nOperation cancelled by user.")
-            sys.exit(0)
-        except Exception as e:
-            log_error(f"Error getting region selection: {str(e)}")
-            print("Please try again.")
+                try:
+                    raw = input(
+                        "Enter region number(s) separated by spaces (e.g. 1  or  1 4 7): "
+                    ).strip().lower()
+                except KeyboardInterrupt:
+                    print()
+                    return 'exit'
 
-    return regions
+                if raw == 'b':
+                    break  # back to main region menu
+                if raw == 'x':
+                    return 'exit'
+
+                tokens = raw.split()
+                valid = True
+                selected = []
+                for tok in tokens:
+                    try:
+                        idx = int(tok)
+                        if 1 <= idx <= len(available):
+                            selected.append(available[idx - 1])
+                        else:
+                            print(
+                                f"Invalid number {tok}. "
+                                f"Please enter values between 1 and {len(available)}."
+                            )
+                            valid = False
+                            break
+                    except ValueError:
+                        print(f"Invalid input '{tok}'. Please enter numbers only.")
+                        valid = False
+                        break
+
+                if valid and selected:
+                    return selected
+                if valid and not selected:
+                    print("No regions selected. Please enter at least one number.")
 
 def get_organization_name() -> str:
     """
@@ -575,6 +575,38 @@ def get_current_log_file() -> Optional[str]:
         if isinstance(handler, logging.FileHandler):
             return handler.baseFilename
     return None
+
+def prompt_confirmation(message: str) -> str:
+    """
+    Display a confirmation prompt and return the user's navigation choice.
+
+    Args:
+        message: Confirmation message to display before the prompt.
+
+    Returns:
+        'confirm' if the user presses Enter,
+        'back' if the user enters 'b',
+        'exit' if the user enters 'x'.
+    """
+    if is_auto_run():
+        return 'confirm'
+
+    print(f"\n{message}")
+    while True:
+        try:
+            raw = input("Press Enter to confirm, b to go back, x to exit: ").strip().lower()
+        except KeyboardInterrupt:
+            print()
+            return 'exit'
+
+        if raw == '':
+            return 'confirm'
+        if raw == 'b':
+            return 'back'
+        if raw == 'x':
+            return 'exit'
+        print("Please press Enter, b, or x.")
+
 
 def prompt_for_confirmation(message: str = "Do you want to continue?", default: bool = True) -> bool:
     """


### PR DESCRIPTION
## Summary

Implements the EC2 gold standard UX flow and lays the `utils.py` foundation that all future exporter standardization (Issue #71) will build on.

## Changes

### `utils.py`
- **`prompt_menu()`** (new): universal bordered numbered menu returning `int`, `'back'`, or `'exit'`; auto-run returns `1`
- **`prompt_region_selection()`** (rewritten): clean numbered menu (Default / All / Select); option 3 supports multi-region via space-separated number tokens; returns `List[str]`, `'back'`, or `'exit'`; never calls `sys.exit()` directly
- **`prompt_confirmation()`** (new): returns `'confirm'`, `'back'`, or `'exit'`; auto-run returns `'confirm'` immediately

### `stratusscan.py`
- `execute_script()`: exit code `10` → `BackSignal`, exit code `11` → `ExitToMainSignal`; real errors still log and return `False`

### `scripts/ec2_export.py`
- `main()` restructured as 4-step state machine: region → filter → confirm → export
- `_prompt_instance_filter()` and `_run_export()` extracted as private helpers
- Banner replaced with `utils.print_script_banner()`
- `b` / `x` at every step produces correct exit code

### Tests
- `tests/test_utils.py`: added `TestPromptMenu` (5), `TestPromptRegionSelectionNew` (8), `TestPromptConfirmation` (5)
- `tests/test_duplicate_code_refactoring.py`: removed `@unittest.skip`; 7 tests rewritten for numbered-menu API
- **301 passed, 0 failed** (was 276 before this branch)

## Test Plan

- [x] `pytest` — 301 passed, 0 failed
- [x] Manual UAT via `stratusscan.py` — region-first flow, `b`/`x` at every step, confirmation line, successful export completion

Closes #72
Partially closes #71 (foundation complete; rollout to remaining scripts tracked separately)