### PR TITLE
fix(api-correctness): MINOR missing GovCloud guards — 5 scripts (#142)

### DIFF
--- a/scripts/cognito_export.py
+++ b/scripts/cognito_export.py
@@ -751,6 +751,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("cognito-idp", partition):
+        utils.log_warning("Amazon Cognito is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS COGNITO EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/scripts/comprehend_export.py
+++ b/scripts/comprehend_export.py
@@ -501,6 +501,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("comprehend", partition):
+        utils.log_warning("Amazon Comprehend is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS AMAZON COMPREHEND EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/scripts/connect_export.py
+++ b/scripts/connect_export.py
@@ -220,6 +220,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("connect", partition):
+        utils.log_warning("Amazon Connect is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS CONNECT EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/scripts/marketplace_export.py
+++ b/scripts/marketplace_export.py
@@ -245,6 +245,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("marketplace", partition):
+        utils.log_warning("AWS Marketplace is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS MARKETPLACE SUBSCRIPTIONS EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/scripts/rekognition_export.py
+++ b/scripts/rekognition_export.py
@@ -386,6 +386,11 @@ def main():
     utils.setup_logging(script_name)
     utils.log_script_start(script_name)
 
+    partition = utils.detect_partition()
+    if not utils.is_service_available_in_partition("rekognition", partition):
+        utils.log_warning("Amazon Rekognition is not available in AWS GovCloud. Skipping.")
+        sys.exit(0)
+
     account_id, account_name = utils.print_script_banner("AWS AMAZON REKOGNITION EXPORT")
     if not account_id:
         utils.log_error("Unable to determine AWS account ID. Please check your credentials.")

--- a/sslib/aws_client.py
+++ b/sslib/aws_client.py
@@ -292,6 +292,12 @@ def is_service_available_in_partition(service: str, partition: str = "aws") -> b
         "sumerian",
         "gamelift",
         "robomaker",
+        "cognito-idp",
+        "cognito-identity",
+        "comprehend",
+        "connect",
+        "rekognition",
+        "bedrock",
     }
 
     govcloud_limited = {


### PR DESCRIPTION
Resolves MINOR missing GovCloud partition guard findings from issue #142. Expands govcloud_unavailable set in sslib/aws_client.py to include cognito-idp, cognito-identity, comprehend, connect, rekognition, bedrock. Adds sys.exit(0) partition guards to cognito_export.py, comprehend_export.py, connect_export.py, marketplace_export.py, rekognition_export.py. compute_optimizer and macie already had guards. reserved_instances_export.py is a false positive — it uses ec2/rds/elasticache/redshift only, no CE calls. Part of #142, milestone v0.3.0.