### PR TITLE
fix(executor): suppress per-script output in batch; add per-script heartbeat

### DIFF
--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -165,6 +165,24 @@ class ScriptExecutor:
                 env=env,
             )
 
+            # When not streaming output, run a background heartbeat so the user
+            # knows a slow script is still working (fires every 10s).
+            _hb_stop = threading.Event()
+            _hb_thread: Optional[threading.Thread] = None
+            if not self.show_output:
+                _hb_t0 = time.monotonic()
+
+                def _heartbeat() -> None:
+                    while not _hb_stop.wait(timeout=10):
+                        print(
+                            f"  ... {script_name}: still running "
+                            f"({int(time.monotonic() - _hb_t0)}s elapsed)",
+                            flush=True,
+                        )
+
+                _hb_thread = threading.Thread(target=_heartbeat, daemon=True)
+                _hb_thread.start()
+
             t_out = threading.Thread(
                 target=_drain,
                 args=(proc.stdout, stdout_lines, self.show_output),
@@ -190,6 +208,11 @@ class ScriptExecutor:
                 proc.kill()
                 return_code = -1
                 timed_out = True
+
+            # Stop the per-script heartbeat before logging the result
+            if _hb_thread is not None:
+                _hb_stop.set()
+                _hb_thread.join()
 
             end_time = datetime.now()
             duration = (end_time - start_time).total_seconds()

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -407,7 +407,7 @@ def main() -> None:
         show_progress=True,
         save_log=True,
         regions=regions,
-        show_output=True,
+        show_output=False,
     )
 
     print()


### PR DESCRIPTION
## Summary

Batch execution output was noisy and inconsistent — each script streamed its own banners, spinners (`| 2s / 2s - 2s`), "Processing region:" lines, etc. with no unified format.

**Changes:**
- `smart_scan.py`: `show_output=False` — the executor now controls all terminal output
- `executor.py`: per-script background heartbeat (10s interval) when `show_output=False`, stopped and joined before the result line is printed

**Before:**
```
[3/38] (8%) api_gateway_export.py
  ============================================================
  AWS API GATEWAY EXPORT
  ============================================================
  [✓] All required dependencies are installed
  === COLLECTING REST APIs (v1) ===
    Scanning 4 region(s) concurrently...
    Processing REST API: testtest
    [1/4] us-east-1 done
    ...
```

**After:**
```
[3/38] (8%) api_gateway_export.py
[✗] api_gateway_export.py failed (code 1): ...

[10/38] (26%) compute_resources.py
  ... compute_resources.py: still running (10s elapsed)
  ... compute_resources.py: still running (20s elapsed)
[✓] compute_resources.py completed in 89s
```

Full script stdout/stderr still captured and saved in the execution log.

## Test plan

- [ ] Deep Scan: verify batch output is clean — no script banners, no spinners
- [ ] Scripts < 10s: verify no heartbeat lines appear
- [ ] Scripts > 10s: verify heartbeat fires every 10s
- [ ] Failed scripts: verify error message still appears in the summary
- [ ] Execution log: verify full output is still written to log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)