### PR TITLE
feat(ux): menu restructure for v0.2.0

### DIFF
--- a/scripts/output_archive.py
+++ b/scripts/output_archive.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+"""
+===========================
+= AWS RESOURCE SCANNER =
+===========================
+
+Title: StratusScan Output Archive Script
+Date: FEB-22-2026
+
+Description:
+Creates a dated zip archive of all files in the output/ directory.
+Follows the gold-standard 2-step flow: confirm → archive.
+"""
+
+import sys
+import zipfile
+import datetime
+from pathlib import Path
+
+try:
+    import utils
+except ImportError:
+    script_dir = Path(__file__).parent.absolute()
+    if script_dir.name.lower() == 'scripts':
+        sys.path.append(str(script_dir.parent))
+    else:
+        sys.path.append(str(script_dir))
+    try:
+        import utils
+    except ImportError:
+        print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
+        sys.exit(1)
+
+utils.setup_logging("output-archive")
+
+
+def _create_archive(account_name: str) -> bool:
+    """
+    Create a dated zip archive of the output/ directory.
+
+    Args:
+        account_name: AWS account name used in the archive filename.
+
+    Returns:
+        True if the archive was created successfully, False otherwise.
+    """
+    output_dir = Path(__file__).parent.parent / "output"
+
+    if not output_dir.exists():
+        print("Output directory not found. Run an export first.")
+        return False
+
+    files = list(output_dir.glob("*.*"))
+    if not files:
+        print("No files found in the output directory. Nothing to archive.")
+        return False
+
+    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+    zip_filename = f"{account_name}-export-{current_date}.zip"
+    zip_path = Path(__file__).parent.parent / zip_filename
+
+    print(f"\nFound {len(files)} file(s) to archive.")
+    print(f"Creating: {zip_filename}\n")
+
+    try:
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            for file in files:
+                zipf.write(file, arcname=file.name)
+                print(f"  Added: {file.name}")
+
+        print(f"\nArchive created successfully: {zip_path}")
+        utils.log_success(f"Output archive created: {zip_path}")
+        return True
+
+    except Exception as e:
+        utils.log_error("Failed to create archive", e)
+        return False
+
+
+def main():
+    """Main function — 2-step state machine: confirm → archive."""
+    try:
+        utils.setup_logging("output-archive")
+        account_id, account_name = utils.print_script_banner("OUTPUT ARCHIVE")
+
+        step = 1
+        while True:
+            if step == 1:
+                result = utils.prompt_confirmation(
+                    f"Create a zip archive of all files in output/ "
+                    f"({account_name}-export-<date>.zip)?"
+                )
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                step = 2
+
+            elif step == 2:
+                _create_archive(account_name)
+                print("\nScript execution completed.")
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -792,14 +792,20 @@ def navigate_menus():
                         create_output_archive(account_name)
                     elif selected_option["name"] == "Configure StratusScan":
                         if selected_option["file"]:
-                            success = execute_script(selected_option["file"])
+                            try:
+                                success = execute_script(selected_option["file"])
+                            except (BackSignal, ExitToMainSignal):
+                                continue
                             if success:
                                 print("\nConfiguration completed successfully!")
                                 print("You may need to restart StratusScan for changes to take effect.")
                             else:
                                 print("\nConfiguration may not have completed successfully.")
                     elif selected_option.get("file"):
-                        execute_script(selected_option["file"])
+                        try:
+                            execute_script(selected_option["file"])
+                        except (BackSignal, ExitToMainSignal):
+                            continue  # Script returned 'b' or 'x' — redisplay main menu
 
             # Submenu
             elif "submenu" in selected_option:

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -424,7 +424,6 @@ def get_menu_structure():
                         "10": {"name": "EC2 Capacity Reservations", "file": scripts_dir / "ec2_capacity_reservations_export.py", "description": "Export EC2 Capacity Reservations"},
                         "11": {"name": "EC2 Dedicated Hosts", "file": scripts_dir / "ec2_dedicated_hosts_export.py", "description": "Export EC2 Dedicated Hosts"},
                         "12": {"name": "All Compute Resources", "file": scripts_dir / "compute_resources.py", "description": "Export all compute resources in one report"},
-                        "13": {"name": "Return to Previous Menu", "file": None, "description": "Return to Infrastructure menu"}
                     }
                 },
                 "2": {
@@ -442,7 +441,6 @@ def get_menu_structure():
                         "10": {"name": "Storage Gateway", "file": scripts_dir / "storagegateway_export.py", "description": "Export Storage Gateway"},
                         "11": {"name": "Glacier Vaults", "file": scripts_dir / "glacier_export.py", "description": "Export Glacier vaults"},
                         "12": {"name": "All Storage Resources", "file": scripts_dir / "storage_resources.py", "description": "Export all storage resources in one report"},
-                        "13": {"name": "Return to Previous Menu", "file": None, "description": "Return to Infrastructure menu"}
                     }
                 },
                 "3": {
@@ -462,7 +460,6 @@ def get_menu_structure():
                         "12": {"name": "Network Firewall", "file": scripts_dir / "network_firewall_export.py", "description": "Export Network Firewall"},
                         "13": {"name": "Network Manager", "file": scripts_dir / "network_manager_export.py", "description": "Export Network Manager topology"},
                         "14": {"name": "All Network Resources", "file": scripts_dir / "network_resources.py", "description": "Export network resources (select regions during run)"},
-                        "15": {"name": "Return to Previous Menu", "file": None, "description": "Return to Infrastructure menu"}
                     }
                 },
                 "4": {
@@ -472,34 +469,41 @@ def get_menu_structure():
                         "2": {"name": "ElastiCache", "file": scripts_dir / "elasticache_export.py", "description": "Export ElastiCache clusters"},
                         "3": {"name": "DocumentDB", "file": scripts_dir / "documentdb_export.py", "description": "Export DocumentDB clusters"},
                         "4": {"name": "Neptune", "file": scripts_dir / "neptune_export.py", "description": "Export Neptune graph databases"},
-                        "5": {"name": "Return to Previous Menu", "file": None, "description": "Return to Infrastructure menu"}
                     }
                 },
-                "5": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "3": {
             "name": "Security & Compliance",
             "submenu": {
-                "1": {"name": "Security Hub", "file": scripts_dir / "security_hub_export.py", "description": "Export Security Hub findings"},
-                "2": {"name": "GuardDuty", "file": scripts_dir / "guardduty_export.py", "description": "Export GuardDuty findings"},
-                "3": {"name": "AWS WAF", "file": scripts_dir / "waf_export.py", "description": "Export WAF web ACLs and rules"},
-                "4": {"name": "CloudTrail", "file": scripts_dir / "cloudtrail_export.py", "description": "Export CloudTrail trails"},
-                "5": {"name": "AWS Config", "file": scripts_dir / "config_export.py", "description": "Export Config rules and compliance"},
-                "6": {"name": "KMS", "file": scripts_dir / "kms_export.py", "description": "Export KMS keys and encryption configs"},
-                "7": {"name": "Secrets Manager", "file": scripts_dir / "secrets_manager_export.py", "description": "Export Secrets Manager metadata"},
-                "8": {"name": "ACM", "file": scripts_dir / "acm_export.py", "description": "Export ACM SSL/TLS certificates"},
-                "9": {"name": "IAM Access Analyzer", "file": scripts_dir / "access_analyzer_export.py", "description": "Export Access Analyzer findings"},
-                "10": {"name": "Detective", "file": scripts_dir / "detective_export.py", "description": "Export Detective behavior graphs"},
-                "11": {"name": "Shield Advanced", "file": scripts_dir / "shield_export.py", "description": "Export Shield DDoS protection"},
-                "12": {"name": "IAM Roles Anywhere", "file": scripts_dir / "iam_rolesanywhere_export.py", "description": "Export IAM Roles Anywhere"},
-                "13": {"name": "Verified Access", "file": scripts_dir / "verifiedaccess_export.py", "description": "Export Verified Access zero-trust"},
-                "14": {"name": "Macie", "file": scripts_dir / "macie_export.py", "description": "Export Macie data security findings"},
-                "15": {"name": "Cognito", "file": scripts_dir / "cognito_export.py", "description": "Export Cognito user pools"},
-                "16": {"name": "ACM Private CA", "file": scripts_dir / "acm_privateca_export.py", "description": "Export ACM Private CAs"},
-                "17": {"name": "IAM Identity Providers", "file": scripts_dir / "iam_identity_providers_export.py", "description": "Export IAM SAML/OIDC providers"},
-                "18": {"name": "Verified Permissions", "file": scripts_dir / "verifiedpermissions_export.py", "description": "Export Verified Permissions Cedar policies"},
-                "19": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
+                "1": {
+                    "name": "Security Monitoring",
+                    "submenu": {
+                        "1": {"name": "Security Hub", "file": scripts_dir / "security_hub_export.py", "description": "Export Security Hub findings"},
+                        "2": {"name": "GuardDuty", "file": scripts_dir / "guardduty_export.py", "description": "Export GuardDuty findings"},
+                        "3": {"name": "Detective", "file": scripts_dir / "detective_export.py", "description": "Export Detective behavior graphs"},
+                        "4": {"name": "Macie", "file": scripts_dir / "macie_export.py", "description": "Export Macie data security findings"},
+                        "5": {"name": "AWS WAF", "file": scripts_dir / "waf_export.py", "description": "Export WAF web ACLs and rules"},
+                        "6": {"name": "Shield Advanced", "file": scripts_dir / "shield_export.py", "description": "Export Shield DDoS protection"},
+                        "7": {"name": "IAM Access Analyzer", "file": scripts_dir / "access_analyzer_export.py", "description": "Export Access Analyzer findings"},
+                    }
+                },
+                "2": {
+                    "name": "Identity, Certs & Config",
+                    "submenu": {
+                        "1": {"name": "KMS", "file": scripts_dir / "kms_export.py", "description": "Export KMS keys and encryption configs"},
+                        "2": {"name": "ACM", "file": scripts_dir / "acm_export.py", "description": "Export ACM SSL/TLS certificates"},
+                        "3": {"name": "ACM Private CA", "file": scripts_dir / "acm_privateca_export.py", "description": "Export ACM Private CAs"},
+                        "4": {"name": "Secrets Manager", "file": scripts_dir / "secrets_manager_export.py", "description": "Export Secrets Manager metadata"},
+                        "5": {"name": "Cognito", "file": scripts_dir / "cognito_export.py", "description": "Export Cognito user pools"},
+                        "6": {"name": "Verified Access", "file": scripts_dir / "verifiedaccess_export.py", "description": "Export Verified Access zero-trust"},
+                        "7": {"name": "Verified Permissions", "file": scripts_dir / "verifiedpermissions_export.py", "description": "Export Verified Permissions Cedar policies"},
+                        "8": {"name": "IAM Roles Anywhere", "file": scripts_dir / "iam_rolesanywhere_export.py", "description": "Export IAM Roles Anywhere"},
+                        "9": {"name": "IAM Identity Providers", "file": scripts_dir / "iam_identity_providers_export.py", "description": "Export IAM SAML/OIDC providers"},
+                        "10": {"name": "CloudTrail", "file": scripts_dir / "cloudtrail_export.py", "description": "Export CloudTrail trails"},
+                        "11": {"name": "AWS Config", "file": scripts_dir / "config_export.py", "description": "Export Config rules and compliance"},
+                    }
+                },
             }
         },
         "4": {
@@ -529,7 +533,6 @@ def get_menu_structure():
                 "7": {"name": "Reserved Instances", "file": scripts_dir / "reserved_instances_export.py", "description": "Export Reserved Instances"},
                 "8": {"name": "Cost Categories", "file": scripts_dir / "cost_categories_export.py", "description": "Export Cost Categories"},
                 "9": {"name": "Cost Anomaly Detection", "file": scripts_dir / "cost_anomaly_detection_export.py", "description": "Export Cost Anomaly Detection"},
-                "10": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "6": {
@@ -546,7 +549,6 @@ def get_menu_structure():
                 "9": {"name": "Cloud Map", "file": scripts_dir / "cloudmap_export.py", "description": "Export Cloud Map service discovery"},
                 "10": {"name": "SES", "file": scripts_dir / "ses_export.py", "description": "Export SES email identities"},
                 "11": {"name": "SES & Pinpoint", "file": scripts_dir / "ses_pinpoint_export.py", "description": "Export SES and Pinpoint combined"},
-                "12": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "7": {
@@ -562,17 +564,15 @@ def get_menu_structure():
                 "8": {"name": "Rekognition", "file": scripts_dir / "rekognition_export.py", "description": "Export Rekognition computer vision"},
                 "9": {"name": "CloudWatch", "file": scripts_dir / "cloudwatch_export.py", "description": "Export CloudWatch alarms and logs"},
                 "10": {"name": "X-Ray", "file": scripts_dir / "xray_export.py", "description": "Export X-Ray distributed tracing"},
-                "11": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "8": {
-            "name": "Developer Tools",
+            "name": "DevOps Services",
             "submenu": {
                 "1": {"name": "CodeBuild", "file": scripts_dir / "codebuild_export.py", "description": "Export CodeBuild projects"},
                 "2": {"name": "CodePipeline", "file": scripts_dir / "codepipeline_export.py", "description": "Export CodePipeline pipelines"},
                 "3": {"name": "CodeCommit", "file": scripts_dir / "codecommit_export.py", "description": "Export CodeCommit repositories"},
                 "4": {"name": "CodeDeploy", "file": scripts_dir / "codedeploy_export.py", "description": "Export CodeDeploy applications"},
-                "5": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "9": {
@@ -585,16 +585,13 @@ def get_menu_structure():
                 "5": {"name": "AWS Marketplace", "file": scripts_dir / "marketplace_export.py", "description": "Export AWS Marketplace configuration"},
                 "6": {"name": "AWS Control Tower", "file": scripts_dir / "controltower_export.py", "description": "Export Control Tower landing zone"},
                 "7": {"name": "Systems Manager Fleet", "file": scripts_dir / "ssm_fleet_export.py", "description": "Export SSM managed instances"},
-                "8": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
             }
         },
         "10": {
             "name": "Output Management",
-            "submenu": {
-                "1": {"name": "Create Output Archive", "file": None, "description": "Create a zip archive of all exported files", "action": "create_archive"},
-                "2": {"name": "Return to Main Menu", "file": None, "description": "Return to the main menu"}
-            }
-        }
+            "file": scripts_dir / "output_archive.py",
+            "description": "Create a zip archive of all exported files"
+        },
     }
 
     # Verify the script files exist (only for actual scripts)


### PR DESCRIPTION
## Summary

- **Removed all numbered 'Return to' entries** from every submenu — `b` and `x` already handle navigation; the numbered entries were redundant noise (13 entries removed across 8 submenus)
- **Split Security & Compliance** (was 18 flat items) into two focused sub-categories:
  - `Security Monitoring`: Security Hub, GuardDuty, Detective, Macie, WAF, Shield Advanced, IAM Access Analyzer
  - `Identity, Certs & Config`: KMS, ACM, ACM Private CA, Secrets Manager, Cognito, Verified Access, Verified Permissions, IAM Roles Anywhere, IAM Identity Providers, CloudTrail, Config
- **Renamed `Developer Tools` → `DevOps Services`**
- **Collapsed `Output Management`** from a single-action submenu into a direct main-menu entry backed by new `scripts/output_archive.py` (gold-standard 2-step: confirm → zip)

## Test plan

- [ ] `pytest` — confirm 301 passed, 0 failed
- [ ] Launch `python3 stratusscan.py` → verify no 'Return to' numbered entries appear in any submenu
- [ ] Navigate `3` (Security & Compliance) → confirm two sub-categories are shown
- [ ] Navigate `8` → confirm it reads 'DevOps Services'
- [ ] Navigate `10` (Output Management) → confirm it launches `output_archive.py` directly (no intermediate submenu)
- [ ] Confirm `b` and `x` navigation still work at all menu levels

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)