### PR TITLE
fix(smart_scan): add vpc_data_export and route_tables_export to ALWAYS_RUN_SCRIPTS

### DIFF
--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -17,8 +17,10 @@ ALWAYS_RUN_SCRIPTS = [
     "cloudtrail_export.py",
     "config_export.py",
     "guardduty_export.py",
+    "vpc_data_export.py",
     "security_groups_export.py",
     "nacl_export.py",
+    "route_tables_export.py",
     "trusted_advisor_cost_optimization_export.py",
     "budgets_export.py",
 ]

--- a/tests/smart_scan/test_mapping.py
+++ b/tests/smart_scan/test_mapping.py
@@ -233,7 +233,7 @@ class TestMappingStatistics:
 
     def test_always_run_count(self):
         """Verify we have expected number of always-run scripts."""
-        assert len(ALWAYS_RUN_SCRIPTS) == 8
+        assert len(ALWAYS_RUN_SCRIPTS) == 10
 
     def test_no_duplicate_scripts_in_service_map(self):
         """Verify no service lists the same script twice."""


### PR DESCRIPTION
## Summary

- `vpc_data_export.py` was never triggered by Smart Scan because VPC doesn't surface as a discrete service in the service discovery output — it's foundational infrastructure, not a service AWS reports as "in use"
- `route_tables_export.py` has the same problem — route tables exist in every VPC
- `security_groups_export.py` and `nacl_export.py` were already in `ALWAYS_RUN_SCRIPTS`; this brings the other two VPC-layer scripts in line with them

## Test plan

- [ ] Run Smart Scan service discovery against a real account
- [ ] Confirm `vpc_data_export.py` and `route_tables_export.py` appear in the always-run batch regardless of what services discovery finds
- [ ] Confirm no duplicate execution if VPC also appears in the discovered services list (deduplication is handled by the executor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)