### PR TITLE
fix(govcloud): set use_fips_endpoint on Config, not as client() kwarg

### DIFF
--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -631,10 +631,12 @@ _DISCOVERY_CLIENT_CONFIG = BotocoreConfig(
 def _get_discovery_client(service: str, region: str):
     """Create a boto3 client configured for fast service discovery checks."""
     session = boto3.Session(region_name=region)
-    kwargs = {}
+    config = _DISCOVERY_CLIENT_CONFIG
+    # FIPS belongs on the botocore Config, not as a client() kwarg (boto3
+    # rejects it there). GovCloud requires FIPS endpoints.
     if region and region.startswith("us-gov-"):
-        kwargs["use_fips_endpoint"] = True
-    return session.client(service, config=_DISCOVERY_CLIENT_CONFIG, **kwargs)
+        config = config.merge(BotocoreConfig(use_fips_endpoint=True))
+    return session.client(service, config=config)
 
 
 def _is_not_in_use_error(exc: Exception) -> bool:

--- a/tests/sslib/test_aws_client.py
+++ b/tests/sslib/test_aws_client.py
@@ -114,7 +114,12 @@ class TestDetectPartition:
 
 class TestGetBoto3ClientFips:
     def test_govcloud_injects_fips(self):
-        """GovCloud regions MUST use FIPS endpoints — security-critical property."""
+        """GovCloud regions MUST use FIPS endpoints — security-critical property.
+
+        FIPS must be set on the botocore Config, NOT passed as a client() kwarg
+        (boto3 rejects ``use_fips_endpoint`` as a client argument — see the
+        GovCloud regression fixed in fix/govcloud-fips-endpoint-kwarg).
+        """
         mock_session = MagicMock()
         mock_client = MagicMock()
         mock_session.client.return_value = mock_client
@@ -124,7 +129,10 @@ class TestGetBoto3ClientFips:
                 get_boto3_client("ec2", region_name="us-gov-west-1")
 
         call_kwargs = mock_session.client.call_args[1]
-        assert call_kwargs.get("use_fips_endpoint") is True, (
+        assert "use_fips_endpoint" not in call_kwargs, (
+            "use_fips_endpoint must NOT be a client() kwarg — boto3 rejects it"
+        )
+        assert call_kwargs["config"].use_fips_endpoint is True, (
             "FIPS endpoint must be injected for GovCloud region us-gov-west-1"
         )
 
@@ -138,7 +146,8 @@ class TestGetBoto3ClientFips:
                 get_boto3_client("s3", region_name="us-gov-east-1")
 
         call_kwargs = mock_session.client.call_args[1]
-        assert call_kwargs.get("use_fips_endpoint") is True
+        assert "use_fips_endpoint" not in call_kwargs
+        assert call_kwargs["config"].use_fips_endpoint is True
 
     def test_commercial_does_not_inject_fips(self):
         """Commercial regions must NOT have FIPS forced on."""
@@ -151,6 +160,7 @@ class TestGetBoto3ClientFips:
 
         call_kwargs = mock_session.client.call_args[1]
         assert "use_fips_endpoint" not in call_kwargs
+        assert call_kwargs["config"].use_fips_endpoint is None
 
     def test_includes_retry_config(self):
         mock_session = MagicMock()

--- a/utils.py
+++ b/utils.py
@@ -3032,12 +3032,13 @@ def _assume_role_cached(
         profile = profile_name or (_SCRIPT_ARGS.profile if _SCRIPT_ARGS else None)
         caller_session = boto3.Session(region_name=region_name, profile_name=profile)
 
-        # FIPS for GovCloud STS
-        sts_kwargs: Dict[str, Any] = {}
+        # FIPS for GovCloud STS — must be set on the botocore Config, not as a
+        # client() kwarg (boto3 rejects it there).
+        sts_config = None
         if region_name and region_name.startswith("us-gov-"):
-            sts_kwargs["use_fips_endpoint"] = True
+            sts_config = Config(use_fips_endpoint=True)
 
-        sts_client = caller_session.client("sts", **sts_kwargs)
+        sts_client = caller_session.client("sts", config=sts_config)
 
         # Assume role with exponential backoff for ThrottlingException
         max_attempts = 5
@@ -3164,15 +3165,22 @@ def get_boto3_client(
     connect_timeout = sdk_config.get("connect_timeout", 10)
     read_timeout = sdk_config.get("read_timeout", 60)
 
-    config = Config(
-        retries=retry_config,
-        connect_timeout=connect_timeout,
-        read_timeout=read_timeout,
-    )
+    config_kwargs: Dict[str, Any] = {
+        "retries": retry_config,
+        "connect_timeout": connect_timeout,
+        "read_timeout": read_timeout,
+    }
 
-    # FIPS injection — GovCloud requires FIPS endpoints
-    if region_name and region_name.startswith("us-gov-") and "use_fips_endpoint" not in kwargs:
-        kwargs["use_fips_endpoint"] = True
+    # FIPS injection — GovCloud requires FIPS endpoints. This belongs on the
+    # botocore Config, NOT as a client() kwarg (boto3 rejects it there). A
+    # caller may still override via kwargs["use_fips_endpoint"].
+    fips_override = kwargs.pop("use_fips_endpoint", None)
+    if fips_override is not None:
+        config_kwargs["use_fips_endpoint"] = fips_override
+    elif region_name and region_name.startswith("us-gov-"):
+        config_kwargs["use_fips_endpoint"] = True
+
+    config = Config(**config_kwargs)
 
     session = get_aws_session(region_name, role_arn=role_arn)
     return session.client(service, config=config, **kwargs)


### PR DESCRIPTION
## Problem

Every AWS client build in GovCloud regions crashes with:

```
Session.client() got an unexpected keyword argument 'use_fips_endpoint'
```

Reported during a live GovCloud EC2 export.

## Root cause

`use_fips_endpoint` is a `botocore.config.Config` option, **not** a valid keyword argument to `session.client()`. Three sites injected it as a client kwarg, which boto3 rejects. The branch only fires for `us-gov-*` regions, so it never surfaced in Commercial testing.

Affected sites:
- `utils.py` — `get_boto3_client()` (primary; hit by every exporter)
- `utils.py` — `get_aws_role_credentials()` STS path (GovCloud cross-account)
- `scripts/services_in_use_export.py` — `_get_discovery_client()` (GovCloud service discovery)

The unit tests in `tests/sslib/test_aws_client.py` asserted the broken behavior (checked the kwarg on a mocked `session.client()`), so they passed against `MagicMock` but never caught the real boto3 rejection.

## Fix

Move `use_fips_endpoint` onto the botocore `Config` object at all three sites. The caller-override path in `get_boto3_client()` is preserved (a `use_fips_endpoint` passed in `**kwargs` is honored on the Config). Tests rewritten to assert `config.use_fips_endpoint` **and** guard that it is never passed as a `client()` kwarg.

## Verification

- Full suite: **428 passed**, 2 skipped. The 2 `test_executor` failures are pre-existing (stale `output/` dir) and confirmed to fail with this branch's changes stashed — unrelated to this fix.
- Real-boto3 smoke test: `get_boto3_client('ec2', region_name='us-gov-west-1')` builds successfully with `use_fips_endpoint=True` on the resolved config.
- Ruff: no new violations introduced.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)