### PR TITLE
feat(ux): Issue #71 Phase 3 — gold-standard sweep: App Services & Data (9 scripts)

### DIFF
--- a/scripts/apprunner_export.py
+++ b/scripts/apprunner_export.py
@@ -442,23 +442,8 @@ def generate_summary(services: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect App Runner data and write the Excel export."""
     # Collect data
     print("\n=== Collecting App Runner Data ===")
     services = collect_apprunner_services(regions)
@@ -514,7 +499,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("apprunner-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS APP RUNNER EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="App Runner")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export App Runner data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/appsync_export.py
+++ b/scripts/appsync_export.py
@@ -462,23 +462,8 @@ def generate_summary(apis: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect AppSync data and write the Excel export."""
     # Collect data
     print("\n=== Collecting AppSync Data ===")
     apis = collect_graphql_apis(regions)
@@ -534,7 +519,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("appsync-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS APPSYNC GRAPHQL API EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="AppSync")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export AppSync data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/elasticbeanstalk_export.py
+++ b/scripts/elasticbeanstalk_export.py
@@ -504,23 +504,8 @@ def generate_summary(applications: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect Elastic Beanstalk data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Elastic Beanstalk Data ===")
     applications = collect_applications(regions)
@@ -576,7 +561,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("elasticbeanstalk-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS ELASTIC BEANSTALK EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="Elastic Beanstalk")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export Elastic Beanstalk data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/glue_athena_export.py
+++ b/scripts/glue_athena_export.py
@@ -368,23 +368,8 @@ def generate_summary(databases: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect Glue and Athena data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Glue & Athena Data ===")
     databases = collect_glue_databases(regions)
@@ -452,7 +437,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("glue-athena-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS GLUE AND ATHENA EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="Glue/Athena")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export Glue and Athena data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/lakeformation_export.py
+++ b/scripts/lakeformation_export.py
@@ -400,23 +400,8 @@ def generate_summary(resources: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.ensure_dependencies('pandas', 'openpyxl', 'boto3'):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect Lake Formation data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Lake Formation Data ===")
     resources = collect_lakeformation_resources(regions)
@@ -472,7 +457,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("lakeformation-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS LAKE FORMATION EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="Lake Formation")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export Lake Formation data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/opensearch_export.py
+++ b/scripts/opensearch_export.py
@@ -439,23 +439,8 @@ def generate_summary(domains: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect OpenSearch data and write the Excel export."""
     # Collect data
     print("\n=== Collecting OpenSearch Data ===")
     domains = collect_opensearch_domains(regions)
@@ -499,7 +484,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("opensearch-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS OPENSEARCH SERVICE EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="OpenSearch")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export OpenSearch data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/redshift_export.py
+++ b/scripts/redshift_export.py
@@ -549,23 +549,8 @@ def generate_summary(clusters: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect Redshift data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Redshift Data ===")
     clusters = collect_redshift_clusters(regions)
@@ -621,7 +606,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("redshift-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS REDSHIFT DATA WAREHOUSE EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="Redshift")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export Redshift data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/stepfunctions_export.py
+++ b/scripts/stepfunctions_export.py
@@ -327,24 +327,8 @@ def generate_summary(state_machines: List[Dict[str, Any]],
     return summary
 
 
-def main():
-    """Main execution function."""
-    script_name = Path(__file__).stem
-    utils.setup_logging(script_name)
-    utils.log_script_start(script_name)
-
-    # Check dependencies
-    if not utils.check_dependencies(['pandas', 'openpyxl', 'boto3']):
-        utils.log_error("Required dependencies not installed")
-        return
-
-    # Get account information
-    account_id, account_name = utils.get_account_info()
-    utils.log_info(f"Account: {account_name} ({utils.mask_account_id(account_id)})")
-
-    # Region selection
-    # Detect partition for region examples
-    regions = utils.prompt_region_selection()
+def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
+    """Collect Step Functions data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Step Functions Data ===")
     state_machines = collect_state_machines(regions)
@@ -394,7 +378,50 @@ def main():
             }
         )
 
-    utils.log_script_end(script_name)
+
+def main():
+    """Main execution function — 3-step state machine (region -> confirm -> export)."""
+    utils.setup_logging("stepfunctions-export")
+
+    try:
+        account_id, account_name = utils.print_script_banner("AWS STEP FUNCTIONS EXPORT")
+
+        step = 1
+        regions = None
+
+        while True:
+            if step == 1:
+                result = utils.prompt_region_selection(service_name="Step Functions")
+                if result == 'back':
+                    sys.exit(10)
+                if result == 'exit':
+                    sys.exit(11)
+                regions = result
+                step = 2
+
+            elif step == 2:
+                region_str = regions[0] if len(regions) == 1 else f"{len(regions)} regions"
+                msg = f"Ready to export Step Functions data ({region_str})."
+                result = utils.prompt_confirmation(msg)
+                if result == 'back':
+                    step = 1
+                    continue
+                if result == 'exit':
+                    sys.exit(11)
+                step = 3
+
+            elif step == 3:
+                _run_export(account_id, account_name, regions)
+                break
+
+    except KeyboardInterrupt:
+        print("\n\nScript interrupted by user. Exiting...")
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception as e:
+        utils.log_error("Unexpected error occurred", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Standardizes 9 Application Services and Data & Analytics exporter scripts to the gold-standard 3-step state machine (region → confirm → export).

| Script | Category |
|--------|----------|
| `apprunner_export.py` | Application Services |
| `appsync_export.py` | Application Services |
| `elasticbeanstalk_export.py` | Application Services |
| `ses_pinpoint_export.py` | Application Services |
| `stepfunctions_export.py` | Application Services |
| `glue_athena_export.py` | Data & Analytics |
| `lakeformation_export.py` | Data & Analytics |
| `opensearch_export.py` | Data & Analytics |
| `redshift_export.py` | Data & Analytics |

All data-collection helpers preserved exactly. No GovCloud guards needed — all 9 services are available in GovCloud.

## Test plan

- [ ] `pytest` — confirm 301 passed, 0 failed
- [ ] Spot-check `b`/`x` navigation on at least one script

Part of #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)