### PR TITLE
feat(export): empty-export suppression + per-run manifest (audit safety layer)

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -9,9 +9,10 @@
   "agency_name": "YOUR-AGENCY",
   "default_regions": ["us-east-1", "us-west-2"],
   "output_settings": {
-    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). Set via 'python configure.py' -> Output Settings.",
+    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). skip_empty_exports: when true, an exporter that finds no resources writes no spreadsheet (the run report still records it as 'ran, 0 assets'). Set via 'python configure.py' -> Output Settings.",
     "format": "xlsx",
     "destination": "local",
+    "skip_empty_exports": true,
     "s3": {
       "bucket": "",
       "prefix": "stratusscan/"

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Tests for empty-export suppression and the per-run manifest in utils.py
+(headless --run-all safety layer).
+
+Covers:
+- skip_empty_exports: empty data writes no file; returns the truthy sentinel
+- non-empty exports still write and return a real path
+- skip_empty=False writes empty files (opt-out)
+- multi-sheet: all-empty suppressed, partial written
+- run manifest (STRATUSSCAN_RUN_MANIFEST) records written/empty rows + context
+- manifest absent when the env var is unset
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+pd = pytest.importorskip("pandas")
+
+
+@pytest.fixture
+def out_dir(tmp_path, monkeypatch):
+    """Isolate exports to a tmp dir and make delivery a no-op passthrough."""
+    d = tmp_path / "output"
+    d.mkdir()
+    # save_* use the module-global `logger`, which is None until setup_logging();
+    # inject one so the save path doesn't AttributeError in the test process.
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-run-manifest"))
+    monkeypatch.setattr(utils, "get_output_dir", lambda: d)
+    # deliver_output is exercised by the S3 tests; here we want the local path back.
+    monkeypatch.setattr(utils, "deliver_output", lambda p: p)
+    return d
+
+
+def _config(monkeypatch, *, fmt="xlsx", skip_empty=True):
+    def fake_config_value(key, default=None, section=None):
+        return {"format": fmt, "skip_empty_exports": skip_empty}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+
+
+def _files(d):
+    return sorted(p.name for p in d.iterdir())
+
+
+class TestSkipEmptySingle:
+    def test_empty_df_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert result  # truthy → exporters' `if output_path:` success path holds
+        assert _files(out_dir) == []
+
+    def test_nonempty_df_written(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        df = pd.DataFrame({"InstanceId": ["i-1", "i-2"]})
+        result = utils.save_dataframe_to_excel(df, "acct-ec2-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-ec2-export-01.01.2026.xlsx"]
+
+    def test_skip_empty_disabled_writes_empty(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=False)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-ec2-export-01.01.2026.xlsx"]
+
+    def test_empty_csv_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, fmt="csv", skip_empty=True)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == []
+
+
+class TestSkipEmptyMulti:
+    def test_all_sheets_empty_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        sheets = {"VPCs": pd.DataFrame(), "Subnets": pd.DataFrame()}
+        result = utils.save_multiple_dataframes_to_excel(sheets, "acct-vpc-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == []
+
+    def test_partial_data_written(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        sheets = {"VPCs": pd.DataFrame({"VpcId": ["vpc-1"]}), "Subnets": pd.DataFrame()}
+        result = utils.save_multiple_dataframes_to_excel(sheets, "acct-vpc-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-vpc-export-01.01.2026.xlsx"]
+
+
+class TestRunManifest:
+    def test_records_written_export(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+        monkeypatch.setenv("STRATUSSCAN_CURRENT_EXPORTER", "ec2_export.py")
+        monkeypatch.setenv("STRATUSSCAN_ACCOUNT_ID", "123456789012")
+        monkeypatch.setenv("STRATUSSCAN_ACCOUNT_NAME", "PROD")
+        monkeypatch.setenv("STRATUSSCAN_REGIONS", "us-east-1,us-west-2")
+
+        df = pd.DataFrame({"InstanceId": ["i-1", "i-2", "i-3"]})
+        utils.save_dataframe_to_excel(df, "PROD-ec2-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        r = records[0]
+        assert r["exporter"] == "ec2_export.py"
+        assert r["account_id"] == "123456789012"
+        assert r["account_name"] == "PROD"
+        assert r["regions"] == "us-east-1,us-west-2"
+        assert r["rows"] == 3
+        assert r["status"] == "written"
+        assert r["file"] is not None
+
+    def test_records_empty_export(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+        monkeypatch.setenv("STRATUSSCAN_CURRENT_EXPORTER", "ec2_export.py")
+
+        utils.save_dataframe_to_excel(pd.DataFrame(), "PROD-ec2-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        assert records[0]["status"] == "empty"
+        assert records[0]["rows"] == 0
+        assert records[0]["file"] is None
+
+    def test_multi_sheet_records_per_sheet_counts(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+
+        sheets = {"VPCs": pd.DataFrame({"VpcId": ["vpc-1", "vpc-2"]}), "Subnets": pd.DataFrame({"SubnetId": ["s-1"]})}
+        utils.save_multiple_dataframes_to_excel(sheets, "PROD-vpc-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        assert records[0]["rows"] == 3
+        assert records[0]["sheets"] == {"VPCs": 2, "Subnets": 1}
+
+    def test_no_manifest_when_env_unset(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        monkeypatch.delenv("STRATUSSCAN_RUN_MANIFEST", raising=False)
+        manifest = tmp_path / "manifest.jsonl"
+
+        utils.save_dataframe_to_excel(pd.DataFrame({"x": [1]}), "PROD-ec2-export-01.01.2026.xlsx")
+        assert not manifest.exists()
+
+    def test_read_missing_manifest_returns_empty(self, tmp_path):
+        assert utils.read_run_manifest(str(tmp_path / "nope.jsonl")) == []

--- a/utils.py
+++ b/utils.py
@@ -955,6 +955,12 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
         if prepare:
             df = prepare_dataframe_for_export(df)
 
+        # Empty-export suppression + manifest accounting (applies to both formats)
+        rows = int(len(df))
+        skipped = _maybe_skip_empty(filename, rows)
+        if skipped is not None:
+            return skipped
+
         if fmt == "csv":
             # Normalise filename: strip .xlsx if caller passed it, force .csv
             if filename.endswith(".xlsx"):
@@ -966,7 +972,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             df.to_csv(output_path, index=False)
             logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-            return deliver_output(str(output_path))
+            return _finalize_export(str(output_path), rows)
 
         # --- xlsx path ---
         # Ensure the output directory exists
@@ -988,7 +994,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             df.to_excel(output_path, sheet_name=sheet_name, index=False)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return deliver_output(str(output_path))
+        return _finalize_export(str(output_path), rows)
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1031,6 +1037,14 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                 for sheet_name, df in dataframes_dict.items()
             }
 
+        # Per-sheet counts drive empty-suppression (skip only when ALL sheets are
+        # empty) and the manifest's asset accounting.
+        sheets = {name: int(len(df)) for name, df in dataframes_dict.items()}
+        total_rows = sum(sheets.values())
+        skipped = _maybe_skip_empty(filename, total_rows, sheets)
+        if skipped is not None:
+            return skipped
+
         output_dir = get_output_dir()
         os.makedirs(output_dir, exist_ok=True)
 
@@ -1051,7 +1065,11 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                 logger.info(_scrub_log(f"Data successfully exported to: {csv_path}"))
                 delivered.append(deliver_output(str(csv_path)))
 
-            return delivered[0] if delivered else None
+            first = delivered[0] if delivered else None
+            # One manifest line for the whole multi-sheet export (first CSV as the
+            # representative file), with per-sheet counts preserved.
+            _record_run_manifest(filename, total_rows, "written", first, sheets)
+            return first
 
         # --- xlsx path ---
         output_path = get_output_filepath(filename)
@@ -1083,7 +1101,7 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     _adjust_column_widths(writer.sheets[sheet_name], df)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return deliver_output(str(output_path))
+        return _finalize_export(str(output_path), total_rows, sheets)
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1348,6 +1366,137 @@ def test_s3_connectivity(
 
     result["ok"] = True
     return result
+
+
+# ---------------------------------------------------------------------------
+# Empty-export suppression + per-run manifest (audit run report)
+# ---------------------------------------------------------------------------
+#
+# Two coupled behaviours that make an unattended --run-all audit trustworthy:
+#
+#   * skip-empty — when an exporter produces no rows, no spreadsheet is written.
+#     This removes the noise of dozens of 0-row workbooks and, crucially, kills
+#     the "empty file looks like a broken exporter" false positive.
+#
+#   * run manifest — every save records what ran and how many assets it found
+#     (including the empties). The manifest is the authoritative answer to
+#     "EC2 was expected but no EC2 file exists — did it run?": yes, it ran and
+#     found 0. Suppression removes the file; the manifest removes the ambiguity.
+#
+# The manifest is written only when STRATUSSCAN_RUN_MANIFEST points at a file
+# (set by the --run-all orchestrator per exporter subprocess). Interactive
+# single exports get suppression but no manifest — their console message
+# ("No data found — export skipped") is the human-facing equivalent.
+
+# Returned by save_* when an empty export is intentionally suppressed. Truthy
+# so the universal exporter idiom `if output_path: log_success` does NOT fall
+# through to a misleading "save failed" error across the 100+ exporters.
+EMPTY_EXPORT_SENTINEL = "(no data found — export skipped)"
+
+
+def skip_empty_exports_enabled() -> bool:
+    """True when empty results should not produce a spreadsheet (default: on)."""
+    return bool(config_value("skip_empty_exports", default=True, section="output_settings"))
+
+
+def _record_run_manifest(
+    filename: str,
+    rows: int,
+    status: str,
+    file_location: Optional[str],
+    sheets: Optional[dict[str, int]] = None,
+) -> None:
+    """
+    Append one record to the per-run manifest if STRATUSSCAN_RUN_MANIFEST is set.
+
+    Best-effort: any failure here is logged at debug and swallowed — recording
+    a manifest line must never break an export. Account/exporter/region context
+    is read from env vars the orchestrator injects into each subprocess.
+
+    Args:
+        filename: The export filename (basename used as the resource hint).
+        rows: Total asset/row count across all sheets.
+        status: "written" or "empty".
+        file_location: Final delivered location (local path or s3:// URI), or None.
+        sheets: Optional per-sheet row counts.
+    """
+    manifest_path = os.environ.get("STRATUSSCAN_RUN_MANIFEST", "").strip()
+    if not manifest_path:
+        return
+
+    try:
+        record = {
+            "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+            "exporter": os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "").strip() or None,
+            "resource": os.path.basename(filename),
+            "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID", "").strip() or None,
+            "account_name": os.environ.get("STRATUSSCAN_ACCOUNT_NAME", "").strip() or None,
+            "regions": os.environ.get("STRATUSSCAN_REGIONS", "").strip() or None,
+            "rows": rows,
+            "status": status,
+            "file": file_location,
+            "sheets": sheets or None,
+        }
+        # Append-only JSONL; concurrent appends are avoided because exporters
+        # run sequentially, but a single write() of one line is atomic enough.
+        with open(manifest_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("stratusscan").debug("Run-manifest record failed: %s", e)
+
+
+def _maybe_skip_empty(
+    filename: str, rows: int, sheets: Optional[dict[str, int]] = None
+) -> Optional[str]:
+    """
+    Decide whether an export with ``rows`` total rows should be suppressed.
+
+    Returns the EMPTY_EXPORT_SENTINEL (and records an "empty" manifest line) when
+    there is no data and suppression is enabled; otherwise None (caller proceeds
+    to write). Centralises the empty-handling so every save path behaves alike.
+    """
+    if rows == 0 and skip_empty_exports_enabled():
+        logger.info("No data for %s — empty export skipped", os.path.basename(filename))
+        _record_run_manifest(filename, 0, "empty", None, sheets)
+        return EMPTY_EXPORT_SENTINEL
+    return None
+
+
+def _finalize_export(
+    local_path: str, rows: int, sheets: Optional[dict[str, int]] = None
+) -> str:
+    """
+    Common tail for every successful save: deliver the file (local or S3) and
+    record a "written" manifest line. Returns the final location (local path or
+    ``s3://`` URI).
+    """
+    final = deliver_output(local_path)
+    _record_run_manifest(local_path, rows, "written", final, sheets)
+    return final
+
+
+def read_run_manifest(manifest_path: str) -> list[dict[str, Any]]:
+    """
+    Read a per-run manifest (JSONL) into a list of records.
+
+    Malformed lines are skipped. Returns an empty list if the file is missing.
+    """
+    records: list[dict[str, Any]] = []
+    if not manifest_path or not os.path.exists(manifest_path):
+        return records
+    try:
+        with open(manifest_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError as e:
+        logging.getLogger("stratusscan").warning("Could not read run manifest %s: %s", manifest_path, e)
+    return records
 
 
 def detect_default_format() -> str:


### PR DESCRIPTION
## Summary

The first piece of the Phase 1 headless audit interface: a **safety layer** that makes an unattended `--run-all` run trustworthy. Implemented once at the shared `save_*` layer in `utils.py`, so all 100+ exporters inherit it with **no per-script edits**.

**Empty-export suppression** (`output_settings.skip_empty_exports`, default **true**):
- An exporter that finds no resources writes **no spreadsheet** — removes the noise of dozens of 0-row workbooks.
- `save_*` short-circuit before write/upload and return a *truthy* `EMPTY_EXPORT_SENTINEL`, so the universal `if output_path: log_success` idiom across the exporters does **not** fall through to a misleading "save failed" error.
- Multi-sheet exports are suppressed only when **all** sheets are empty.

**Per-run manifest** (`STRATUSSCAN_RUN_MANIFEST` env, set by the orchestrator per subprocess):
- Every save appends a JSONL record `{exporter, resource, account, regions, rows, status (written|empty), file, per-sheet counts}`.
- This is the authoritative answer to the real-world false positive — *"EC2 was expected but there's no EC2 file, did it even run?"* → **yes, it ran and found 0 assets.** Suppression removes the file; the manifest removes the ambiguity. The `--run-all` orchestrator (next PR) turns this into the spreadsheet run report.
- Best-effort: manifest IO failures never break an export. `read_run_manifest()` parses it back.

Also unifies all `save_*` return paths through `_finalize_export()`, which **closes a gap from #175** where single-sheet CSV exports were not S3-delivered.

## Why

> Built from Nick's requirements: ALL exporters run in an unattended audit, but empty results must not produce spreadsheets (noise), and there must be a report stating what ran / what was found / asset counts — because previously an empty/missing EC2 export was mistaken for a failure when the account simply had no EC2.

## Linked Issue(s)

Part of the v1.0 Unattended Audit Mode plan (Phase 1). Issues to be cut for the manifest/skip-empty work items.

## Validation

- [x] Unit tests — `tests/test_run_manifest.py` (11) + existing `tests/test_s3_upload.py` (18), all passing
- [x] No regressions — exporters + dataframe + smoke (146 passed), smart_scan (88 passed). Skip-empty-default-on broke zero exporter tests.

```text
tests/test_run_manifest.py ........... [11]
146 passed (exporters/dataframe/smoke) · 88 passed (smart_scan)
```

## Risk Assessment

- Functional regression: **low–medium** — `skip_empty_exports` defaults on, changing interactive behavior (empty results no longer write a file). Mitigated: clear `No <resource> found — export skipped` log; opt-out via config; full test pass.
- Security impact: **none**
- Deployment risk: **low**

## Note

Stacked on #199 (`feat/175-s3-upload`) — it builds on that PR's `deliver_output()`. Will retarget to `dev` once #199 merges. Review #199 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)