### PR TITLE
feat(ux): per-instance progress heartbeat — ec2_export and rds_export (#120)

### DIFF
--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -23,6 +23,7 @@ Features:
 """
 
 import sys
+import time
 import datetime
 import csv
 import json
@@ -471,6 +472,7 @@ def get_instance_data(region, instance_filter=None):
         all_reservations = []
         for page in pages:
             all_reservations.extend(page['Reservations'])
+            time.sleep(0.1)
 
         # Count total instances first for progress tracking
         total_instances = 0
@@ -540,6 +542,8 @@ def get_instance_data(region, instance_filter=None):
                 progress = (processed / total_instances) * 100 if total_instances > 0 else 0
 
                 utils.log_info(f"[{progress:.1f}%] Processing instance {processed}/{total_instances}: {instance_id}")
+                if processed % 25 == 0:
+                    print(f"  [{region}] {processed}/{total_instances} EC2 instances processed...", flush=True)
                 # Get the root volume information
                 root_device = next((device for device in instance.get('BlockDeviceMappings', [])
                                   if device['DeviceName'] == instance.get('RootDeviceName')), None)

--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -23,6 +23,7 @@ Phase 4B Update:
 """
 
 import sys
+import time
 import datetime
 import csv
 import json
@@ -358,6 +359,7 @@ def get_rds_instances(region):
     all_instances = []
     for page in paginator.paginate():
         all_instances.extend(page['DBInstances'])
+        time.sleep(0.1)
 
     total_instances = len(all_instances)
     if total_instances > 0:
@@ -371,6 +373,8 @@ def get_rds_instances(region):
         progress = (processed / total_instances) * 100 if total_instances > 0 else 0
 
         utils.log_info(f"[{progress:.1f}%] Processing RDS instance {processed}/{total_instances}: {instance_id}")
+        if processed % 10 == 0:
+            print(f"  [{region}] {processed}/{total_instances} RDS instances processed...", flush=True)
         # Extract security group IDs from VPC security groups
         sg_ids = [sg['VpcSecurityGroupId'] for sg in instance.get('VpcSecurityGroups', [])]
         sg_info = get_security_group_info(rds_client, sg_ids)


### PR DESCRIPTION
## Summary

Adds a terminal heartbeat inside the per-instance processing loops for the two exporters that make the most per-instance API calls and are most likely to appear hung.

- **`ec2_export.py`**: prints every 25 instances — `[us-east-1] 25/147 EC2 instances processed...`
- **`rds_export.py`**: prints every 10 instances — `[us-east-1] 10/43 RDS instances processed...`
- Both scripts: 100ms inter-page delay on the describe paginator (throttle consistency with #109)

Region name is included so interleaved output from concurrent threads is readable.
Existing `utils.log_info()` per-instance lines are unchanged — they go to the log file only.

## Test plan

- [x] 301 tests passed
- [ ] Run `ec2_export.py` on a real account with 25+ instances — confirm heartbeat lines appear
- [ ] Run `rds_export.py` on a real account with 10+ instances — confirm heartbeat lines appear

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)