### PR TITLE
fix(ux): suppress INFO log noise from console output

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -115,9 +115,9 @@ def setup_logging(script_name: str = "stratusscan", log_to_file: bool = True) ->
         datefmt='%Y-%m-%d %H:%M:%S'
     )
 
-    # Console handler (always enabled)
+    # Console handler — WARNING+ only; INFO goes to the log file exclusively
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(logging.WARNING)
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
 


### PR DESCRIPTION
## Summary

- Sets `console_handler.setLevel(logging.WARNING)` in `utils.setup_logging()` (was `INFO`)
- INFO-level messages (initialization banners, menu selection logs, script-start separators, progress updates) now go to the log file only
- WARNING and ERROR messages continue to appear on screen
- **1 line changed in 1 file** — fix is universal across all 80+ exporter scripts with no per-script changes required

## Before / After

**Before:** every script launch printed ~5 lines of log noise before the first menu appeared:
```
2026-02-22 16:14:47 - INFO - MENU SELECTION: Identity & Access Management.1 - IAM
Executing: /path/to/iam_export.py
============================================================
2026-02-22 16:14:21 - INFO - StratusScan logging initialized - Log file: ...
2026-02-22 16:14:21 - INFO - Script: iam-export
```

**After:** clean console; full INFO detail still captured in `logs/`.

## Test plan

- [ ] `pytest` — confirm 301 passed, 0 failed
- [ ] Launch `python3 stratusscan.py` → navigate to any exporter → confirm no INFO lines appear on screen
- [ ] Confirm WARNING/ERROR messages still surface (e.g., missing config, partition unavailable)
- [ ] Confirm `logs/` files still contain full INFO detail

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)