### PR TITLE
feat(cli): headless --run-all full-audit orchestrator + spreadsheet run report

### DIFF
--- a/stratusscan.py
+++ b/stratusscan.py
@@ -1257,6 +1257,146 @@ def navigate_menus():
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
+def _run_full_audit(regions_arg, output) -> None:
+    """
+    Headless full-audit run: execute every exporter non-interactively, write a
+    per-run manifest, then build and deliver a spreadsheet run report.
+
+    This is the command the scheduled CodeBuild runner invokes:
+        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
+
+    Args:
+        regions_arg: Comma-separated region string, or None for exporter defaults.
+        output: 'local', 's3', or None to honour the configured destination.
+
+    Exits the process: 1 on credential failure or zero successful exporters,
+    2 on an --output s3 request with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — full audit run")
+    print("=" * 60)
+
+    # 1. Credentials
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Full audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Account: {account_name} ({account_id})")
+
+    # 2. Regions
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+
+    # 3. Output destination — the flag is authoritative over config for this run
+    #    and for every exporter subprocess (inherited via os.environ).
+    if output:
+        os.environ["STRATUSSCAN_OUTPUT_DESTINATION"] = output
+    destination = utils.resolve_s3_destination()
+    if destination["enabled"]:
+        print(f"  Output: s3://{destination['bucket']}/{destination['prefix']}")
+    elif output == "s3":
+        utils.log_error("Full audit: --output s3 requested but no S3 bucket is configured")
+        print("  [x] --output s3 requires a bucket (config output_settings.s3.bucket")
+        print("      or the STRATUSSCAN_S3_BUCKET env var).")
+        sys.exit(2)
+    else:
+        print(f"  Output: local ({utils.get_output_dir()})")
+
+    # 4. Exporters — every *_export.py on disk
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Full audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+    total = len(exporters)
+    print(f"  Exporters: {total}")
+    print("=" * 60)
+
+    # 5. Fresh per-run manifest (children append; parent reads it afterward)
+    run_ts = utils.get_export_date()
+    manifest_path = utils.get_output_dir() / f"{account_name}-audit-run-manifest-{run_ts}.jsonl"
+    try:
+        if manifest_path.exists():
+            manifest_path.unlink()
+    except OSError:
+        pass
+
+    # 6. Run each exporter sequentially. Sequential is deliberate: parallel
+    #    subprocesses multiply API throttling and interleave logs — both bad for
+    #    evidence integrity. A failure never aborts the run; it lands in the report.
+    results = []
+    run_start = time.monotonic()
+    for idx, script_path in enumerate(exporters, 1):
+        name = script_path.name
+        print(f"\n[{idx}/{total}] {name}")
+
+        child_env = os.environ.copy()
+        child_env["STRATUSSCAN_AUTO_RUN"] = "1"
+        child_env["STRATUSSCAN_RUN_MANIFEST"] = str(manifest_path)
+        child_env["STRATUSSCAN_CURRENT_EXPORTER"] = name
+        child_env["STRATUSSCAN_ACCOUNT_ID"] = account_id or ""
+        child_env["STRATUSSCAN_ACCOUNT_NAME"] = account_name or ""
+        if regions:
+            child_env["STRATUSSCAN_REGIONS"] = ",".join(regions)
+
+        start = time.monotonic()
+        return_code = 0
+        error_message = None
+        try:
+            proc = subprocess.run([sys.executable, str(script_path)], env=child_env, timeout=1800)
+            return_code = proc.returncode
+        except subprocess.TimeoutExpired:
+            return_code, error_message = -1, "timed out (30 min)"
+            utils.log_error("Full audit: %s timed out", name)
+        except Exception as exc:  # noqa: BLE001
+            return_code, error_message = -1, str(exc)
+            utils.log_error("Full audit: %s error: %s", name, exc)
+
+        duration = time.monotonic() - start
+        results.append({
+            "script": name,
+            "success": return_code == 0,
+            "return_code": return_code,
+            "duration_seconds": duration,
+            "error_message": error_message,
+        })
+        print(f"      {'done' if return_code == 0 else 'FAILED'} ({duration:.0f}s)")
+
+    run_duration = time.monotonic() - run_start
+
+    # 7. Build + deliver the run report (delivers per destination; never empty,
+    #    so it is never suppressed). STRATUSSCAN_RUN_MANIFEST is intentionally
+    #    NOT set in this parent process, so the report does not record itself.
+    manifest_records = utils.read_run_manifest(str(manifest_path))
+    report_df = utils.build_run_report_dataframe(results, manifest_records)
+    report_filename = utils.create_export_filename(account_name, "audit-run-report")
+    report_location = utils.save_dataframe_to_excel(report_df, report_filename, sheet_name="Run Report")
+
+    # 8. Summary
+    counts = {}
+    if not report_df.empty:
+        counts = report_df["Status"].value_counts().to_dict()
+    n_ok = counts.get(utils.RUN_STATUS_OK, 0)
+    n_empty = counts.get(utils.RUN_STATUS_EMPTY, 0)
+    n_none = counts.get(utils.RUN_STATUS_NO_OUTPUT, 0)
+    n_failed = counts.get(utils.RUN_STATUS_FAILED, 0)
+    total_assets = int(report_df["Assets"].sum()) if not report_df.empty else 0
+
+    print("\n" + "=" * 60)
+    print("FULL AUDIT COMPLETE")
+    print("=" * 60)
+    print(f"  Exporters run : {total}  ({int(run_duration)}s total)")
+    print(f"  With data     : {n_ok}  ({total_assets} assets)")
+    print(f"  Empty (0)     : {n_empty}")
+    print(f"  No output     : {n_none}")
+    print(f"  Failed        : {n_failed}")
+    print(f"  Run report    : {report_location}")
+    print("=" * 60)
+
+    sys.exit(0 if results and n_ok > 0 else 1)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="stratusscan",
@@ -1275,6 +1415,22 @@ def _build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="enable debug-level console output",
+    )
+    parser.add_argument(
+        "--run-all",
+        action="store_true",
+        help="run every exporter non-interactively (headless full audit) and write a run report",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["local", "s3"],
+        default=None,
+        help="output destination for --run-all (overrides config; default: configured destination)",
+    )
+    parser.add_argument(
+        "--regions",
+        default=None,
+        help="comma-separated regions for --run-all (e.g. us-east-1,us-west-2)",
     )
     return parser
 
@@ -1329,6 +1485,10 @@ def main():
     if args.dry_run:
         _run_dry_run()
         return  # sys.exit(0) called inside, but be explicit
+
+    if args.run_all:
+        _run_full_audit(args.regions, args.output)
+        return  # sys.exit() called inside
 
     try:
         utils.log_section("STARTING MAIN MENU NAVIGATION")

--- a/tests/test_run_all_orchestrator.py
+++ b/tests/test_run_all_orchestrator.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the headless --run-all orchestrator (_run_full_audit in
+stratusscan.py).
+
+Uses tiny fake *_export.py subprocesses (stdlib only) that append a manifest
+record, so the test drives the real subprocess loop, manifest read, report
+build, report save, and exit-code logic without touching AWS.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+import stratusscan  # noqa: E402
+import utils  # noqa: E402
+
+pd = pytest.importorskip("pandas")
+
+
+WRITTEN_EXPORTER = '''\
+import os, json
+mp = os.environ["STRATUSSCAN_RUN_MANIFEST"]
+name = os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "")
+with open(mp, "a", encoding="utf-8") as f:
+    f.write(json.dumps({
+        "exporter": name, "resource": name, "rows": 7, "status": "written",
+        "file": "out/%s.xlsx" % name, "sheets": None,
+        "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID"),
+        "regions": os.environ.get("STRATUSSCAN_REGIONS"),
+    }) + "\\n")
+'''
+
+FAILING_EXPORTER = "import sys; sys.exit(1)\n"
+
+
+@pytest.fixture
+def audit_env(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+
+    monkeypatch.setattr(utils, "validate_aws_credentials", lambda: (True, "123456789012", "TESTACCT"))
+    monkeypatch.setattr(utils, "get_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(utils, "get_output_dir", lambda: out_dir)
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-orchestrator"))
+
+    def fake_config_value(key, default=None, section=None):
+        return {"format": "xlsx", "skip_empty_exports": True,
+                "destination": "local", "s3": {"bucket": "", "prefix": "stratusscan/"}}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+    monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+
+    return scripts_dir, out_dir
+
+
+def _write(scripts_dir, name, body):
+    (scripts_dir / name).write_text(body)
+
+
+class TestRunFullAudit:
+    def test_happy_path_builds_report_and_exits_zero(self, audit_env):
+        scripts_dir, out_dir = audit_env
+        _write(scripts_dir, "alpha_export.py", WRITTEN_EXPORTER)
+        _write(scripts_dir, "zeta_export.py", FAILING_EXPORTER)
+
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit("us-east-1,us-west-2", "local")
+        assert exc.value.code == 0  # at least one exporter succeeded
+
+        reports = list(out_dir.glob("*audit-run-report*.xlsx"))
+        assert len(reports) == 1
+
+        df = pd.read_excel(reports[0])
+        rows = {r["Exporter"]: r for r in df.to_dict("records")}
+        assert rows["alpha_export.py"]["Status"] == utils.RUN_STATUS_OK
+        assert rows["alpha_export.py"]["Assets"] == 7
+        assert rows["zeta_export.py"]["Status"] == utils.RUN_STATUS_FAILED
+
+        # The per-run manifest was written next to the report
+        assert list(out_dir.glob("*audit-run-manifest*.jsonl"))
+
+    def test_all_failed_exits_one(self, audit_env):
+        scripts_dir, out_dir = audit_env
+        _write(scripts_dir, "alpha_export.py", FAILING_EXPORTER)
+
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "local")
+        assert exc.value.code == 1
+
+    def test_no_exporters_exits_one(self, audit_env):
+        # empty scripts dir
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "local")
+        assert exc.value.code == 1
+
+    def test_output_s3_without_bucket_exits_two(self, audit_env):
+        scripts_dir, _ = audit_env
+        _write(scripts_dir, "alpha_export.py", WRITTEN_EXPORTER)
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "s3")
+        assert exc.value.code == 2

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Tests for the run-report builder (utils.build_run_report_dataframe) and the
+STRATUSSCAN_OUTPUT_DESTINATION override in resolve_s3_destination.
+
+The report merges per-script execution results with per-save manifest records
+into the four auditor-facing outcomes: OK, EMPTY, NO OUTPUT, FAILED.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+pytest.importorskip("pandas")
+
+
+def _rows_by_exporter(df):
+    return {r["Exporter"]: r for r in df.to_dict("records")}
+
+
+class TestBuildRunReport:
+    def _build(self):
+        executor_results = [
+            {"script": "ec2_export.py", "success": True, "return_code": 0, "duration_seconds": 3.2, "error_message": None},
+            {"script": "vpc_export.py", "success": True, "return_code": 0, "duration_seconds": 1.0, "error_message": None},
+            {"script": "rds_export.py", "success": True, "return_code": 0, "duration_seconds": 2.0, "error_message": None},
+            {"script": "iam_export.py", "success": False, "return_code": 1, "duration_seconds": 0.5, "error_message": "boom"},
+        ]
+        manifest_records = [
+            {"exporter": "ec2_export.py", "rows": 5, "status": "written", "file": "s3://b/ec2.xlsx", "sheets": None, "regions": "us-east-1"},
+            {"exporter": "vpc_export.py", "rows": 0, "status": "empty", "file": None, "sheets": {"VPCs": 0, "Subnets": 0}, "regions": "us-east-1"},
+            # rds_export.py: ran clean but never saved → NO OUTPUT
+            # iam_export.py: failed before/while saving → FAILED
+        ]
+        return utils.build_run_report_dataframe(executor_results, manifest_records)
+
+    def test_status_classification(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Status"] == utils.RUN_STATUS_OK
+        assert rows["vpc_export.py"]["Status"] == utils.RUN_STATUS_EMPTY
+        assert rows["rds_export.py"]["Status"] == utils.RUN_STATUS_NO_OUTPUT
+        assert rows["iam_export.py"]["Status"] == utils.RUN_STATUS_FAILED
+
+    def test_asset_counts(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Assets"] == 5
+        assert rows["vpc_export.py"]["Assets"] == 0
+        assert rows["rds_export.py"]["Assets"] == 0
+
+    def test_output_file_only_for_written(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Output File"] == "s3://b/ec2.xlsx"
+        assert rows["vpc_export.py"]["Output File"] == ""
+        assert rows["rds_export.py"]["Output File"] == ""
+
+    def test_failed_detail_carries_error(self):
+        rows = _rows_by_exporter(self._build())
+        assert "boom" in rows["iam_export.py"]["Detail"]
+
+    def test_sheets_rendered(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["vpc_export.py"]["Sheets"] == "VPCs:0, Subnets:0"
+
+    def test_sorted_by_exporter(self):
+        df = self._build()
+        assert list(df["Exporter"]) == sorted(df["Exporter"])
+
+    def test_empty_inputs_yield_empty_frame_with_columns(self):
+        df = utils.build_run_report_dataframe([], [])
+        assert df.empty
+        assert "Status" in df.columns and "Assets" in df.columns
+
+
+class TestOutputDestinationOverride:
+    def _config(self, monkeypatch, destination, bucket):
+        def fake(key, default=None, section=None):
+            return {
+                "destination": destination,
+                "s3": {"bucket": bucket, "prefix": "stratusscan/"},
+            }.get(key, default)
+        monkeypatch.setattr(utils, "config_value", fake)
+        for var in ("STRATUSSCAN_OUTPUT_DESTINATION", "STRATUSSCAN_S3_BUCKET", "STRATUSSCAN_S3_PREFIX"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_env_forces_s3(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="cfg-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "s3")
+        assert utils.resolve_s3_destination()["enabled"] is True
+
+    def test_env_forces_local_over_config_s3(self, monkeypatch):
+        self._config(monkeypatch, destination="s3", bucket="cfg-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_env_forces_local_over_bucket_env(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="")
+        monkeypatch.setenv("STRATUSSCAN_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+        # explicit local wins even though a bucket env is set
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_s3_force_without_bucket_not_enabled(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "s3")
+        assert utils.resolve_s3_destination()["enabled"] is False

--- a/utils.py
+++ b/utils.py
@@ -1129,10 +1129,14 @@ def resolve_s3_destination() -> dict[str, Any]:
     """
     Resolve the effective output destination from config + environment.
 
-    The ``STRATUSSCAN_S3_BUCKET`` env var is the headless/CI hook: when set it
-    forces S3 delivery regardless of the config ``destination`` value, so a
-    scheduled runner can route output to S3 without a committed config.json.
-    ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix the same way.
+    Resolution priority for the destination:
+      1. ``STRATUSSCAN_OUTPUT_DESTINATION`` env (``local``/``s3``) — authoritative;
+         this is how the ``--output`` flag forces a destination for the headless
+         orchestrator and every exporter subprocess it launches. ``local`` here
+         wins even if a bucket is configured.
+      2. ``STRATUSSCAN_S3_BUCKET`` env set — implies S3 (CI hook; no config.json
+         needed). ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix.
+      3. config ``output_settings.destination``.
 
     Returns:
         dict: ``{"enabled": bool, "bucket": str, "prefix": str}``.
@@ -1140,16 +1144,21 @@ def resolve_s3_destination() -> dict[str, Any]:
               is known.
     """
     settings = config_value("s3", default={}, section="output_settings") or {}
-    destination = config_value("destination", default="local", section="output_settings")
+    config_destination = str(config_value("destination", default="local", section="output_settings")).lower()
 
+    env_dest = os.environ.get("STRATUSSCAN_OUTPUT_DESTINATION", "").strip().lower()
     env_bucket = os.environ.get("STRATUSSCAN_S3_BUCKET", "").strip()
     env_prefix = os.environ.get("STRATUSSCAN_S3_PREFIX", "").strip()
 
     bucket = env_bucket or (settings.get("bucket", "") or "").strip()
     prefix = env_prefix or settings.get("prefix", "stratusscan/")
 
-    # S3 is active if the env var forced it OR config selected it.
-    selected = bool(env_bucket) or str(destination).lower() == "s3"
+    if env_dest in ("local", "s3"):
+        # Explicit flag override wins over everything (including a set bucket).
+        selected = env_dest == "s3"
+    else:
+        # Otherwise a set bucket env, or config, selects S3.
+        selected = bool(env_bucket) or config_destination == "s3"
 
     return {
         "enabled": bool(selected and bucket),
@@ -1497,6 +1506,103 @@ def read_run_manifest(manifest_path: str) -> list[dict[str, Any]]:
     except OSError as e:
         logging.getLogger("stratusscan").warning("Could not read run manifest %s: %s", manifest_path, e)
     return records
+
+
+# Run-report status vocabulary (one per exporter attempted in a --run-all run).
+RUN_STATUS_OK = "OK"                # exited clean, wrote at least one populated export
+RUN_STATUS_EMPTY = "EMPTY"          # exited clean, ran, found 0 assets (no file written)
+RUN_STATUS_NO_OUTPUT = "NO OUTPUT"  # exited clean but saved nothing (e.g. service N/A in partition)
+RUN_STATUS_FAILED = "FAILED"        # non-zero exit / crash / timeout
+
+
+def _format_sheets(sheets: Optional[dict[str, int]]) -> str:
+    """Render per-sheet counts as 'Sheet:rows, ...' for the report."""
+    if not sheets:
+        return ""
+    return ", ".join(f"{name}:{count}" for name, count in sheets.items())
+
+
+def build_run_report_dataframe(
+    executor_results: list[dict[str, Any]],
+    manifest_records: list[dict[str, Any]],
+):
+    """
+    Merge per-script execution results with per-save manifest records into a
+    single run-report DataFrame — the authoritative "what ran / what was found"
+    artifact for an unattended audit.
+
+    Each row is one exporter attempted, with a status that distinguishes the
+    four outcomes auditors care about: OK (data found), EMPTY (ran, 0 assets),
+    NO OUTPUT (ran clean but nothing to export — e.g. service not in partition),
+    and FAILED. The asset count is recorded even when no spreadsheet exists,
+    which is precisely what kills the "no EC2 file, did it run?" false positive.
+
+    Args:
+        executor_results: list of dicts with at least ``script``, ``success``,
+            ``return_code``, ``duration_seconds`` (ExecutionResult flattened).
+        manifest_records: records from :func:`read_run_manifest`.
+
+    Returns:
+        pandas.DataFrame sorted by exporter name.
+    """
+    import pandas as pd
+
+    # Index manifest records by exporter filename.
+    by_exporter: dict[str, list[dict[str, Any]]] = {}
+    for rec in manifest_records:
+        key = rec.get("exporter") or rec.get("resource") or ""
+        by_exporter.setdefault(key, []).append(rec)
+
+    rows: list[dict[str, Any]] = []
+    for res in executor_results:
+        exporter = res.get("script", "")
+        recs = by_exporter.get(exporter, [])
+        written = [r for r in recs if r.get("status") == "written"]
+        assets = sum(int(r.get("rows") or 0) for r in recs)
+
+        if not res.get("success", False):
+            status = RUN_STATUS_FAILED
+        elif written:
+            status = RUN_STATUS_OK
+        elif recs:  # only empty records
+            status = RUN_STATUS_EMPTY
+        else:
+            status = RUN_STATUS_NO_OUTPUT
+
+        file_loc = ""
+        if written:
+            file_loc = written[0].get("file") or ""
+
+        sheets_str = ""
+        for r in recs:
+            if r.get("sheets"):
+                sheets_str = _format_sheets(r.get("sheets"))
+                break
+
+        regions = ""
+        if recs and recs[0].get("regions"):
+            regions = recs[0]["regions"]
+
+        detail = ""
+        if status == RUN_STATUS_FAILED:
+            detail = (res.get("error_message") or f"exit code {res.get('return_code')}").strip()
+
+        rows.append({
+            "Exporter": exporter,
+            "Status": status,
+            "Assets": assets,
+            "Output File": file_loc,
+            "Sheets": sheets_str,
+            "Regions": regions,
+            "Duration (s)": round(float(res.get("duration_seconds") or 0), 1),
+            "Detail": detail,
+        })
+
+    columns = ["Exporter", "Status", "Assets", "Output File", "Sheets", "Regions", "Duration (s)", "Detail"]
+    df = pd.DataFrame(rows, columns=columns)
+    if not df.empty:
+        df = df.sort_values("Exporter").reset_index(drop=True)
+    return df
 
 
 def detect_default_format() -> str:


### PR DESCRIPTION
## Summary

The core of the Phase 1 headless interface — the command the scheduled CodeBuild runner invokes:

```
stratusscan --run-all --output s3 --regions us-east-1,us-west-2
```

**`stratusscan.py`**
- New flags `--run-all`, `--output {local,s3}`, `--regions` (alongside the existing Layer-2 flags). No flags → unchanged interactive menu.
- `_run_full_audit()`: validates credentials → resolves account + regions + destination → runs **every `scripts/*_export.py`** sequentially and headless (sets `STRATUSSCAN_AUTO_RUN`, and per-exporter `STRATUSSCAN_RUN_MANIFEST` / `STRATUSSCAN_CURRENT_EXPORTER` / account / region env) → builds and delivers a **spreadsheet run report**.
- Sequential **by design** — parallel subprocesses multiply API throttling and interleave logs, both bad for evidence integrity. A failed exporter never aborts the run; it lands in the report. Exit `1` on creds failure / zero successes, `2` on `--output s3` with no bucket, else `0`.

**`utils.py`**
- `build_run_report_dataframe()`: pure merge of per-script execution results with per-save manifest records → one row per exporter, classified **OK / EMPTY (ran, 0 assets) / NO OUTPUT (clean, nothing to export) / FAILED**, with asset counts. This is the artifact that resolves *"no EC2 file — did it run?"*.
- `resolve_s3_destination()`: `STRATUSSCAN_OUTPUT_DESTINATION` env (`local|s3`) is now the highest-priority override, so `--output` is authoritative for the run and every exporter subprocess (explicit `local` wins even over a configured bucket).

## Why

The headless run interface the v1.0 buildspec is written against, wired to the safety layer from #202: every exporter runs unattended, empty results produce no spreadsheet, and the run report states what ran / what was found / asset counts.

## Validation

- [x] `tests/test_run_report.py` (11) — status classification, asset sums, output-file gating, sheets, sort, destination-override matrix
- [x] `tests/test_run_all_orchestrator.py` (4) — end-to-end `--run-all` over fake exporter subprocesses: report build + content, exit codes (0/1/1/2)
- [x] 145 passed across new-feature + smoke suites; no new ruff F/E9 in changed code
- [x] `stratusscan --help` shows the new flags; no-flag path still drops to the interactive menu

## Risk Assessment

- Functional regression: **low** — purely additive; the interactive path is untouched when no flags are passed.
- Security impact: **none** — read-only scanning; only the existing write-only S3 path.
- Deployment risk: **low**

## Note

Stacked on **#202** (`feat/run-manifest-skip-empty`) → **#199** (`feat/175-s3-upload`). Review/merge order: #199 → #202 → this. Will retarget to `dev` as the stack lands.

## Remaining Phase 1 (separate PRs)
- `--org-scan --scan-role <name>` — Organizations enumeration, looping this orchestrator per account
- Version-drift detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)