### PR TITLE
feat(export): S3 upload as a post-export delivery destination (#175)

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -9,8 +9,13 @@
   "agency_name": "YOUR-AGENCY",
   "default_regions": ["us-east-1", "us-west-2"],
   "output_settings": {
-    "__comment": "Export format: xlsx (requires openpyxl) or csv. Set automatically by Config Wizard.",
-    "format": "xlsx"
+    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). Set via 'python configure.py' -> Output Settings.",
+    "format": "xlsx",
+    "destination": "local",
+    "s3": {
+      "bucket": "",
+      "prefix": "stratusscan/"
+    }
   },
   "resource_preferences": {
     "ec2": {

--- a/configure.py
+++ b/configure.py
@@ -427,8 +427,17 @@ def print_dashboard(config: dict, config_path: Path):
     config_status = get_config_status(config, config_path)
     print_status_line("Configuration", config_status, 70)
 
-    output_fmt = config.get("output_settings", {}).get("format", utils.detect_default_format())
+    out_settings = config.get("output_settings", {})
+    output_fmt = out_settings.get("format", utils.detect_default_format())
     print_status_line("Export Format", output_fmt, 70)
+
+    destination = out_settings.get("destination", "local")
+    if destination == "s3":
+        bucket = (out_settings.get("s3", {}) or {}).get("bucket", "")
+        dest_str = f"S3: {bucket}" if bucket else "S3 (bucket not set!)"
+    else:
+        dest_str = "local (output/)"
+    print_status_line("Output Destination", dest_str, 70)
 
     print("╚" + "═" * 68 + "╝")
 
@@ -485,8 +494,11 @@ def print_dashboard(config: dict, config_path: Path):
     role_status = f"{role_count} configured" if role_count else "None configured"
     print(f"  [6] Cross-Account Roles                    {role_status}")
 
-    output_fmt = config.get("output_settings", {}).get("format", utils.detect_default_format())
-    print(f"  [7] Output Format                          {output_fmt}")
+    out_settings = config.get("output_settings", {})
+    output_fmt = out_settings.get("format", utils.detect_default_format())
+    out_dest = out_settings.get("destination", "local")
+    dest_label = "S3" if out_dest == "s3" else "local"
+    print(f"  [7] Output Settings                        {output_fmt} → {dest_label}")
 
     # Actions
     print("\nActions:")
@@ -495,30 +507,26 @@ def print_dashboard(config: dict, config_path: Path):
 
     print("\n" + "═" * 70)
 
-def configure_output_settings(config: dict):
-    """
-    Configure the export output format (xlsx or csv).
+def _ensure_output_settings(config: dict) -> dict:
+    """Return config['output_settings'], creating it (and the nested s3 block) if absent."""
+    out = config.setdefault("output_settings", {})
+    out.setdefault("s3", {})
+    return out
 
-    Reads current output_settings from config, shows the current value, and
-    prompts the user to change it. Updates config in place and sets the
-    _config_modified flag when a change is made.
 
-    Args:
-        config (dict): Configuration dictionary (mutated in place)
-    """
+def _set_output_format(config: dict):
+    """Prompt for and apply the export format (xlsx/csv)."""
     global _config_modified
 
-    current_settings = config.get("output_settings", {})
-    current_fmt = current_settings.get("format", utils.detect_default_format())
+    out = _ensure_output_settings(config)
+    current_fmt = out.get("format", utils.detect_default_format())
 
-    print("\n" + "═" * 70)
-    print("OUTPUT FORMAT SETTINGS")
-    print("═" * 70)
-    print(f"  Current format: {current_fmt}")
-    print()
+    print("\n" + "─" * 70)
+    print("EXPORT FORMAT")
+    print("─" * 70)
+    print(f"  Current: {current_fmt}")
     print("  [1] xlsx  — Excel workbook (requires openpyxl)")
     print("  [2] csv   — Universal CSV (stdlib only, multi-sheet exports split into files)")
-    print()
     choice = input("Select format (1/2, or Enter to keep current): ").strip()
 
     if choice == "1":
@@ -527,19 +535,185 @@ def configure_output_settings(config: dict):
         new_fmt = "csv"
     else:
         print("  No change made.")
-        input("\nPress Enter to return to menu...")
         return
 
     if new_fmt == current_fmt:
         print(f"  Format already set to '{new_fmt}'. No change.")
     else:
-        if "output_settings" not in config:
-            config["output_settings"] = {}
-        config["output_settings"]["format"] = new_fmt
+        out["format"] = new_fmt
         _config_modified = True
         print(f"  Export format set to '{new_fmt}'.")
 
-    input("\nPress Enter to return to menu...")
+
+def _set_output_destination(config: dict):
+    """Prompt for and apply the output destination (local/s3)."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current_dest = out.get("destination", "local")
+
+    print("\n" + "─" * 70)
+    print("OUTPUT DESTINATION")
+    print("─" * 70)
+    print(f"  Current: {current_dest}")
+    print("  [1] local — save to output/ (default)")
+    print("  [2] s3    — upload to an S3 bucket, then delete the local copy on success")
+    choice = input("Select destination (1/2, or Enter to keep current): ").strip()
+
+    if choice == "1":
+        new_dest = "local"
+    elif choice == "2":
+        new_dest = "s3"
+    else:
+        print("  No change made.")
+        return
+
+    if new_dest == current_dest:
+        print(f"  Destination already set to '{new_dest}'. No change.")
+    else:
+        out["destination"] = new_dest
+        _config_modified = True
+        print(f"  Output destination set to '{new_dest}'.")
+
+    if new_dest == "s3" and not out.get("s3", {}).get("bucket"):
+        print("  ⚠️  No S3 bucket configured yet — set it with [3] before exporting.")
+
+
+def _set_s3_bucket(config: dict):
+    """Prompt for and apply the S3 bucket name."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current = out["s3"].get("bucket", "")
+
+    print("\n" + "─" * 70)
+    print("S3 BUCKET")
+    print("─" * 70)
+    print(f"  Current: {current or '(not set)'}")
+    new_bucket = input("Enter S3 bucket name (Enter to keep current): ").strip()
+    if not new_bucket:
+        print("  No change made.")
+        return
+
+    out["s3"]["bucket"] = new_bucket
+    _config_modified = True
+    print(f"  S3 bucket set to '{new_bucket}'.")
+
+
+def _set_s3_prefix(config: dict):
+    """Prompt for and apply the S3 key prefix."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current = out["s3"].get("prefix", "stratusscan/")
+
+    print("\n" + "─" * 70)
+    print("S3 PREFIX")
+    print("─" * 70)
+    print(f"  Current: {current}")
+    print("  Key prefix within the bucket (e.g. 'stratusscan/'). Enter '/' for no prefix.")
+    new_prefix = input("Enter S3 prefix (Enter to keep current): ").strip()
+    if not new_prefix:
+        print("  No change made.")
+        return
+
+    new_prefix = "" if new_prefix == "/" else new_prefix
+    out["s3"]["prefix"] = new_prefix
+    _config_modified = True
+    print(f"  S3 prefix set to '{new_prefix}'.")
+
+
+def _run_s3_connectivity_test(config: dict):
+    """Run the HeadBucket → PutObject → DeleteObject roundtrip and print results."""
+    out = _ensure_output_settings(config)
+    bucket = out["s3"].get("bucket", "")
+    prefix = out["s3"].get("prefix", "stratusscan/")
+
+    print("\n" + "─" * 70)
+    print("TEST S3 CONNECTION")
+    print("─" * 70)
+
+    if not bucket:
+        print("  ❌ No S3 bucket configured. Set one with [3] first.")
+        return
+
+    print(f"  Bucket: {bucket}")
+    print(f"  Prefix: {prefix}")
+    print("  Running HeadBucket → PutObject → DeleteObject ...\n")
+
+    result = utils.test_s3_connectivity(bucket, prefix)
+
+    if result.get("region"):
+        print(f"  Region: {result['region']}")
+    for step in result["steps"]:
+        if step["ok"]:
+            print(f"  ✅ {step['step']}")
+        else:
+            print(f"  ❌ {step['step']}")
+            print(f"       {step['error']}")
+
+    print()
+    if result["ok"]:
+        print("  ✅ S3 connectivity OK — exports will upload to this bucket.")
+    else:
+        failed = result.get("failed_step")
+        print(f"  ❌ S3 connectivity FAILED at step: {failed}")
+        print("     Common causes: wrong region, PutObject denied by bucket policy/KMS/VPC")
+        print("     endpoint condition, prefix-level permission mismatch, or Block Public")
+        print("     Access conflict. See policies/s3-upload-permissions.json for the")
+        print("     minimum IAM grant required.")
+
+
+def configure_output_settings(config: dict):
+    """
+    Configure export output settings: format, destination, and S3 details.
+
+    Submenu loop covering format (xlsx/csv), destination (local/s3), S3 bucket
+    and prefix, and an on-demand S3 connectivity test. Mutates config in place
+    and sets _config_modified when a change is made.
+
+    Args:
+        config (dict): Configuration dictionary (mutated in place)
+    """
+    while True:
+        out = _ensure_output_settings(config)
+        fmt = out.get("format", utils.detect_default_format())
+        dest = out.get("destination", "local")
+        bucket = out["s3"].get("bucket", "") or "(not set)"
+        prefix = out["s3"].get("prefix", "stratusscan/")
+
+        print("\n" + "═" * 70)
+        print("OUTPUT SETTINGS")
+        print("═" * 70)
+        print(f"  Format:      {fmt}")
+        print(f"  Destination: {dest}")
+        if dest == "s3":
+            print(f"  S3 bucket:   {bucket}")
+            print(f"  S3 prefix:   {prefix}")
+        print()
+        print("  [1] Change export format (xlsx/csv)")
+        print("  [2] Change destination (local/s3)")
+        print("  [3] Set S3 bucket")
+        print("  [4] Set S3 prefix")
+        print("  [5] Test S3 connection")
+        print("  [B] Back to main menu")
+
+        choice = input("\nSelect option: ").strip().upper()
+
+        if choice == "1":
+            _set_output_format(config)
+        elif choice == "2":
+            _set_output_destination(config)
+        elif choice == "3":
+            _set_s3_bucket(config)
+        elif choice == "4":
+            _set_s3_prefix(config)
+        elif choice == "5":
+            _run_s3_connectivity_test(config)
+        elif choice in ("B", ""):
+            return
+        else:
+            print("  ❌ Invalid choice.")
 
 
 def config_wizard(config: dict):
@@ -562,7 +736,8 @@ def config_wizard(config: dict):
     _clr()
     print("✅ Step 1/6 complete — Account Mappings\n")
     print("Step 2/6 — Export Format\n")
-    configure_output_settings(config)
+    _set_output_format(config)
+    input("\nPress Enter to continue...")
 
     _clr()
     print("✅ Step 2/6 complete — Export Format\n")

--- a/policies/s3-upload-permissions.json
+++ b/policies/s3-upload-permissions.json
@@ -1,0 +1,24 @@
+{
+  "__comment": "StratusScan S3 upload (Issue #175). Grants ONLY the write-only access needed to deliver exports to one bucket/prefix — separate and independently auditable from the read-only scan policies. Replace YOUR-BUCKET-NAME with your bucket and adjust the 'stratusscan/' prefix to match output_settings.s3.prefix. For GovCloud use partition 'aws-us-gov' in the ARNs. Note: the HeadBucket API used by the connectivity test is authorized by s3:ListBucket.",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StratusScanS3BucketLevel",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME"
+    },
+    {
+      "Sid": "StratusScanS3ObjectWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME/stratusscan/*"
+    }
+  ]
+}

--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for the S3 output-delivery feature (Issue #175) in utils.py.
+
+Covers:
+- upload_to_s3()            — success deletes local + returns s3 uri; failure retains local
+- deliver_output()          — routes to S3 when enabled, passthrough when local
+- resolve_s3_destination()  — config vs STRATUSSCAN_S3_BUCKET env override
+- test_s3_connectivity()    — HeadBucket -> PutObject -> DeleteObject step reporting
+- _build_s3_key()           — prefix/basename joining
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+REGION = "us-east-1"
+BUCKET = "stratusscan-test-bucket"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    # Ensure no stray env override leaks between tests.
+    monkeypatch.delenv("STRATUSSCAN_S3_BUCKET", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_S3_PREFIX", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_REGIONS", raising=False)
+
+
+def _make_bucket():
+    s3 = boto3.client("s3", region_name=REGION)
+    s3.create_bucket(Bucket=BUCKET)
+    return s3
+
+
+def _local_file(tmp_path, name="acct-ec2-export-01.01.2026.xlsx", body=b"data"):
+    p = tmp_path / name
+    p.write_bytes(body)
+    return str(p)
+
+
+class TestBuildS3Key:
+    def test_prefix_and_basename_joined(self):
+        assert utils._build_s3_key("stratusscan/", "/out/acct-ec2.xlsx") == "stratusscan/acct-ec2.xlsx"
+
+    def test_prefix_without_trailing_slash_gets_one(self):
+        assert utils._build_s3_key("evidence", "/out/x.csv") == "evidence/x.csv"
+
+    def test_empty_prefix_is_bare_key(self):
+        assert utils._build_s3_key("", "/out/x.csv") == "x.csv"
+
+    def test_leading_slash_stripped(self):
+        assert utils._build_s3_key("/stratusscan/", "/out/x.csv") == "stratusscan/x.csv"
+
+
+class TestUploadToS3:
+    @mock_aws
+    def test_success_uploads_and_deletes_local(self, tmp_path):
+        s3 = _make_bucket()
+        local = _local_file(tmp_path)
+
+        uri = utils.upload_to_s3(local, BUCKET, "stratusscan/")
+
+        assert uri == f"s3://{BUCKET}/stratusscan/acct-ec2-export-01.01.2026.xlsx"
+        # Object landed in S3
+        obj = s3.get_object(Bucket=BUCKET, Key="stratusscan/acct-ec2-export-01.01.2026.xlsx")
+        assert obj["Body"].read() == b"data"
+        # Local copy deleted on success
+        assert not Path(local).exists()
+
+    @mock_aws
+    def test_failure_retains_local_and_returns_none(self, tmp_path):
+        _make_bucket()
+        local = _local_file(tmp_path)
+
+        # Upload to a bucket that does not exist -> failure
+        uri = utils.upload_to_s3(local, "no-such-bucket-xyz", "stratusscan/")
+
+        assert uri is None
+        assert Path(local).exists()  # retained as fallback
+
+    @mock_aws
+    def test_missing_local_file_returns_none(self):
+        _make_bucket()
+        assert utils.upload_to_s3("/does/not/exist.xlsx", BUCKET) is None
+
+    def test_empty_bucket_returns_none(self, tmp_path):
+        local = _local_file(tmp_path)
+        assert utils.upload_to_s3(local, "") is None
+        assert Path(local).exists()
+
+
+class TestResolveS3Destination:
+    def test_env_var_forces_s3(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("STRATUSSCAN_S3_PREFIX", "ci/")
+        dest = utils.resolve_s3_destination()
+        assert dest == {"enabled": True, "bucket": "env-bucket", "prefix": "ci/"}
+
+    def test_config_s3_destination(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "s3",
+                ("s3", "output_settings"): {"bucket": "cfg-bucket", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        dest = utils.resolve_s3_destination()
+        assert dest["enabled"] is True
+        assert dest["bucket"] == "cfg-bucket"
+        assert dest["prefix"] == "stratusscan/"
+
+    def test_local_destination_not_enabled(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "local",
+                ("s3", "output_settings"): {"bucket": "", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_s3_selected_but_no_bucket_not_enabled(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "s3",
+                ("s3", "output_settings"): {"bucket": "", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+
+class TestDeliverOutput:
+    def test_local_destination_passthrough(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": False, "bucket": "", "prefix": ""},
+        )
+        local = _local_file(tmp_path)
+        assert utils.deliver_output(local) == local
+        assert Path(local).exists()
+
+    @mock_aws
+    def test_s3_destination_uploads(self, monkeypatch, tmp_path):
+        _make_bucket()
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": True, "bucket": BUCKET, "prefix": "stratusscan/"},
+        )
+        local = _local_file(tmp_path)
+        result = utils.deliver_output(local)
+        assert result.startswith(f"s3://{BUCKET}/stratusscan/")
+        assert not Path(local).exists()
+
+    @mock_aws
+    def test_failed_upload_falls_back_to_local(self, monkeypatch, tmp_path):
+        # bucket not created -> upload fails -> deliver returns local path
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": True, "bucket": "missing-bucket", "prefix": "stratusscan/"},
+        )
+        local = _local_file(tmp_path)
+        assert utils.deliver_output(local) == local
+        assert Path(local).exists()
+
+
+class TestS3Connectivity:
+    @mock_aws
+    def test_full_roundtrip_ok(self):
+        _make_bucket()
+        result = utils.test_s3_connectivity(BUCKET, "stratusscan/")
+        assert result["ok"] is True
+        assert result["failed_step"] is None
+        assert [s["step"] for s in result["steps"]] == ["HeadBucket", "PutObject", "DeleteObject"]
+        assert all(s["ok"] for s in result["steps"])
+        # Probe object cleaned up
+        s3 = boto3.client("s3", region_name=REGION)
+        assert "Contents" not in s3.list_objects_v2(Bucket=BUCKET)
+
+    @mock_aws
+    def test_missing_bucket_fails_at_headbucket(self):
+        result = utils.test_s3_connectivity("no-such-bucket-zzz", "stratusscan/")
+        assert result["ok"] is False
+        assert result["failed_step"] == "HeadBucket"
+
+    def test_no_bucket_fails_at_config(self):
+        result = utils.test_s3_connectivity("", "stratusscan/")
+        assert result["ok"] is False
+        assert result["failed_step"] == "config"

--- a/utils.py
+++ b/utils.py
@@ -966,7 +966,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             df.to_csv(output_path, index=False)
             logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-            return str(output_path)
+            return deliver_output(str(output_path))
 
         # --- xlsx path ---
         # Ensure the output directory exists
@@ -988,7 +988,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             df.to_excel(output_path, sheet_name=sheet_name, index=False)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return str(output_path)
+        return deliver_output(str(output_path))
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1042,17 +1042,16 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     base_stem = base_stem[: -len(ext)]
                     break
 
-            first_path: Optional[str] = None
+            delivered: list[str] = []
             for sheet_name, df in dataframes_dict.items():
                 slug = _re.sub(r'[^a-z0-9]+', '-', sheet_name.lower()).strip('-')
                 csv_filename = f"{base_stem}-{slug}.csv"
                 csv_path = output_dir / csv_filename
                 df.to_csv(csv_path, index=False)
                 logger.info(_scrub_log(f"Data successfully exported to: {csv_path}"))
-                if first_path is None:
-                    first_path = str(csv_path)
+                delivered.append(deliver_output(str(csv_path)))
 
-            return first_path
+            return delivered[0] if delivered else None
 
         # --- xlsx path ---
         output_path = get_output_filepath(filename)
@@ -1084,11 +1083,272 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     _adjust_column_widths(writer.sheets[sheet_name], df)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return str(output_path)
+        return deliver_output(str(output_path))
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
         return None
+
+
+# ---------------------------------------------------------------------------
+# Output delivery — S3 upload (Issue #175)
+# ---------------------------------------------------------------------------
+#
+# Two delivery destinations are supported via the ``output_settings`` config
+# block (or the ``STRATUSSCAN_S3_BUCKET`` env var for headless/CI runs):
+#
+#   * ``local`` (default) — files stay in ``output/`` exactly as before.
+#   * ``s3``            — files are written to ``output/`` first, uploaded to
+#                          the configured bucket, then the local copy is deleted
+#                          on a successful upload. On failure the local file is
+#                          retained as a fallback and the local path is returned.
+#
+# Scanning stays read-only everywhere; the only write any of this performs is a
+# write-only ``PutObject`` to the one designated bucket.
+
+
+def resolve_s3_destination() -> dict[str, Any]:
+    """
+    Resolve the effective output destination from config + environment.
+
+    The ``STRATUSSCAN_S3_BUCKET`` env var is the headless/CI hook: when set it
+    forces S3 delivery regardless of the config ``destination`` value, so a
+    scheduled runner can route output to S3 without a committed config.json.
+    ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix the same way.
+
+    Returns:
+        dict: ``{"enabled": bool, "bucket": str, "prefix": str}``.
+              ``enabled`` is True only when S3 delivery is active AND a bucket
+              is known.
+    """
+    settings = config_value("s3", default={}, section="output_settings") or {}
+    destination = config_value("destination", default="local", section="output_settings")
+
+    env_bucket = os.environ.get("STRATUSSCAN_S3_BUCKET", "").strip()
+    env_prefix = os.environ.get("STRATUSSCAN_S3_PREFIX", "").strip()
+
+    bucket = env_bucket or (settings.get("bucket", "") or "").strip()
+    prefix = env_prefix or settings.get("prefix", "stratusscan/")
+
+    # S3 is active if the env var forced it OR config selected it.
+    selected = bool(env_bucket) or str(destination).lower() == "s3"
+
+    return {
+        "enabled": bool(selected and bucket),
+        "bucket": bucket,
+        "prefix": prefix,
+    }
+
+
+def _s3_bootstrap_region() -> str:
+    """
+    Pick a region for the initial bucket-location lookup and as the upload
+    fallback. Order: STRATUSSCAN_REGIONS → config default_regions → us-east-1.
+
+    Using an operating region (rather than hardcoding us-east-1) keeps the
+    partition correct so GovCloud buckets resolve against a GovCloud endpoint.
+    """
+    env_regions = os.environ.get("STRATUSSCAN_REGIONS", "").strip()
+    if env_regions:
+        first = env_regions.split(",")[0].strip()
+        if first:
+            return first
+
+    defaults = config_value("default_regions", default=[]) or []
+    if defaults:
+        return defaults[0]
+
+    return "us-east-1"
+
+
+def _resolve_bucket_region(bucket: str, bootstrap_region: str) -> Optional[str]:
+    """
+    Return the region a bucket lives in via ``GetBucketLocation``.
+
+    ``LocationConstraint`` is ``None``/empty for us-east-1 (AWS quirk); map that
+    back to ``us-east-1``. Returns None if the lookup fails (caller falls back
+    to the bootstrap region).
+    """
+    try:
+        client = get_boto3_client("s3", bootstrap_region)
+        loc = client.get_bucket_location(Bucket=bucket).get("LocationConstraint")
+        return loc or "us-east-1"
+    except Exception as e:
+        logging.getLogger("stratusscan").debug(
+            "GetBucketLocation failed for bucket '%s' from %s: %s", bucket, bootstrap_region, e
+        )
+        return None
+
+
+def _build_s3_key(prefix: str, local_path: str) -> str:
+    """Join a prefix and a file's basename into an S3 key (single '/' separators)."""
+    name = os.path.basename(local_path)
+    prefix = (prefix or "").lstrip("/")
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    return f"{prefix}{name}"
+
+
+def upload_to_s3(
+    local_path: str,
+    bucket: str,
+    prefix: str = "stratusscan/",
+    region: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Upload a local file to S3 and delete the local copy on success.
+
+    Uses :func:`get_boto3_client` so the upload inherits retry/FIPS behaviour
+    (GovCloud buckets get a FIPS endpoint automatically). The local file is
+    removed only after a successful upload; on any failure it is left in place
+    as a fallback.
+
+    Args:
+        local_path: Path to the file to upload.
+        bucket: Destination S3 bucket name.
+        prefix: Key prefix within the bucket.
+        region: Bucket region. If None, resolved via GetBucketLocation with a
+                bootstrap-region fallback.
+
+    Returns:
+        str: The ``s3://bucket/key`` URI on success, or None on failure.
+    """
+    log = logging.getLogger("stratusscan")
+
+    if not os.path.exists(local_path):
+        log.error("upload_to_s3: local file does not exist: %s", local_path)
+        return None
+    if not bucket:
+        log.error("upload_to_s3: no bucket configured; cannot upload %s", local_path)
+        return None
+
+    bootstrap = _s3_bootstrap_region()
+    if region is None:
+        region = _resolve_bucket_region(bucket, bootstrap) or bootstrap
+
+    key = _build_s3_key(prefix, local_path)
+    try:
+        client = get_boto3_client("s3", region)
+        client.upload_file(local_path, bucket, key)
+    except Exception as e:
+        log.error("S3 upload failed for %s -> s3://%s/%s: %s", local_path, bucket, key, e)
+        log.error("Local file retained at: %s", local_path)
+        return None
+
+    uri = f"s3://{bucket}/{key}"
+    log.info("Uploaded to %s", uri)
+
+    try:
+        os.remove(local_path)
+    except OSError as e:
+        # Upload succeeded — a stranded local copy is non-fatal, just noisy.
+        log.warning("Uploaded to S3 but could not delete local copy %s: %s", local_path, e)
+
+    return uri
+
+
+def deliver_output(local_path: str) -> str:
+    """
+    Post-save delivery hook: route a freshly-saved file to its destination.
+
+    Called by the ``save_*`` helpers after a file is written locally. If S3
+    delivery is active and an upload succeeds, returns the ``s3://`` URI (the
+    local copy is gone). Otherwise — local destination, no bucket, or a failed
+    upload — returns the original local path unchanged.
+
+    Args:
+        local_path: Path to the file just written to ``output/``.
+
+    Returns:
+        str: The S3 URI when uploaded, else the local path.
+    """
+    dest = resolve_s3_destination()
+    if not dest["enabled"]:
+        return local_path
+
+    uri = upload_to_s3(local_path, dest["bucket"], dest["prefix"])
+    return uri if uri else local_path
+
+
+def test_s3_connectivity(
+    bucket: str,
+    prefix: str = "stratusscan/",
+    region: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Run a full write roundtrip against a bucket and report which step failed.
+
+    Steps: ``HeadBucket`` → ``PutObject`` (probe file) → ``DeleteObject``
+    (cleanup). S3 permissions are notoriously fiddly, so each step's outcome is
+    captured individually with the verbatim boto3 error — no generic "failed"
+    messages. This is library code: it returns a structured result and never
+    prints; the CLI layer renders it.
+
+    Args:
+        bucket: Bucket to test.
+        prefix: Key prefix the probe object is written under.
+        region: Bucket region (resolved via GetBucketLocation if None).
+
+    Returns:
+        dict: ``{"ok": bool, "bucket": str, "region": str|None, "key": str,
+                 "steps": [{"step", "ok", "error"}], "failed_step": str|None}``
+    """
+    result: dict[str, Any] = {
+        "ok": False,
+        "bucket": bucket,
+        "region": region,
+        "key": None,
+        "steps": [],
+        "failed_step": None,
+    }
+
+    if not bucket:
+        result["steps"].append(
+            {"step": "config", "ok": False, "error": "No bucket configured."}
+        )
+        result["failed_step"] = "config"
+        return result
+
+    bootstrap = _s3_bootstrap_region()
+    if region is None:
+        region = _resolve_bucket_region(bucket, bootstrap) or bootstrap
+    result["region"] = region
+
+    key = _build_s3_key(prefix, "stratusscan-connectivity-test.txt")
+    result["key"] = key
+
+    def _run(step_name, fn) -> bool:
+        try:
+            fn()
+            result["steps"].append({"step": step_name, "ok": True, "error": None})
+            return True
+        except Exception as e:
+            result["steps"].append({"step": step_name, "ok": False, "error": str(e)})
+            result["failed_step"] = step_name
+            return False
+
+    try:
+        client = get_boto3_client("s3", region)
+    except Exception as e:
+        result["steps"].append({"step": "client", "ok": False, "error": str(e)})
+        result["failed_step"] = "client"
+        return result
+
+    if not _run("HeadBucket", lambda: client.head_bucket(Bucket=bucket)):
+        return result
+    if not _run(
+        "PutObject",
+        lambda: client.put_object(
+            Bucket=bucket, Key=key, Body=b"stratusscan connectivity test"
+        ),
+    ):
+        return result
+    if not _run("DeleteObject", lambda: client.delete_object(Bucket=bucket, Key=key)):
+        return result
+
+    result["ok"] = True
+    return result
+
 
 def detect_default_format() -> str:
     """
@@ -1189,7 +1449,7 @@ def aws_error_handler(
 
     Example:
         @aws_error_handler("Collecting IAM users", default_return=[])
-        def collect_iam_users() -> List[Dict[str, Any]]:
+        def collect_iam_users() -> list[dict[str, Any]]:
             iam = get_boto3_client('iam')
             users = []
             for user in iam.list_users()['Users']:


### PR DESCRIPTION
## Summary

Adds **S3 as an opt-in output destination** alongside `local`. Implements Issue #175 to its settled spec. Files are written to `output/` first, uploaded to the configured bucket, then the local copy is deleted on success (retained on failure as a fallback). This is the data-plane delivery piece the v1.0 Unattended Audit Mode runner writes to.

- `output_settings` config gains `destination` (`local`|`s3`) + `s3: {bucket, prefix}`
- `utils.upload_to_s3()` — retry/FIPS-aware via `get_boto3_client`; deletes local on success
- `utils.deliver_output()` — post-save hook in both `save_*` helpers; returns the `s3://` URI when uploaded
- `utils.resolve_s3_destination()` — config + `STRATUSSCAN_S3_BUCKET`/`_PREFIX` env override (headless/CI hook; forces S3 with no committed config.json)
- `utils.test_s3_connectivity()` — `HeadBucket → PutObject → DeleteObject`, verbatim per-step errors, structured return (no `print()`, Issue #171 compliant)
- `configure.py` — `[7] Output Settings` submenu (format/destination/bucket/prefix/Test S3 Connection) + dashboard row
- `policies/s3-upload-permissions.json` — write-only IAM grant, customer-agnostic placeholders

## Why

CloudShell file-download friction (the #175 motivation) and the foundation the scheduled CodeBuild runner uses to deliver exports to the central Audit bucket. Scanning stays read-only; the only write is a write-only `PutObject` to one designated bucket.

## Linked Issue(s)

Closes #175

## Validation

- [x] Unit tests — 18 new moto tests in `tests/test_s3_upload.py`, all passing
- [x] Manual verification — syntax + ruff (no new F/E9 errors in changed regions)
- [x] No regressions — full suite identical to clean `dev` (the one red test, `test_get_account_name_with_mapping`, fails pre-existingly on `dev` — unrelated, see #201)

```text
tests/test_s3_upload.py .................. [100%]
18 passed
```

## Risk Assessment

- Functional regression: **low** — additive; default `destination: local` preserves current behavior exactly
- Security impact: **low** — adds a single write-only S3 path; read-only scanning unchanged
- Deployment risk: **low**

## Notes / Follow-ups (separate issues)

1. `smart_scan/executor._find_output_file` globs local `output/*.xlsx` post-run — with S3 delivery the local files are gone, so interactive smart-scan would report "no output" on success. Moot for the headless runner (S3 event is the completion signal).
2. Pre-existing failing test `test_get_account_name_with_mapping` (patches a stale `ACCOUNT_MAPPINGS` global `get_account_name` no longer reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)