### PR TITLE
fix(api-correctness): resolve all 7 MODERATE audit findings (#142)

### DIFF
--- a/scripts/bedrock_export.py
+++ b/scripts/bedrock_export.py
@@ -500,6 +500,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("bedrock", partition):
+        utils.log_warning("Amazon Bedrock is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS AMAZON BEDROCK EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/scripts/cloudformation_export.py
+++ b/scripts/cloudformation_export.py
@@ -212,8 +212,8 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
             utils.log_info(f"  Found {len(stacks)} stack(s)")
             all_stacks.extend(stacks)
 
-            # Collect resources for each stack (sample first 10 to avoid too much data)
-            for stack in stacks[:10]:
+            # Collect resources for each stack
+            for stack in stacks:
                 stack_name = stack['StackName']
                 resources = collect_stack_resources(region, stack_name)
                 all_resources.extend(resources)

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -386,6 +386,69 @@ def collect_insight_selectors(regions: List[str]) -> List[Dict[str, Any]]:
     return all_insights
 
 
+@utils.aws_error_handler("Collecting CloudTrail Lake event data stores from region", default_return=[])
+def collect_event_data_stores_from_region(region: str) -> List[Dict[str, Any]]:
+    """
+    Collect CloudTrail Lake event data store information from a single region.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        list: List of dictionaries with event data store information
+    """
+    if not utils.is_aws_region(region):
+        return []
+
+    stores_data = []
+
+    ct_client = utils.get_boto3_client('cloudtrail', region_name=region)
+
+    paginator = ct_client.get_paginator('list_event_data_stores')
+    for page in paginator.paginate():
+        for store in page.get('EventDataStores', []):
+            stores_data.append({
+                'Region': region,
+                'Name': store.get('Name', ''),
+                'ARN': store.get('EventDataStoreArn', ''),
+                'Status': store.get('Status', ''),
+                'Multi-Region': store.get('MultiRegionEnabled', False),
+                'Organization': store.get('OrganizationEnabled', False),
+                'Retention (Days)': store.get('RetentionPeriod', ''),
+                'Termination Protected': store.get('TerminationProtectionEnabled', False),
+                'Created': str(store.get('CreatedTimestamp', '')),
+                'Updated': str(store.get('UpdatedTimestamp', '')),
+            })
+
+    utils.log_info(f"Found {len(stores_data)} event data store(s) in {region}")
+    return stores_data
+
+
+def collect_event_data_stores(regions: List[str]) -> List[Dict[str, Any]]:
+    """
+    Collect CloudTrail Lake event data store information using concurrent scanning.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        list: List of dictionaries with event data store information
+    """
+    print("\n=== COLLECTING CLOUDTRAIL LAKE EVENT DATA STORES ===")
+    utils.log_info(f"Scanning {len(regions)} regions for event data stores...")
+
+    region_results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=collect_event_data_stores_from_region,
+        show_progress=True
+    )
+
+    all_stores = [store for stores_in_region in region_results for store in stores_in_region]
+
+    utils.log_success(f"Total event data stores collected: {len(all_stores)}")
+    return all_stores
+
+
 def export_cloudtrail_data(account_id: str, account_name: str):
     """
     Export CloudTrail information to an Excel file.
@@ -417,6 +480,11 @@ def export_cloudtrail_data(account_id: str, account_name: str):
     insights = collect_insight_selectors(regions)
     if insights:
         data_frames['Insight Selectors'] = pd.DataFrame(insights)
+
+    # STEP 4: Collect CloudTrail Lake event data stores
+    event_data_stores = collect_event_data_stores(regions)
+    if event_data_stores:
+        data_frames['Event Data Stores'] = pd.DataFrame(event_data_stores)
 
     # Check if we have any data
     if not data_frames:

--- a/scripts/cloudwatch_export.py
+++ b/scripts/cloudwatch_export.py
@@ -213,6 +213,106 @@ def collect_log_groups(regions: List[str]) -> List[Dict[str, Any]]:
     return all_log_groups
 
 
+def _scan_dashboards_region(region: str) -> List[Dict[str, Any]]:
+    """Scan a single region for CloudWatch dashboards."""
+    dashboards_data = []
+
+    if not utils.is_aws_region(region):
+        return dashboards_data
+
+    try:
+        cw_client = utils.get_boto3_client('cloudwatch', region_name=region)
+        paginator = cw_client.get_paginator('list_dashboards')
+
+        for page in paginator.paginate():
+            for dashboard in page.get('DashboardEntries', []):
+                dashboards_data.append({
+                    'Region': region,
+                    'Dashboard Name': dashboard.get('DashboardName', ''),
+                    'ARN': dashboard.get('DashboardArn', ''),
+                    'Last Modified': str(dashboard.get('LastModified', '')),
+                    'Size (bytes)': dashboard.get('Size', ''),
+                })
+    except Exception as e:
+        utils.log_error(f"Error scanning CloudWatch dashboards in {region}", e)
+
+    return dashboards_data
+
+
+@utils.aws_error_handler("Collecting CloudWatch dashboards", default_return=[])
+def collect_dashboards(regions: List[str]) -> List[Dict[str, Any]]:
+    """
+    Collect CloudWatch dashboard information from AWS regions.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        list: List of dictionaries with dashboard information
+    """
+    print("\n=== COLLECTING CLOUDWATCH DASHBOARDS ===")
+
+    results = utils.scan_regions_concurrent(regions, _scan_dashboards_region)
+    all_dashboards = [d for result in results for d in result]
+
+    utils.log_success(f"Total CloudWatch dashboards collected: {len(all_dashboards)}")
+    return all_dashboards
+
+
+def _scan_metric_filters_region(region: str) -> List[Dict[str, Any]]:
+    """Scan a single region for CloudWatch Logs metric filters."""
+    filters_data = []
+
+    if not utils.is_aws_region(region):
+        return filters_data
+
+    try:
+        logs_client = utils.get_boto3_client('logs', region_name=region)
+        paginator = logs_client.get_paginator('describe_metric_filters')
+
+        for page in paginator.paginate():
+            for f in page.get('metricFilters', []):
+                transformations = f.get('metricTransformations', [{}])
+                metric_name = transformations[0].get('metricName', '') if transformations else ''
+                metric_namespace = transformations[0].get('metricNamespace', '') if transformations else ''
+                metric_value = transformations[0].get('metricValue', '') if transformations else ''
+
+                filters_data.append({
+                    'Region': region,
+                    'Filter Name': f.get('filterName', ''),
+                    'Log Group': f.get('logGroupName', ''),
+                    'Filter Pattern': f.get('filterPattern', ''),
+                    'Metric Name': metric_name,
+                    'Metric Namespace': metric_namespace,
+                    'Metric Value': metric_value,
+                    'Creation Time': str(f.get('creationTime', '')),
+                })
+    except Exception as e:
+        utils.log_error(f"Error scanning metric filters in {region}", e)
+
+    return filters_data
+
+
+@utils.aws_error_handler("Collecting CloudWatch metric filters", default_return=[])
+def collect_metric_filters(regions: List[str]) -> List[Dict[str, Any]]:
+    """
+    Collect CloudWatch Logs metric filter information from AWS regions.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        list: List of dictionaries with metric filter information
+    """
+    print("\n=== COLLECTING CLOUDWATCH METRIC FILTERS ===")
+
+    results = utils.scan_regions_concurrent(regions, _scan_metric_filters_region)
+    all_filters = [f for result in results for f in result]
+
+    utils.log_success(f"Total metric filters collected: {len(all_filters)}")
+    return all_filters
+
+
 def export_cloudwatch_data(account_id: str, account_name: str):
     """
     Export CloudWatch information to an Excel file.
@@ -240,8 +340,18 @@ def export_cloudwatch_data(account_id: str, account_name: str):
     if log_groups:
         data_frames['Log Groups'] = pd.DataFrame(log_groups)
 
-    # STEP 3: Create summary
-    if alarms or log_groups:
+    # STEP 3: Collect dashboards
+    dashboards = collect_dashboards(regions)
+    if dashboards:
+        data_frames['Dashboards'] = pd.DataFrame(dashboards)
+
+    # STEP 4: Collect metric filters
+    metric_filters = collect_metric_filters(regions)
+    if metric_filters:
+        data_frames['Metric Filters'] = pd.DataFrame(metric_filters)
+
+    # STEP 5: Create summary
+    if alarms or log_groups or dashboards or metric_filters:
         summary_data = []
 
         total_alarms = len(alarms)
@@ -267,6 +377,8 @@ def export_cloudwatch_data(account_id: str, account_name: str):
             summary_data.append({'Metric': f'Alarms in {state} State', 'Value': count})
         summary_data.append({'Metric': 'Total Log Groups', 'Value': total_log_groups})
         summary_data.append({'Metric': 'Total Log Storage (MB)', 'Value': round(total_log_storage_mb, 2)})
+        summary_data.append({'Metric': 'Total Dashboards', 'Value': len(dashboards)})
+        summary_data.append({'Metric': 'Total Metric Filters', 'Value': len(metric_filters)})
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 

--- a/scripts/ecs_export.py
+++ b/scripts/ecs_export.py
@@ -422,6 +422,108 @@ def get_ecs_resources(regions: List[str]) -> List[Dict[str, Any]]:
     utils.log_success(f"Total ECS resources collected: {len(all_resources)}")
     return all_resources
 
+def get_standalone_tasks_from_region(region: str) -> List[Dict[str, Any]]:
+    """
+    Collect ECS tasks not managed by a service (one-off / scheduled tasks) from a single region.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        list: List of dictionaries with standalone task information
+    """
+    standalone_tasks = []
+
+    if not utils.is_aws_region(region):
+        return standalone_tasks
+
+    try:
+        ecs_client = utils.get_boto3_client('ecs', region_name=region)
+
+        # List all clusters
+        cluster_arns = []
+        paginator = ecs_client.get_paginator('list_clusters')
+        for page in paginator.paginate():
+            cluster_arns.extend(page.get('clusterArns', []))
+
+        for cluster_arn in cluster_arns:
+            cluster_name = cluster_arn.split('/')[-1]
+
+            # Get all task ARNs in this cluster (all statuses)
+            all_task_arns = []
+            for status in ('RUNNING', 'STOPPED'):
+                try:
+                    task_paginator = ecs_client.get_paginator('list_tasks')
+                    for page in task_paginator.paginate(cluster=cluster_arn, desiredStatus=status):
+                        all_task_arns.extend(page.get('taskArns', []))
+                except Exception:
+                    pass
+
+            # Describe in batches of 100
+            for i in range(0, len(all_task_arns), 100):
+                batch = all_task_arns[i:i + 100]
+                try:
+                    response = ecs_client.describe_tasks(cluster=cluster_arn, tasks=batch)
+                    for task in response.get('tasks', []):
+                        group = task.get('group', '')
+                        # Service-managed tasks have group = "service:<name>"
+                        if group.startswith('service:'):
+                            continue
+
+                        standalone_tasks.append({
+                            'Region': region,
+                            'Cluster Name': cluster_name,
+                            'Task ARN': task.get('taskArn', ''),
+                            'Task Definition': task.get('taskDefinitionArn', '').split('/')[-1],
+                            'Group': group,
+                            'Status': task.get('lastStatus', ''),
+                            'Desired Status': task.get('desiredStatus', ''),
+                            'Launch Type': task.get('launchType', ''),
+                            'Started By': task.get('startedBy', ''),
+                            'Created At': str(task.get('createdAt', '')),
+                            'Started At': str(task.get('startedAt', '')),
+                            'Stopped At': str(task.get('stoppedAt', '')),
+                            'Stop Code': task.get('stopCode', ''),
+                            'Stopped Reason': task.get('stoppedReason', ''),
+                            'CPU': task.get('cpu', ''),
+                            'Memory': task.get('memory', ''),
+                        })
+                except Exception as e:
+                    utils.log_error(f"Error describing tasks in {cluster_name}/{region}", e)
+
+    except EndpointConnectionError:
+        pass
+    except Exception as e:
+        utils.log_error(f"Error collecting standalone ECS tasks in {region}", e)
+
+    return standalone_tasks
+
+
+def get_standalone_tasks(regions: List[str]) -> List[Dict[str, Any]]:
+    """
+    Collect standalone ECS tasks from multiple regions concurrently.
+
+    Args:
+        regions: List of AWS region names to scan
+
+    Returns:
+        list: Combined list of standalone tasks from all regions
+    """
+    print("\n=== COLLECTING ECS STANDALONE TASKS ===")
+    utils.log_info(f"Scanning {len(regions)} regions for standalone tasks...")
+
+    region_results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=get_standalone_tasks_from_region,
+        show_progress=True
+    )
+
+    all_tasks = [task for tasks_in_region in region_results for task in tasks_in_region]
+
+    utils.log_success(f"Total standalone ECS tasks collected: {len(all_tasks)}")
+    return all_tasks
+
+
 def main():
     """
     Main function to coordinate the ECS export process.
@@ -441,20 +543,28 @@ def main():
         regions = utils.prompt_region_selection()
 
         all_ecs_resources = get_ecs_resources(regions)
+        standalone_tasks = get_standalone_tasks(regions)
 
-        # Create DataFrame
-        df = pd.DataFrame(all_ecs_resources)
+        # Build multi-sheet export
+        data_frames = {}
+        if all_ecs_resources:
+            data_frames['Service Tasks'] = pd.DataFrame(all_ecs_resources)
+        if standalone_tasks:
+            data_frames['Standalone Tasks'] = pd.DataFrame(standalone_tasks)
 
         # Create export filename using utils
         filename = utils.create_export_filename(account_name, "ecs-resources", "all")
 
-        # Export to Excel
-        output_path = utils.save_dataframe_to_excel(df, filename)
+        if data_frames:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, filename)
+        else:
+            output_path = utils.save_dataframe_to_excel(pd.DataFrame(), filename)
 
         if output_path:
             print(f"\nExport completed successfully!")
             print(f"File saved as: {output_path}")
-            print(f"Total ECS resources collected: {len(all_ecs_resources)}")
+            print(f"Total service-linked ECS resources: {len(all_ecs_resources)}")
+            print(f"Total standalone ECS tasks: {len(standalone_tasks)}")
         else:
             print("\nError exporting data to Excel.")
 

--- a/scripts/guardduty_export.py
+++ b/scripts/guardduty_export.py
@@ -108,6 +108,13 @@ def collect_detectors_from_region(region: str) -> List[Dict[str, Any]]:
             if updated_at:
                 updated_at = updated_at if isinstance(updated_at, str) else updated_at.strftime('%Y-%m-%d %H:%M:%S')
 
+            # Protection features (newer GuardDuty categories: EKS Runtime, RDS, Lambda, Malware)
+            features = detector.get('Features', [])
+            features_str = ', '.join(
+                f"{f.get('Name', '')}: {f.get('Status', '')}"
+                for f in features
+            ) if features else 'N/A'
+
             # Tags
             tags = detector.get('Tags', {})
             tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
@@ -122,6 +129,7 @@ def collect_detectors_from_region(region: str) -> List[Dict[str, Any]]:
                 'VPC Flow Logs': flow_logs,
                 'S3 Logs': s3_logs,
                 'Kubernetes Audit Logs': k8s_audit_logs,
+                'Protection Features': features_str,
                 'Service Role': service_role,
                 'Created At': created_at,
                 'Updated At': updated_at,

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -163,36 +163,36 @@ def get_user_account_assignments(sso_admin_client, instance_arn, user_id):
     except Exception:
         pass
 
-    paginator = sso_admin_client.get_paginator('list_account_assignments')
+    # Use list_account_assignments_for_principal to fetch all assignments for this
+    # user in a single paginated call (O(assignments) instead of O(permission_sets * pages)).
     assignments = []
+    ps_name_cache = {}
 
-    ps_paginator = sso_admin_client.get_paginator('list_permission_sets')
-    permission_sets = []
-    for page in ps_paginator.paginate(InstanceArn=instance_arn):
-        permission_sets.extend(page.get('PermissionSets', []))
+    try:
+        paginator = sso_admin_client.get_paginator('list_account_assignments_for_principal')
+        for page in paginator.paginate(
+            InstanceArn=instance_arn,
+            PrincipalId=user_id,
+            PrincipalType='USER'
+        ):
+            for assignment in page.get('AccountAssignments', []):
+                account_id = assignment.get('AccountId', '')
+                permission_set_arn = assignment.get('PermissionSetArn', '')
+                account_name = accounts.get(account_id, account_id)
 
-    for permission_set_arn in permission_sets:
-        try:
-            for page in paginator.paginate(
-                InstanceArn=instance_arn,
-                PermissionSetArn=permission_set_arn
-            ):
-                for assignment in page.get('AccountAssignments', []):
-                    if (assignment.get('PrincipalType') == 'USER' and
-                            assignment.get('PrincipalId') == user_id):
-                        account_id = assignment.get('TargetId')
-                        account_name = accounts.get(account_id, account_id)
-                        try:
-                            ps_response = sso_admin_client.describe_permission_set(
-                                InstanceArn=instance_arn,
-                                PermissionSetArn=permission_set_arn
-                            )
-                            ps_name = ps_response['PermissionSet'].get('Name', 'Unknown')
-                        except Exception:
-                            ps_name = permission_set_arn.split('/')[-1]
-                        assignments.append(f"{account_name}:{ps_name}")
-        except Exception:
-            continue
+                if permission_set_arn not in ps_name_cache:
+                    try:
+                        ps_response = sso_admin_client.describe_permission_set(
+                            InstanceArn=instance_arn,
+                            PermissionSetArn=permission_set_arn
+                        )
+                        ps_name_cache[permission_set_arn] = ps_response['PermissionSet'].get('Name', 'Unknown')
+                    except Exception:
+                        ps_name_cache[permission_set_arn] = permission_set_arn.split('/')[-1]
+
+                assignments.append(f"{account_name}:{ps_name_cache[permission_set_arn]}")
+    except Exception:
+        pass
 
     return ', '.join(assignments) if assignments else 'None'
 


### PR DESCRIPTION
## Summary

Resolves all 7 MODERATE findings from the API correctness audit (issue #142).

- **bedrock_export.py** — Added GovCloud partition guard; Bedrock is not available in `aws-us-gov`
- **cloudformation_export.py** — Removed `[:10]` slice that silently capped stack resource collection to the first 10 stacks
- **cloudtrail_export.py** — Added CloudTrail Lake event data stores via `list_event_data_stores` paginator (new "Event Data Stores" sheet); the script header already advertised this feature but it was unimplemented
- **cloudwatch_export.py** — Added dashboards (`list_dashboards`) and metric filters (`describe_metric_filters`) as two new sheets; summary row counts updated
- **ecs_export.py** — Added standalone task collection (tasks not managed by a service, identified by `group` not starting with `service:`); export changed from single-sheet to multi-sheet ("Service Tasks" + "Standalone Tasks")
- **guardduty_export.py** — Added `Protection Features` column capturing the `Features` list from `get_detector()` (covers newer protection categories: EKS Runtime, RDS Login Events, Lambda, Malware Protection that are not in the deprecated `DataSources` field)
- **iam_identity_center_export.py** — Replaced O(N²) nested loop in `get_user_account_assignments()` (iterating all permission sets × accounts to find one user's assignments) with `list_account_assignments_for_principal` which fetches all assignments for a specific user in a single paginated call; added permission set name cache to avoid redundant `describe_permission_set` calls

> Note: `globalaccelerator_export.py` and `health_export.py` were flagged by the audit agent but already had correct implementations — no changes made to those.

## Test plan

- [ ] Syntax-verified all 7 files with `ast.parse` (all pass)
- [ ] Run `python scripts/bedrock_export.py` in GovCloud — confirm exits 0 with warning
- [ ] Run `python scripts/cloudformation_export.py` in an account with >10 stacks — confirm all stacks collected
- [ ] Run `python scripts/cloudtrail_export.py` in an account with CloudTrail Lake — confirm "Event Data Stores" sheet present
- [ ] Run `python scripts/cloudwatch_export.py` — confirm "Dashboards" and "Metric Filters" sheets present
- [ ] Run `python scripts/ecs_export.py` — confirm two sheets exported ("Service Tasks", "Standalone Tasks")
- [ ] Run `python scripts/guardduty_export.py` — confirm "Protection Features" column populated
- [ ] Run `python scripts/iam_identity_center_export.py` — confirm user account assignments export; validate no O(N²) behavior in large accounts

Closes no new issues. Part of #142, milestone v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)