### PR TITLE
fix(api-correctness): resolve MINOR pagination gaps — 7 scripts (#142)

### DIFF
--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -242,9 +242,11 @@ def scan_api_stages_in_region(region: str) -> List[Dict[str, Any]]:
     try:
         apigw_client = utils.get_boto3_client('apigateway', region_name=region)
 
-        # Get REST APIs first
-        apis_response = apigw_client.get_rest_apis()
-        apis = apis_response.get('items', [])
+        # Get REST APIs (paginated)
+        apis = []
+        paginator = apigw_client.get_paginator('get_rest_apis')
+        for page in paginator.paginate():
+            apis.extend(page.get('items', []))
 
         for api in apis:
             api_id = api.get('id', '')

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -85,9 +85,12 @@ def _scan_event_rules_region(region: str) -> List[Dict[str, Any]]:
 
     try:
         events_client = utils.get_boto3_client('events', region_name=region)
-        buses_response = events_client.list_event_buses()
+        buses = []
+        buses_paginator = events_client.get_paginator('list_event_buses')
+        for page in buses_paginator.paginate():
+            buses.extend(page.get('EventBuses', []))
 
-        for bus in buses_response.get('EventBuses', []):
+        for bus in buses:
             bus_name = bus.get('Name', 'default')
             try:
                 paginator = events_client.get_paginator('list_rules')
@@ -136,52 +139,56 @@ def _scan_rule_targets_region(region: str) -> List[Dict[str, Any]]:
 
     try:
         events_client = utils.get_boto3_client('events', region_name=region)
-        buses_response = events_client.list_event_buses()
+        buses = []
+        buses_paginator = events_client.get_paginator('list_event_buses')
+        for page in buses_paginator.paginate():
+            buses.extend(page.get('EventBuses', []))
 
-        for bus in buses_response.get('EventBuses', []):
+        for bus in buses:
             bus_name = bus.get('Name', 'default')
             try:
-                rules_response = events_client.list_rules(EventBusName=bus_name)
-                for rule in rules_response.get('Rules', []):
-                    rule_name = rule.get('Name', '')
-                    try:
-                        targets_response = events_client.list_targets_by_rule(Rule=rule_name, EventBusName=bus_name)
-                        for target in targets_response.get('Targets', []):
-                            target_arn = target.get('Arn', 'N/A')
+                rules_paginator = events_client.get_paginator('list_rules')
+                for rules_page in rules_paginator.paginate(EventBusName=bus_name):
+                    for rule in rules_page.get('Rules', []):
+                        rule_name = rule.get('Name', '')
+                        try:
+                            targets_response = events_client.list_targets_by_rule(Rule=rule_name, EventBusName=bus_name)
+                            for target in targets_response.get('Targets', []):
+                                target_arn = target.get('Arn', 'N/A')
 
-                            # Determine target type from ARN
-                            target_type = 'Unknown'
-                            if ':lambda:' in target_arn:
-                                target_type = 'Lambda'
-                            elif ':sqs:' in target_arn:
-                                target_type = 'SQS'
-                            elif ':sns:' in target_arn:
-                                target_type = 'SNS'
-                            elif ':kinesis:' in target_arn:
-                                target_type = 'Kinesis'
-                            elif ':states:' in target_arn:
-                                target_type = 'Step Functions'
-                            elif ':events:' in target_arn:
-                                target_type = 'Event Bus'
-                            elif ':logs:' in target_arn:
-                                target_type = 'CloudWatch Logs'
+                                # Determine target type from ARN
+                                target_type = 'Unknown'
+                                if ':lambda:' in target_arn:
+                                    target_type = 'Lambda'
+                                elif ':sqs:' in target_arn:
+                                    target_type = 'SQS'
+                                elif ':sns:' in target_arn:
+                                    target_type = 'SNS'
+                                elif ':kinesis:' in target_arn:
+                                    target_type = 'Kinesis'
+                                elif ':states:' in target_arn:
+                                    target_type = 'Step Functions'
+                                elif ':events:' in target_arn:
+                                    target_type = 'Event Bus'
+                                elif ':logs:' in target_arn:
+                                    target_type = 'CloudWatch Logs'
 
-                            retry_policy = target.get('RetryPolicy', {})
-                            targets_data.append({
-                                'Region': region,
-                                'Event Bus': bus_name,
-                                'Rule Name': rule_name,
-                                'Target ID': target.get('Id', 'N/A'),
-                                'Target Type': target_type,
-                                'Target ARN': target_arn,
-                                'Role ARN': target.get('RoleArn', 'N/A'),
-                                'Has Input Transformer': 'Yes' if target.get('InputTransformer') else 'No',
-                                'Has Dead Letter Queue': 'Yes' if target.get('DeadLetterConfig') else 'No',
-                                'Max Retry Attempts': retry_policy.get('MaximumRetryAttempts', 'Default'),
-                                'Max Event Age (seconds)': retry_policy.get('MaximumEventAgeInSeconds', 'Default')
-                            })
-                    except Exception as e:
-                        utils.log_warning(f"Could not get targets for rule {rule_name}: {e}")
+                                retry_policy = target.get('RetryPolicy', {})
+                                targets_data.append({
+                                    'Region': region,
+                                    'Event Bus': bus_name,
+                                    'Rule Name': rule_name,
+                                    'Target ID': target.get('Id', 'N/A'),
+                                    'Target Type': target_type,
+                                    'Target ARN': target_arn,
+                                    'Role ARN': target.get('RoleArn', 'N/A'),
+                                    'Has Input Transformer': 'Yes' if target.get('InputTransformer') else 'No',
+                                    'Has Dead Letter Queue': 'Yes' if target.get('DeadLetterConfig') else 'No',
+                                    'Max Retry Attempts': retry_policy.get('MaximumRetryAttempts', 'Default'),
+                                    'Max Event Age (seconds)': retry_policy.get('MaximumEventAgeInSeconds', 'Default')
+                                })
+                        except Exception as e:
+                            utils.log_warning(f"Could not get targets for rule {rule_name}: {e}")
             except Exception as e:
                 utils.log_warning(f"Could not process bus {bus_name}: {e}")
     except Exception as e:

--- a/scripts/glue_athena_export.py
+++ b/scripts/glue_athena_export.py
@@ -97,8 +97,10 @@ def _scan_glue_tables_region(region: str) -> List[Dict[str, Any]]:
     try:
         glue_client = utils.get_boto3_client('glue', region_name=region)
         try:
-            databases_response = glue_client.get_databases()
-            databases = databases_response.get('DatabaseList', [])
+            databases = []
+            db_paginator = glue_client.get_paginator('get_databases')
+            for page in db_paginator.paginate():
+                databases.extend(page.get('DatabaseList', []))
         except Exception as e:
             utils.log_warning(f"Could not list databases in {region}: {str(e)}")
             return regional_tables
@@ -423,7 +425,8 @@ def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
         'Summary': summary_df
     }
 
-    if utils.save_multiple_dataframes_to_excel(dataframes, filename):
+    utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -69,9 +69,11 @@ def collect_image_pipelines(regions: List[str]) -> List[Dict[str, Any]]:
         try:
             imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
 
-            # Get image pipelines
-            response = imagebuilder.list_image_pipelines()
-            pipeline_arns = [p['arn'] for p in response.get('imagePipelineList', [])]
+            # Get image pipelines (paginated)
+            pipeline_arns = []
+            paginator = imagebuilder.get_paginator('list_image_pipelines')
+            for page in paginator.paginate():
+                pipeline_arns.extend([p['arn'] for p in page.get('imagePipelineList', [])])
 
             print(f"  Found {len(pipeline_arns)} pipelines")
 

--- a/scripts/sqs_sns_export.py
+++ b/scripts/sqs_sns_export.py
@@ -51,8 +51,10 @@ def _scan_sqs_queues_region(region: str) -> List[Dict[str, Any]]:
 
     try:
         sqs_client = utils.get_boto3_client('sqs', region_name=region)
-        queues_response = sqs_client.list_queues()
-        queue_urls = queues_response.get('QueueUrls', [])
+        queue_urls = []
+        paginator = sqs_client.get_paginator('list_queues')
+        for page in paginator.paginate():
+            queue_urls.extend(page.get('QueueUrls', []))
 
         for queue_url in queue_urls:
             queue_name = queue_url.split('/')[-1]

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -475,9 +475,11 @@ def collect_client_vpn_endpoints(regions: List[str]) -> List[Dict[str, Any]]:
         try:
             ec2 = utils.get_boto3_client('ec2', region_name=region)
 
-            # Describe Client VPN endpoints
-            response = ec2.describe_client_vpn_endpoints()
-            endpoint_list = response.get('ClientVpnEndpoints', [])
+            # Describe Client VPN endpoints (paginated)
+            endpoint_list = []
+            paginator = ec2.get_paginator('describe_client_vpn_endpoints')
+            for page in paginator.paginate():
+                endpoint_list.extend(page.get('ClientVpnEndpoints', []))
 
             for endpoint in endpoint_list:
                 endpoint_id = endpoint.get('ClientVpnEndpointId', '')
@@ -572,9 +574,11 @@ def scan_client_vpn_authorization_rules_in_region(region: str) -> List[Dict[str,
     try:
         ec2 = utils.get_boto3_client('ec2', region_name=region)
 
-        # First get all Client VPN endpoints
-        endpoints_response = ec2.describe_client_vpn_endpoints()
-        endpoint_list = endpoints_response.get('ClientVpnEndpoints', [])
+        # First get all Client VPN endpoints (paginated)
+        endpoint_list = []
+        endpoints_paginator = ec2.get_paginator('describe_client_vpn_endpoints')
+        for page in endpoints_paginator.paginate():
+            endpoint_list.extend(page.get('ClientVpnEndpoints', []))
 
         for endpoint in endpoint_list:
             endpoint_id = endpoint.get('ClientVpnEndpointId', '')

--- a/scripts/xray_export.py
+++ b/scripts/xray_export.py
@@ -39,9 +39,16 @@ def _scan_sampling_rules_region(region: str) -> List[Dict[str, Any]]:
     xray_client = utils.get_boto3_client('xray', region_name=region)
 
     try:
-        # Get sampling rules
-        response = xray_client.get_sampling_rules()
-        sampling_rules = response.get('SamplingRuleRecords', [])
+        # Get sampling rules (manual NextToken loop — no boto3 paginator for get_sampling_rules)
+        sampling_rules = []
+        kwargs = {}
+        while True:
+            response = xray_client.get_sampling_rules(**kwargs)
+            sampling_rules.extend(response.get('SamplingRuleRecords', []))
+            next_token = response.get('NextToken')
+            if not next_token:
+                break
+            kwargs = {'NextToken': next_token}
 
         for rule_record in sampling_rules:
             rule = rule_record.get('SamplingRule', {})


### PR DESCRIPTION
## Summary

Resolves the MINOR pagination gap findings from the API correctness audit (issue #142).

- **api_gateway_export.py** — Paginate `get_rest_apis()` in `scan_api_stages_in_region()` (was fetching first page only)
- **eventbridge_export.py** — Paginate `list_event_buses()` in both the rules scanner and targets scanner; also paginate `list_rules()` in the targets scanner (bonus fix spotted while editing)
- **glue_athena_export.py** — Paginate `get_databases()` in `_scan_glue_tables_region()`; also fix a pre-existing bare `if`-block syntax error on the save call (same pattern as the MAJOR fixes in PR #143)
- **image_builder_export.py** — Paginate `list_image_pipelines()`
- **sqs_sns_export.py** — Paginate `list_queues()` — was silently capped at 1000 queues per region
- **xray_export.py** — Add manual `NextToken` loop for `get_sampling_rules()` — no boto3 paginator exists for this operation
- **vpn_export.py** — Paginate `describe_client_vpn_endpoints()` in both collection sites (endpoint inventory and authorization rules)

## Test plan

- [ ] Syntax verified all 7 files with `ast.parse` (all pass)
- [ ] Run each script against a real account and confirm no truncation warnings
- [ ] Verify SQS export collects >1000 queues in accounts with large queue counts
- [ ] Verify EventBridge export collects buses and rules from all custom event buses

Part of #142, milestone v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)