### PR TITLE
fix(exporters): ECS NameError crash — rewrite main() to call get_ecs_resources()

### DIFF
--- a/scripts/ecs_export.py
+++ b/scripts/ecs_export.py
@@ -429,44 +429,34 @@ def main():
     try:
         # Print the script title and get account information
         account_id, account_name = utils.print_script_banner("AWS ECS (ELASTIC CONTAINER SERVICE) RESOURCE EXPORT")
-        
+
         # Check dependencies
         if not utils.ensure_dependencies('pandas', 'openpyxl'):
             sys.exit(1)
-        
+
         # Import pandas after checking dependencies
         import pandas as pd
 
-        # Detect partition for region examples
         regions = utils.prompt_region_selection()
-        region_suffix = 'all'
+
+        all_ecs_resources = get_ecs_resources(regions)
+
         # Create DataFrame
         df = pd.DataFrame(all_ecs_resources)
-        
-        # Generate filename with current date
-        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-        
-        # Specify region in filename if a specific region was chosen
-        region_suffix = "" if region_choice == 'all' else f"-{region_choice}"
-        
+
         # Create export filename using utils
-        filename = utils.create_export_filename(
-            account_name, 
-            "ecs-resources", 
-            region_suffix, 
-            current_date
-        )
-        
+        filename = utils.create_export_filename(account_name, "ecs-resources", "all")
+
         # Export to Excel
         output_path = utils.save_dataframe_to_excel(df, filename)
-        
+
         if output_path:
             print(f"\nExport completed successfully!")
             print(f"File saved as: {output_path}")
             print(f"Total ECS resources collected: {len(all_ecs_resources)}")
         else:
             print("\nError exporting data to Excel.")
-        
+
     except KeyboardInterrupt:
         print("\nOperation cancelled by user.")
         sys.exit(1)


### PR DESCRIPTION
## Summary

- Rewrites `ecs_export.py main()` to call `get_ecs_resources(regions)` — the collection function existed and was correct but was never wired up
- Removes references to undefined `all_ecs_resources` and `region_choice` variables that caused an immediate `NameError` on every run
- Uses `utils.create_export_filename()` with the standard 3-argument signature
- ZIP duplicate fix is on `feat/90-compute-resources-rebuild` (the `_detect_new_xlsx` fallback removal) — referenced in #103 but shipped separately since it lives on a different branch pending UAT

## Test plan

- [ ] 301 tests pass (`pytest -q`)
- [ ] `python scripts/ecs_export.py` runs without NameError
- [ ] Output file created with correct `{ACCOUNT}-ecs-resources-all-export-{date}.xlsx` filename

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)