### PR TITLE
fix(discovery): use short boto3 timeouts for service checks

### DIFF
--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -26,6 +26,9 @@ from typing import List, Dict, Any, Tuple
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import boto3
+from botocore.config import Config as BotocoreConfig
+
 try:
     import utils
 except ImportError:
@@ -606,7 +609,30 @@ _NOT_IN_USE_FRAGMENTS = (
     "not enabled",                                # Macie, others: not enabled
     "must create a landing zone",                 # Control Tower: not deployed
     "endpoint discovery failed",                  # Timestream: endpoint issue
+    "read timeout",                               # service took too long — treat as not detected
+    "connect timeout",                            # connection too slow — treat as not detected
+    "readtimeouterror",                           # botocore ReadTimeoutError class name
+    "connecttimeouterror",                        # botocore ConnectTimeoutError class name
 )
+
+# Boto3 client config for service discovery checks: fast failure over resilience.
+# Discovery checks need to know quickly whether a service has resources — if a
+# service doesn't respond within 15s it's almost certainly not in use or the
+# endpoint is unavailable. Export scripts still use the default 60s timeout.
+_DISCOVERY_CLIENT_CONFIG = BotocoreConfig(
+    connect_timeout=5,
+    read_timeout=15,
+    retries={'max_attempts': 2, 'mode': 'standard'},
+)
+
+
+def _get_discovery_client(service: str, region: str):
+    """Create a boto3 client configured for fast service discovery checks."""
+    session = boto3.Session(region_name=region)
+    kwargs = {}
+    if region and region.startswith("us-gov-"):
+        kwargs["use_fips_endpoint"] = True
+    return session.client(service, config=_DISCOVERY_CLIENT_CONFIG, **kwargs)
 
 
 def _is_not_in_use_error(exc: Exception) -> bool:
@@ -663,7 +689,7 @@ def check_service_in_region(service_name: str, config: dict, region: str) -> Tup
         success or on a recognized "not in use / not available" condition.
     """
     try:
-        client = utils.get_boto3_client(config['client'], region_name=region)
+        client = _get_discovery_client(config['client'], region)
         count = config['check'](client, region)
         return (service_name, count, region, None)
     except Exception as e:


### PR DESCRIPTION
## Summary

Discovery checks were using the default 60s boto3 read timeout, causing services that aren't in use to hang for 60-85s each. From UAT output, the five culprits were Lightsail (80s), Global Accelerator (60s), Timestream (85s), App Runner (70s), and Connect (80s) — roughly 6 minutes of dead time per scan on a typical account.

**Root cause**: `utils.get_boto3_client()` uses `read_timeout=60s` and `max_attempts=10` (adaptive). For discovery, we need fast failure not resilience.

**Fix**:
- `_DISCOVERY_CLIENT_CONFIG`: `connect_timeout=5s`, `read_timeout=15s`, `max_attempts=2` (standard mode)
- `_get_discovery_client()`: applies the discovery config, handles GovCloud FIPS injection
- `check_service_in_region` now uses `_get_discovery_client()` instead of `utils.get_boto3_client()`
- Read/connect timeout strings added to `_NOT_IN_USE_FRAGMENTS` — timeout = "not detected", not an error
- `_enrich_with_detail` (Deep Scan second pass) is unchanged and still uses `utils.get_boto3_client()`

**Expected improvement**: ~15s max per slow service instead of 60-85s. Saves several minutes on typical Quick Scan runs.

## Test plan

- [ ] Quick Scan: Lightsail, Global Accelerator, Timestream, App Runner, Connect should each resolve in ≤15s
- [ ] Services that ARE in use (EC2, S3, etc.) should be unaffected
- [ ] Deep Scan: `_enrich_with_detail` should still use standard timeouts (no regression)
- [ ] GovCloud: FIPS injection still applied for `us-gov-*` regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)