### PR TITLE
feat(throttling): retry tuning, inter-page delays, and heartbeat (#109)

### DIFF
--- a/scripts/ebs_snapshots_export.py
+++ b/scripts/ebs_snapshots_export.py
@@ -19,6 +19,7 @@ Phase 4B Update:
 """
 
 import sys
+import time
 import datetime
 from pathlib import Path
 
@@ -178,6 +179,12 @@ def get_snapshots(region):
                 'Region': region,
                 'Tags': snapshot_tags
             })
+        # Inter-page delay to avoid throttling on large accounts
+        time.sleep(0.1)
+        # Heartbeat every 500 records so terminal stays alive
+        collected = len(snapshots_data)
+        if collected > 0 and collected % 500 == 0:
+            print(f"  [{collected:,} snapshots collected — still running...]")
 
     return snapshots_data
 
@@ -218,6 +225,7 @@ def main():
         region_results = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_snapshots,
+            max_workers=2,
             show_progress=True
         )
 

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -21,6 +21,7 @@ Phase 4B Update:
 
 import os
 import sys
+import time
 import datetime
 import argparse
 from pathlib import Path
@@ -113,6 +114,7 @@ def get_bucket_object_count(bucket_name, region):
     for page in paginator.paginate(Bucket=bucket_name):
         if 'Contents' in page:
             total_objects += len(page['Contents'])
+        time.sleep(0.1)
 
     return total_objects
 
@@ -257,6 +259,7 @@ def get_latest_storage_lens_data(account_id):
         region_results = utils.scan_regions_concurrent(
             regions=aws_regions,
             scan_function=collect_cloudwatch_metrics_for_region,
+            max_workers=2,
             show_progress=False  # Don't show progress for S3 metrics collection
         )
 

--- a/scripts/security_groups_export.py
+++ b/scripts/security_groups_export.py
@@ -20,6 +20,7 @@ Phase 4B Update:
 """
 
 import sys
+import time
 import datetime
 from pathlib import Path
 
@@ -282,12 +283,14 @@ def get_security_group_rules(region):
     security_groups_all = []
     for page in sg_paginator.paginate():
         security_groups_all.extend(page.get('SecurityGroups', []))
+        time.sleep(0.1)
 
     # Get all security group rules using paginator
     rules_paginator = ec2_client.get_paginator('describe_security_group_rules')
     all_rules = []
     for page in rules_paginator.paginate():
         all_rules.extend(page.get('SecurityGroupRules', []))
+        time.sleep(0.1)
 
     # Create a map of security group rules for faster lookup
     rules_map = {}
@@ -660,6 +663,7 @@ def main():
         region_results = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_security_groups,
+            max_workers=2,
             show_progress=True
         )
 

--- a/sslib/aws_client.py
+++ b/sslib/aws_client.py
@@ -206,7 +206,7 @@ def get_boto3_client(service: str, region_name: Optional[str] = None, **kwargs) 
     """
     sdk_config = config_value("aws_sdk_config", default={})
 
-    retry_config = sdk_config.get("retries", {"max_attempts": 5, "mode": "adaptive"})
+    retry_config = sdk_config.get("retries", {"max_attempts": 10, "mode": "adaptive"})
     connect_timeout = sdk_config.get("connect_timeout", 10)
     read_timeout = sdk_config.get("read_timeout", 60)
 


### PR DESCRIPTION
## Summary

Tier 1 of Issue #109 — reduces throttle errors on large-account scans and provides terminal heartbeat for long-running paginators.

- **`sslib/aws_client.py`**: Default `max_attempts` bumped from 5 → 10 (adaptive mode unchanged). Allows overrides via `config.json` `aws_sdk_config.retries`.
- **`scripts/ebs_snapshots_export.py`**: 100 ms inter-page sleep in `get_snapshots()` paginator loop; heartbeat print every 500 records collected; `max_workers=2` on concurrent region scan.
- **`scripts/security_groups_export.py`**: 100 ms inter-page sleep on both `describe_security_groups` and `describe_security_group_rules` paginators; `max_workers=2`.
- **`scripts/s3_export.py`**: 100 ms inter-page sleep in `get_bucket_object_count()`; `max_workers=2` for CloudWatch concurrent region scan.

Tier 2 (streaming Excel writes) tracked separately.

## Test plan

- [x] `pytest -m "not slow and not integration and not aws"` — 301 passed, 0 failures
- [ ] Spot-check `ebs_snapshots_export.py` against a real account with >500 snapshots — confirm heartbeat lines appear and no throttle errors
- [ ] Verify `max_attempts=10` is active by inspecting boto3 client config in a debug run

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)