### PR TITLE
feat(ci): add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest

--- a/tests/test_duplicate_code_refactoring.py
+++ b/tests/test_duplicate_code_refactoring.py
@@ -270,14 +270,10 @@ class TestIntegration(unittest.TestCase):
 
     @patch('sslib.aws_client.get_boto3_client')
     @patch('sslib.aws_client.get_account_name')
-    @patch('builtins.__import__')
-    def test_typical_script_flow(self, mock_import, mock_get_name, mock_client):
+    def test_typical_script_flow(self, mock_get_name, mock_client):
         """Test typical script flow using all three utility functions."""
         # Clear cache
         sslib.aws_client._account_info_cache = None
-
-        # Setup mocks
-        mock_import.side_effect = lambda pkg: None  # All dependencies installed
 
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {'Account': '123456789012'}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` to run pytest on push to `dev` and PRs targeting `dev`/`main`
- Matrix build across Python 3.9 and 3.12
- Removes `@patch('builtins.__import__')` in `test_duplicate_code_refactoring.py` — the mock was incompatible with Python 3.9 and was causing test failures in CI

## Test plan
- [ ] CI workflow triggers on PR open
- [ ] Both Python 3.9 and 3.12 matrix jobs pass
- [ ] `test_typical_script_flow` passes without the `__import__` patch

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)