### PR TITLE
fix(exporters): remove unsupported resource_type= kwarg — closes #101

### DIFF
--- a/scripts/acm_export.py
+++ b/scripts/acm_export.py
@@ -214,7 +214,6 @@ def collect_acm_certificates(regions: List[str]) -> List[Dict[str, Any]]:
     all_certificates = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_acm_certificates_in_region,
-        resource_type="ACM certificates"
     )
 
     utils.log_success(f"Total ACM certificates collected: {len(all_certificates)}")
@@ -310,7 +309,6 @@ def collect_certificate_validation_details(regions: List[str]) -> List[Dict[str,
     all_validations = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_certificate_validation_details_in_region,
-        resource_type="certificate validation details"
     )
 
     utils.log_success(f"Total validation details collected: {len(all_validations)}")

--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -128,7 +128,6 @@ def collect_rest_apis(regions: List[str]) -> List[Dict[str, Any]]:
     all_apis = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_rest_apis_in_region,
-        resource_type="REST APIs"
     )
 
     utils.log_success(f"Total REST APIs collected: {len(all_apis)}")
@@ -222,7 +221,6 @@ def collect_http_apis(regions: List[str]) -> List[Dict[str, Any]]:
     all_apis = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_http_apis_in_region,
-        resource_type="HTTP APIs"
     )
 
     utils.log_success(f"Total HTTP APIs collected: {len(all_apis)}")
@@ -342,7 +340,6 @@ def collect_api_stages(regions: List[str]) -> List[Dict[str, Any]]:
     all_stages = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_api_stages_in_region,
-        resource_type="API stages"
     )
 
     utils.log_success(f"Total API stages collected: {len(all_stages)}")

--- a/scripts/cognito_export.py
+++ b/scripts/cognito_export.py
@@ -191,7 +191,6 @@ def collect_user_pools(regions: List[str]) -> List[Dict[str, Any]]:
     all_pools = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_user_pools_in_region,
-        resource_type="Cognito user pools"
     )
 
     utils.log_info(f"Collected {len(all_pools)} user pools")
@@ -289,7 +288,6 @@ def collect_identity_pools(regions: List[str]) -> List[Dict[str, Any]]:
     all_identity_pools = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_identity_pools_in_region,
-        resource_type="Cognito identity pools"
     )
 
     utils.log_info(f"Collected {len(all_identity_pools)} identity pools")
@@ -432,7 +430,6 @@ def collect_user_pool_clients(regions: List[str]) -> List[Dict[str, Any]]:
     all_clients = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_user_pool_clients_in_region,
-        resource_type="Cognito user pool clients"
     )
 
     utils.log_info(f"Collected {len(all_clients)} user pool clients")
@@ -561,7 +558,6 @@ def collect_identity_providers(regions: List[str]) -> List[Dict[str, Any]]:
     all_providers = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_identity_providers_in_region,
-        resource_type="Cognito identity providers"
     )
 
     utils.log_info(f"Collected {len(all_providers)} identity providers")
@@ -651,7 +647,6 @@ def collect_user_pool_groups(regions: List[str]) -> List[Dict[str, Any]]:
     all_groups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_user_pool_groups_in_region,
-        resource_type="Cognito user pool groups"
     )
 
     utils.log_info(f"Collected {len(all_groups)} user pool groups")

--- a/scripts/dynamodb_export.py
+++ b/scripts/dynamodb_export.py
@@ -196,7 +196,6 @@ def collect_dynamodb_tables(regions: List[str]) -> List[Dict[str, Any]]:
     all_tables = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_dynamodb_tables_in_region,
-        resource_type="DynamoDB tables"
     )
 
     utils.log_success(f"Total DynamoDB tables collected: {len(all_tables)}")
@@ -314,7 +313,6 @@ def collect_global_secondary_indexes(regions: List[str]) -> List[Dict[str, Any]]
     all_gsis = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_global_secondary_indexes_in_region,
-        resource_type="Global Secondary Indexes"
     )
 
     utils.log_success(f"Total Global Secondary Indexes collected: {len(all_gsis)}")
@@ -403,7 +401,6 @@ def collect_dynamodb_backups(regions: List[str]) -> List[Dict[str, Any]]:
     all_backups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_dynamodb_backups_in_region,
-        resource_type="DynamoDB backups"
     )
 
     utils.log_success(f"Total DynamoDB backups collected: {len(all_backups)}")

--- a/scripts/ecr_export.py
+++ b/scripts/ecr_export.py
@@ -144,7 +144,6 @@ def collect_ecr_repositories(regions: List[str]) -> List[Dict[str, Any]]:
     all_repos = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_ecr_repositories_in_region,
-        resource_type="ECR repositories"
     )
 
     utils.log_success(f"Total ECR repositories collected: {len(all_repos)}")
@@ -257,7 +256,6 @@ def collect_ecr_images(regions: List[str]) -> List[Dict[str, Any]]:
     all_images = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_ecr_images_in_region,
-        resource_type="ECR images"
     )
 
     utils.log_success(f"Total ECR images collected: {len(all_images)}")
@@ -355,7 +353,6 @@ def collect_lifecycle_policies(regions: List[str]) -> List[Dict[str, Any]]:
     all_policies = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_lifecycle_policies_in_region,
-        resource_type="ECR lifecycle policies"
     )
 
     utils.log_success(f"Total lifecycle policy records collected: {len(all_policies)}")

--- a/scripts/elasticache_export.py
+++ b/scripts/elasticache_export.py
@@ -166,7 +166,6 @@ def collect_replication_groups(regions: List[str]) -> List[Dict[str, Any]]:
     all_replication_groups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_replication_groups_in_region,
-        resource_type="ElastiCache replication groups"
     )
 
     utils.log_success(f"Total ElastiCache replication groups collected: {len(all_replication_groups)}")
@@ -280,7 +279,6 @@ def collect_cache_clusters(regions: List[str]) -> List[Dict[str, Any]]:
     all_clusters = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_cache_clusters_in_region,
-        resource_type="ElastiCache cache clusters"
     )
 
     utils.log_success(f"Total ElastiCache cache clusters collected: {len(all_clusters)}")
@@ -366,7 +364,6 @@ def collect_cache_subnet_groups(regions: List[str]) -> List[Dict[str, Any]]:
     all_subnet_groups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_cache_subnet_groups_in_region,
-        resource_type="ElastiCache subnet groups"
     )
 
     utils.log_success(f"Total ElastiCache subnet groups collected: {len(all_subnet_groups)}")

--- a/scripts/kms_export.py
+++ b/scripts/kms_export.py
@@ -181,7 +181,6 @@ def collect_kms_keys(regions: List[str], account_id: str) -> List[Dict[str, Any]
     all_keys = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_kms_keys_in_region,
-        resource_type="KMS keys",
         account_id=account_id
     )
 
@@ -260,7 +259,6 @@ def collect_kms_aliases(regions: List[str]) -> List[Dict[str, Any]]:
     all_aliases = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_kms_aliases_in_region,
-        resource_type="KMS aliases"
     )
 
     utils.log_success(f"Total KMS aliases collected: {len(all_aliases)}")
@@ -366,7 +364,6 @@ def collect_kms_grants(regions: List[str]) -> List[Dict[str, Any]]:
     all_grants = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_kms_grants_in_region,
-        resource_type="KMS grants"
     )
 
     utils.log_success(f"Total KMS grants collected: {len(all_grants)}")

--- a/scripts/opensearch_export.py
+++ b/scripts/opensearch_export.py
@@ -228,7 +228,6 @@ def collect_opensearch_domains(regions: List[str]) -> List[Dict[str, Any]]:
     all_domains = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_opensearch_domains_in_region,
-        resource_type="OpenSearch domains"
     )
 
     return all_domains
@@ -296,7 +295,6 @@ def collect_opensearch_tags(regions: List[str]) -> List[Dict[str, Any]]:
     all_tags = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_opensearch_tags_in_region,
-        resource_type="OpenSearch domain tags"
     )
 
     return all_tags

--- a/scripts/redshift_export.py
+++ b/scripts/redshift_export.py
@@ -201,7 +201,6 @@ def collect_redshift_clusters(regions: List[str]) -> List[Dict[str, Any]]:
     all_clusters = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_redshift_clusters_in_region,
-        resource_type="Redshift clusters"
     )
 
     return all_clusters
@@ -302,7 +301,6 @@ def collect_redshift_snapshots(regions: List[str]) -> List[Dict[str, Any]]:
     all_snapshots = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_redshift_snapshots_in_region,
-        resource_type="Redshift snapshots"
     )
 
     return all_snapshots
@@ -351,7 +349,6 @@ def collect_redshift_parameter_groups(regions: List[str]) -> List[Dict[str, Any]
     all_parameter_groups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_redshift_parameter_groups_in_region,
-        resource_type="Redshift parameter groups"
     )
 
     return all_parameter_groups
@@ -419,7 +416,6 @@ def collect_redshift_subnet_groups(regions: List[str]) -> List[Dict[str, Any]]:
     all_subnet_groups = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_redshift_subnet_groups_in_region,
-        resource_type="Redshift subnet groups"
     )
 
     return all_subnet_groups

--- a/scripts/secrets_manager_export.py
+++ b/scripts/secrets_manager_export.py
@@ -181,7 +181,6 @@ def collect_secrets(regions: List[str]) -> List[Dict[str, Any]]:
     all_secrets = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_secrets_in_region,
-        resource_type="Secrets Manager secrets"
     )
 
     utils.log_success(f"Total secrets collected: {len(all_secrets)}")
@@ -279,7 +278,6 @@ def collect_secret_versions(regions: List[str]) -> List[Dict[str, Any]]:
     all_versions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_secret_versions_in_region,
-        resource_type="secret versions"
     )
 
     utils.log_success(f"Total secret versions collected: {len(all_versions)}")
@@ -364,7 +362,6 @@ def collect_secret_replications(regions: List[str]) -> List[Dict[str, Any]]:
     all_replications = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_secret_replications_in_region,
-        resource_type="secret replications"
     )
 
     utils.log_success(f"Total secret replications collected: {len(all_replications)}")

--- a/scripts/transit_gateway_export.py
+++ b/scripts/transit_gateway_export.py
@@ -156,7 +156,6 @@ def collect_transit_gateways(regions: List[str]) -> List[Dict[str, Any]]:
     all_tgws = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_transit_gateways_in_region,
-        resource_type="Transit Gateways"
     )
 
     utils.log_success(f"Total Transit Gateways collected: {len(all_tgws)}")
@@ -260,7 +259,6 @@ def collect_transit_gateway_attachments(regions: List[str]) -> List[Dict[str, An
     all_attachments = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_transit_gateway_attachments_in_region,
-        resource_type="Transit Gateway attachments"
     )
 
     utils.log_success(f"Total attachments collected: {len(all_attachments)}")
@@ -351,7 +349,6 @@ def collect_transit_gateway_route_tables(regions: List[str]) -> List[Dict[str, A
     all_route_tables = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_transit_gateway_route_tables_in_region,
-        resource_type="Transit Gateway route tables"
     )
 
     utils.log_success(f"Total route tables collected: {len(all_route_tables)}")
@@ -464,7 +461,6 @@ def collect_transit_gateway_routes(regions: List[str]) -> List[Dict[str, Any]]:
     all_routes = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_transit_gateway_routes_in_region,
-        resource_type="Transit Gateway routes"
     )
 
     utils.log_success(f"Total routes collected: {len(all_routes)}")

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -147,7 +147,6 @@ def collect_vpn_connections(regions: List[str]) -> List[Dict[str, Any]]:
     vpn_connections = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_vpn_connections_in_region,
-        resource_type="VPN connections"
     )
 
     utils.log_success(f"Total Site-to-Site VPN connections collected: {len(vpn_connections)}")
@@ -271,7 +270,6 @@ def collect_vpn_tunnels(regions: List[str]) -> List[Dict[str, Any]]:
     tunnels = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_vpn_tunnels_in_region,
-        resource_type="VPN tunnels"
     )
 
     utils.log_success(f"Total VPN tunnels collected: {len(tunnels)}")
@@ -353,7 +351,6 @@ def collect_customer_gateways(regions: List[str]) -> List[Dict[str, Any]]:
     gateways = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_customer_gateways_in_region,
-        resource_type="customer gateways"
     )
 
     utils.log_success(f"Total customer gateways collected: {len(gateways)}")
@@ -443,7 +440,6 @@ def collect_virtual_private_gateways(regions: List[str]) -> List[Dict[str, Any]]
     vgws = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_virtual_private_gateways_in_region,
-        resource_type="virtual private gateways"
     )
 
     utils.log_success(f"Total virtual private gateways collected: {len(vgws)}")
@@ -626,7 +622,6 @@ def collect_client_vpn_authorization_rules(regions: List[str]) -> List[Dict[str,
     rules = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_client_vpn_authorization_rules_in_region,
-        resource_type="Client VPN authorization rules"
     )
 
     utils.log_success(f"Total Client VPN authorization rules collected: {len(rules)}")


### PR DESCRIPTION
## Summary

Removes the `resource_type=` keyword argument from all 40 call sites across 12 export scripts.

This kwarg was dropped from `scan_regions_concurrent()` during the Sprint 4 `sslib` extraction (PR #62) but the call sites were never updated. Every affected script has been silently returning no data since that merge — the `TypeError` was caught internally and the script exited 0.

**Scripts fixed:** `acm_export`, `api_gateway_export`, `cognito_export`, `dynamodb_export`, `ecr_export`, `elasticache_export`, `kms_export`, `opensearch_export`, `redshift_export`, `secrets_manager_export`, `transit_gateway_export`, `vpn_export`

**Change:** kwarg removal only — no logic, no structure, no behavior changes beyond restoring correct function.

## Test plan

- [x] 301 tests passing, 0 new failures
- [ ] UAT: run affected scripts against real AWS account to confirm data is collected

Closes #101