### PR TITLE
fix(ux): main menu footer shows only 'q = quit'

### DIFF
--- a/stratusscan.py
+++ b/stratusscan.py
@@ -629,7 +629,7 @@ def display_main_menu():
     for option, info in menu_structure.items():
         print(f"{option}. {info['name']}")
 
-    print("\n  b = back  |  x = main menu  |  q = quit")
+    print("\n  q = quit")
 
     return menu_structure
 


### PR DESCRIPTION
## Summary

- Removes `b = back  |  x = main menu` from the main menu footer hint — those actions are meaningless at the top level
- Submenu footers are unchanged (`b = back  |  x = main menu  |  q = quit`)
- 1 line changed in `stratusscan.py:display_main_menu()`

## Before / After

**Before:**
```
  b = back  |  x = main menu  |  q = quit
```

**After:**
```
  q = quit
```

## Test plan

- [ ] `pytest` — confirm 301 passed, 0 failed
- [ ] Launch `python3 stratusscan.py` → confirm main menu shows only `q = quit`
- [ ] Navigate into any submenu → confirm footer still shows `b = back  |  x = main menu  |  q = quit`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)