### PR TITLE
feat(cli): organization-wide headless audit (--org-scan --scan-role)

### DIFF
--- a/stratusscan.py
+++ b/stratusscan.py
@@ -1257,79 +1257,66 @@ def navigate_menus():
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-def _run_full_audit(regions_arg, output) -> None:
+def _safe_label(name) -> str:
+    """Sanitise an account name for use in a filename (alnum, dot, dash, underscore)."""
+    import re
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", (name or "").strip()).strip("-") or "account"
+
+
+def _resolve_audit_destination(output):
     """
-    Headless full-audit run: execute every exporter non-interactively, write a
-    per-run manifest, then build and deliver a spreadsheet run report.
-
-    This is the command the scheduled CodeBuild runner invokes:
-        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
-
-    Args:
-        regions_arg: Comma-separated region string, or None for exporter defaults.
-        output: 'local', 's3', or None to honour the configured destination.
-
-    Exits the process: 1 on credential failure or zero successful exporters,
-    2 on an --output s3 request with no bucket, 0 otherwise.
+    Apply the --output flag (authoritative over config for this run and every
+    exporter subprocess), print the resolved destination, and return it.
+    Exits 2 if --output s3 was requested with no bucket configured.
     """
-    print("\nStratusScanCLI-AWS — full audit run")
-    print("=" * 60)
-
-    # 1. Credentials
-    ok, account_id, account_name = utils.validate_aws_credentials()
-    if not ok:
-        utils.log_error("Full audit: AWS credentials not found or invalid")
-        print("  [x] AWS credentials: not found or invalid")
-        sys.exit(1)
-    print(f"  Account: {account_name} ({account_id})")
-
-    # 2. Regions
-    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
-    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
-
-    # 3. Output destination — the flag is authoritative over config for this run
-    #    and for every exporter subprocess (inherited via os.environ).
     if output:
         os.environ["STRATUSSCAN_OUTPUT_DESTINATION"] = output
     destination = utils.resolve_s3_destination()
     if destination["enabled"]:
         print(f"  Output: s3://{destination['bucket']}/{destination['prefix']}")
     elif output == "s3":
-        utils.log_error("Full audit: --output s3 requested but no S3 bucket is configured")
+        utils.log_error("Audit: --output s3 requested but no S3 bucket is configured")
         print("  [x] --output s3 requires a bucket (config output_settings.s3.bucket")
         print("      or the STRATUSSCAN_S3_BUCKET env var).")
         sys.exit(2)
     else:
         print(f"  Output: local ({utils.get_output_dir()})")
+    return destination
 
-    # 4. Exporters — every *_export.py on disk
-    scripts_dir = utils.get_scripts_dir()
-    exporters = sorted(scripts_dir.glob("*_export.py"))
-    if not exporters:
-        utils.log_error("Full audit: no exporter scripts found")
-        print("  [x] No exporter scripts found.")
-        sys.exit(1)
-    total = len(exporters)
-    print(f"  Exporters: {total}")
-    print("=" * 60)
 
-    # 5. Fresh per-run manifest (children append; parent reads it afterward)
-    run_ts = utils.get_export_date()
-    manifest_path = utils.get_output_dir() / f"{account_name}-audit-run-manifest-{run_ts}.jsonl"
+def _audit_counts(report_df) -> dict:
+    """Tally per-status counts and total assets from a run-report DataFrame."""
+    counts = report_df["Status"].value_counts().to_dict() if not report_df.empty else {}
+    return {
+        "ok": counts.get(utils.RUN_STATUS_OK, 0),
+        "empty": counts.get(utils.RUN_STATUS_EMPTY, 0),
+        "no_output": counts.get(utils.RUN_STATUS_NO_OUTPUT, 0),
+        "failed": counts.get(utils.RUN_STATUS_FAILED, 0),
+        "total_assets": int(report_df["Assets"].sum()) if not report_df.empty else 0,
+    }
+
+
+def _run_exporters_for_account(exporters, account_id, account_name, regions, role_arn, manifest_path) -> list:
+    """
+    Run every exporter once for a single account, optionally via an assumed role.
+
+    Sequential by design: parallel subprocesses multiply API throttling and
+    interleave logs — both bad for evidence integrity. A failed exporter never
+    aborts the run; it lands in the report. Returns a list of per-exporter
+    result dicts (script, success, return_code, duration_seconds, error_message).
+    """
+    # Fresh manifest for this account (children append; parent reads it after).
     try:
         if manifest_path.exists():
             manifest_path.unlink()
     except OSError:
         pass
 
-    # 6. Run each exporter sequentially. Sequential is deliberate: parallel
-    #    subprocesses multiply API throttling and interleave logs — both bad for
-    #    evidence integrity. A failure never aborts the run; it lands in the report.
     results = []
-    run_start = time.monotonic()
+    total = len(exporters)
     for idx, script_path in enumerate(exporters, 1):
         name = script_path.name
-        print(f"\n[{idx}/{total}] {name}")
+        print(f"  [{idx}/{total}] {name}")
 
         child_env = os.environ.copy()
         child_env["STRATUSSCAN_AUTO_RUN"] = "1"
@@ -1339,6 +1326,8 @@ def _run_full_audit(regions_arg, output) -> None:
         child_env["STRATUSSCAN_ACCOUNT_NAME"] = account_name or ""
         if regions:
             child_env["STRATUSSCAN_REGIONS"] = ",".join(regions)
+        if role_arn:
+            child_env["STRATUSSCAN_ROLE_ARN"] = role_arn
 
         start = time.monotonic()
         return_code = 0
@@ -1348,10 +1337,10 @@ def _run_full_audit(regions_arg, output) -> None:
             return_code = proc.returncode
         except subprocess.TimeoutExpired:
             return_code, error_message = -1, "timed out (30 min)"
-            utils.log_error("Full audit: %s timed out", name)
+            utils.log_error(f"Audit: {name} timed out (account {account_id})")
         except Exception as exc:  # noqa: BLE001
             return_code, error_message = -1, str(exc)
-            utils.log_error("Full audit: %s error: %s", name, exc)
+            utils.log_error(f"Audit: {name} error (account {account_id})", exc)
 
         duration = time.monotonic() - start
         results.append({
@@ -1361,40 +1350,195 @@ def _run_full_audit(regions_arg, output) -> None:
             "duration_seconds": duration,
             "error_message": error_message,
         })
-        print(f"      {'done' if return_code == 0 else 'FAILED'} ({duration:.0f}s)")
+    return results
 
-    run_duration = time.monotonic() - run_start
 
-    # 7. Build + deliver the run report (delivers per destination; never empty,
-    #    so it is never suppressed). STRATUSSCAN_RUN_MANIFEST is intentionally
-    #    NOT set in this parent process, so the report does not record itself.
+def _build_and_deliver_report(results, manifest_path, account_label):
+    """Build the run report from results + manifest and deliver it. Returns
+    (report_df, report_location)."""
     manifest_records = utils.read_run_manifest(str(manifest_path))
     report_df = utils.build_run_report_dataframe(results, manifest_records)
-    report_filename = utils.create_export_filename(account_name, "audit-run-report")
+    report_filename = utils.create_export_filename(account_label, "audit-run-report")
     report_location = utils.save_dataframe_to_excel(report_df, report_filename, sheet_name="Run Report")
+    return report_df, report_location
 
-    # 8. Summary
-    counts = {}
-    if not report_df.empty:
-        counts = report_df["Status"].value_counts().to_dict()
-    n_ok = counts.get(utils.RUN_STATUS_OK, 0)
-    n_empty = counts.get(utils.RUN_STATUS_EMPTY, 0)
-    n_none = counts.get(utils.RUN_STATUS_NO_OUTPUT, 0)
-    n_failed = counts.get(utils.RUN_STATUS_FAILED, 0)
-    total_assets = int(report_df["Assets"].sum()) if not report_df.empty else 0
+
+def _run_full_audit(regions_arg, output) -> None:
+    """
+    Headless single-account full-audit run: execute every exporter
+    non-interactively, write a per-run manifest, then build and deliver a
+    spreadsheet run report.
+
+        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
+
+    Exits: 1 on credential failure or zero successful exporters, 2 on
+    --output s3 with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — full audit run")
+    print("=" * 60)
+
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Full audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Account: {account_name} ({account_id})")
+
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+
+    _resolve_audit_destination(output)
+
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Full audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+    print(f"  Exporters: {len(exporters)}")
+    print("=" * 60)
+
+    run_ts = utils.get_export_date()
+    label = _safe_label(account_name)
+    manifest_path = utils.get_output_dir() / f"{label}-audit-run-manifest-{run_ts}.jsonl"
+
+    run_start = time.monotonic()
+    results = _run_exporters_for_account(exporters, account_id, account_name, regions, None, manifest_path)
+    run_duration = time.monotonic() - run_start
+
+    report_df, report_location = _build_and_deliver_report(results, manifest_path, label)
+    c = _audit_counts(report_df)
 
     print("\n" + "=" * 60)
     print("FULL AUDIT COMPLETE")
     print("=" * 60)
-    print(f"  Exporters run : {total}  ({int(run_duration)}s total)")
-    print(f"  With data     : {n_ok}  ({total_assets} assets)")
-    print(f"  Empty (0)     : {n_empty}")
-    print(f"  No output     : {n_none}")
-    print(f"  Failed        : {n_failed}")
+    print(f"  Exporters run : {len(exporters)}  ({int(run_duration)}s total)")
+    print(f"  With data     : {c['ok']}  ({c['total_assets']} assets)")
+    print(f"  Empty (0)     : {c['empty']}")
+    print(f"  No output     : {c['no_output']}")
+    print(f"  Failed        : {c['failed']}")
     print(f"  Run report    : {report_location}")
     print("=" * 60)
 
-    sys.exit(0 if results and n_ok > 0 else 1)
+    sys.exit(0 if results and c["ok"] > 0 else 1)
+
+
+def _run_org_audit(regions_arg, output, scan_role, exclude_arg) -> None:
+    """
+    Headless organization-wide audit: from the audit account, enumerate every
+    active org account, assume the uniformly-named read-only scan role in each,
+    run the full exporter set, deliver a per-account run report, then deliver an
+    org-level summary rolling up every account.
+
+        stratusscan --org-scan --scan-role StratusScanReadOnly --output s3 --regions us-east-1
+
+    Accounts whose scan role cannot be assumed are skipped and recorded as
+    ROLE FAILED in the summary (the StackSet may still be rolling out) — the run
+    is not aborted. Exits: 1 on credential / enumeration failure or zero
+    accounts scanned, 2 on --output s3 with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — organization audit run")
+    print("=" * 60)
+
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Org audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Audit account: {account_name} ({account_id})")
+
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+    print(f"  Scan role: {scan_role}")
+
+    _resolve_audit_destination(output)
+    partition = utils.detect_partition()
+
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Org audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+
+    # Enumerate the organization from the audit account.
+    try:
+        accounts = utils.list_organization_accounts(active_only=True)
+    except Exception as exc:  # noqa: BLE001
+        utils.log_error("Org audit: organizations:ListAccounts failed", exc)
+        print(f"  [x] Could not list organization accounts: {exc}")
+        print("      The audit account needs Organizations read access (management or")
+        print("      delegated administrator).")
+        sys.exit(1)
+
+    exclude = {a.strip() for a in exclude_arg.split(",") if a.strip()} if exclude_arg else set()
+    accounts = [a for a in accounts if a["id"] not in exclude]
+    if not accounts:
+        print("  [x] No active accounts to scan.")
+        sys.exit(1)
+    print(f"  Accounts: {len(accounts)} active" + (f"  ({len(exclude)} excluded)" if exclude else ""))
+    print(f"  Exporters: {len(exporters)} per account")
+    print("=" * 60)
+
+    run_ts = utils.get_export_date()
+    summaries = []
+    n_scanned = 0
+    org_start = time.monotonic()
+
+    for i, acct in enumerate(accounts, 1):
+        aid = acct["id"]
+        aname = acct["name"] or aid
+        print(f"\n[account {i}/{len(accounts)}] {aname} ({aid})")
+
+        role_arn = utils.build_arn("iam", f"role/{scan_role}", region="", account_id=aid, partition=partition)
+        assumable, err = utils.verify_assume_role(role_arn, regions[0] if regions else None)
+        if not assumable:
+            print(f"  [skip] cannot assume {role_arn}")
+            print(f"         {err}")
+            utils.log_error(f"Org audit: assume-role failed for {aid}: {err}")
+            summaries.append({
+                "account_id": aid, "account_name": aname,
+                "status": utils.ACCOUNT_STATUS_ROLE_FAILED,
+                "exporters": 0, "ok": 0, "empty": 0, "no_output": 0, "failed": 0,
+                "total_assets": 0, "report": "", "detail": (err or "")[:300],
+            })
+            continue
+
+        label = f"{_safe_label(aname)}-{aid}"
+        manifest_path = utils.get_output_dir() / f"{label}-audit-run-manifest-{run_ts}.jsonl"
+        results = _run_exporters_for_account(exporters, aid, aname, regions, role_arn, manifest_path)
+        report_df, report_loc = _build_and_deliver_report(results, manifest_path, label)
+        c = _audit_counts(report_df)
+        n_scanned += 1
+        summaries.append({
+            "account_id": aid, "account_name": aname,
+            "status": utils.ACCOUNT_STATUS_SCANNED,
+            "exporters": len(results), "ok": c["ok"], "empty": c["empty"],
+            "no_output": c["no_output"], "failed": c["failed"],
+            "total_assets": c["total_assets"], "report": report_loc or "", "detail": "",
+        })
+        print(f"  done — {c['ok']} with data, {c['total_assets']} assets, {c['failed']} failed")
+
+    org_duration = time.monotonic() - org_start
+
+    # Org-level summary roll-up — the top-level index over per-account reports.
+    summary_df = utils.build_org_summary_dataframe(summaries)
+    summary_filename = utils.create_export_filename(f"{_safe_label(account_name)}-ORG", "org-audit-summary")
+    summary_loc = utils.save_dataframe_to_excel(summary_df, summary_filename, sheet_name="Org Summary")
+
+    n_role_failed = sum(1 for s in summaries if s["status"] == utils.ACCOUNT_STATUS_ROLE_FAILED)
+    total_assets = sum(s["total_assets"] for s in summaries)
+
+    print("\n" + "=" * 60)
+    print("ORGANIZATION AUDIT COMPLETE")
+    print("=" * 60)
+    print(f"  Accounts        : {len(accounts)}  ({int(org_duration)}s total)")
+    print(f"  Scanned         : {n_scanned}  ({total_assets} assets)")
+    print(f"  Role failed     : {n_role_failed}")
+    print(f"  Org summary     : {summary_loc}")
+    print("=" * 60)
+
+    sys.exit(0 if n_scanned > 0 else 1)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1431,6 +1575,23 @@ def _build_parser() -> argparse.ArgumentParser:
         "--regions",
         default=None,
         help="comma-separated regions for --run-all (e.g. us-east-1,us-west-2)",
+    )
+    parser.add_argument(
+        "--org-scan",
+        action="store_true",
+        help="run the full audit across every active account in the AWS Organization (requires --scan-role)",
+    )
+    parser.add_argument(
+        "--scan-role",
+        default=None,
+        metavar="NAME",
+        help="name of the read-only role to assume in each org account (with --org-scan)",
+    )
+    parser.add_argument(
+        "--exclude-accounts",
+        default=None,
+        metavar="IDS",
+        help="comma-separated account IDs to skip during --org-scan",
     )
     return parser
 
@@ -1485,6 +1646,13 @@ def main():
     if args.dry_run:
         _run_dry_run()
         return  # sys.exit(0) called inside, but be explicit
+
+    if args.org_scan:
+        if not args.scan_role:
+            print("--org-scan requires --scan-role <name> (the role to assume in each account)")
+            sys.exit(2)
+        _run_org_audit(args.regions, args.output, args.scan_role, args.exclude_accounts)
+        return  # sys.exit() called inside
 
     if args.run_all:
         _run_full_audit(args.regions, args.output)

--- a/tests/test_org_scan.py
+++ b/tests/test_org_scan.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Tests for organization-wide scanning (--org-scan):
+- utils.list_organization_accounts (active filter)
+- utils.verify_assume_role (assume-role preflight)
+- utils.build_org_summary_dataframe (roll-up)
+- stratusscan._run_org_audit (per-account reports + summary, role-failed skip)
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+import stratusscan  # noqa: E402
+import utils  # noqa: E402
+
+pd = pytest.importorskip("pandas")
+
+
+# --- list_organization_accounts ------------------------------------------------
+
+class _FakePaginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeOrgClient:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def get_paginator(self, name):
+        assert name == "list_accounts"
+        return _FakePaginator(self._pages)
+
+
+class TestListOrganizationAccounts:
+    PAGES = [{
+        "Accounts": [
+            {"Id": "111111111111", "Name": "Audit", "Email": "a@x", "Status": "ACTIVE"},
+            {"Id": "222222222222", "Name": "Prod", "Email": "p@x", "Status": "ACTIVE"},
+            {"Id": "333333333333", "Name": "Old", "Email": "o@x", "Status": "SUSPENDED"},
+        ]
+    }]
+
+    def test_active_only_filters_suspended(self, monkeypatch):
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _FakeOrgClient(self.PAGES))
+        accounts = utils.list_organization_accounts(active_only=True)
+        ids = [a["id"] for a in accounts]
+        assert ids == ["111111111111", "222222222222"]
+        assert accounts[0]["name"] == "Audit"
+
+    def test_include_inactive(self, monkeypatch):
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _FakeOrgClient(self.PAGES))
+        assert len(utils.list_organization_accounts(active_only=False)) == 3
+
+
+# --- verify_assume_role --------------------------------------------------------
+
+class TestVerifyAssumeRole:
+    def test_success(self, monkeypatch):
+        class _STS:
+            def get_caller_identity(self):
+                return {"Account": "222222222222"}
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _STS())
+        ok, err = utils.verify_assume_role("arn:aws:iam::222222222222:role/Scan")
+        assert ok is True and err is None
+
+    def test_failure_returns_error(self, monkeypatch):
+        def _boom(*a, **k):
+            raise Exception("AccessDenied: not authorized to assume role")
+        monkeypatch.setattr(utils, "get_boto3_client", _boom)
+        ok, err = utils.verify_assume_role("arn:aws:iam::333333333333:role/Scan")
+        assert ok is False
+        assert "AccessDenied" in err
+
+
+# --- build_org_summary_dataframe ----------------------------------------------
+
+class TestOrgSummary:
+    def test_rollup_rows_and_columns(self):
+        summaries = [
+            {"account_id": "222", "account_name": "Prod", "status": utils.ACCOUNT_STATUS_SCANNED,
+             "exporters": 2, "ok": 1, "empty": 1, "no_output": 0, "failed": 0,
+             "total_assets": 7, "report": "s3://b/prod.xlsx", "detail": ""},
+            {"account_id": "333", "account_name": "Dev", "status": utils.ACCOUNT_STATUS_ROLE_FAILED,
+             "exporters": 0, "ok": 0, "empty": 0, "no_output": 0, "failed": 0,
+             "total_assets": 0, "report": "", "detail": "AccessDenied"},
+        ]
+        df = utils.build_org_summary_dataframe(summaries)
+        assert list(df["Account"]) == ["Dev", "Prod"]  # sorted
+        prod = {r["Account"]: r for r in df.to_dict("records")}["Prod"]
+        assert prod["Status"] == utils.ACCOUNT_STATUS_SCANNED
+        assert prod["Total Assets"] == 7
+        assert prod["Report"] == "s3://b/prod.xlsx"
+        for col in ("Account ID", "Status", "With Data", "Failed", "Total Assets", "Report"):
+            assert col in df.columns
+
+    def test_empty_inputs(self):
+        df = utils.build_org_summary_dataframe([])
+        assert df.empty and "Status" in df.columns
+
+
+# --- _run_org_audit integration ------------------------------------------------
+
+WRITTEN_EXPORTER = '''\
+import os, json
+mp = os.environ["STRATUSSCAN_RUN_MANIFEST"]
+name = os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "")
+with open(mp, "a", encoding="utf-8") as f:
+    f.write(json.dumps({"exporter": name, "resource": name, "rows": 7,
+                        "status": "written", "file": "x.xlsx", "sheets": None,
+                        "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID")}) + "\\n")
+'''
+
+
+@pytest.fixture
+def org_env(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "alpha_export.py").write_text(WRITTEN_EXPORTER)
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+
+    monkeypatch.setattr(utils, "validate_aws_credentials", lambda: (True, "111111111111", "AUDIT"))
+    monkeypatch.setattr(utils, "detect_partition", lambda *a, **k: "aws")
+    monkeypatch.setattr(utils, "get_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(utils, "get_output_dir", lambda: out_dir)
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-org"))
+
+    monkeypatch.setattr(utils, "list_organization_accounts", lambda active_only=True: [
+        {"id": "222222222222", "name": "Prod", "email": "", "status": "ACTIVE"},
+        {"id": "333333333333", "name": "Dev", "email": "", "status": "ACTIVE"},
+    ])
+
+    # Prod assumable, Dev not (StackSet not yet rolled out there).
+    def fake_verify(role_arn, region_name=None):
+        return ("222222222222" in role_arn, None if "222222222222" in role_arn else "AccessDenied")
+    monkeypatch.setattr(utils, "verify_assume_role", fake_verify)
+
+    def fake_config_value(key, default=None, section=None):
+        return {"format": "xlsx", "skip_empty_exports": True,
+                "destination": "local", "s3": {"bucket": "", "prefix": "stratusscan/"}}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+    monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+
+    return out_dir
+
+
+class TestRunOrgAudit:
+    def test_per_account_reports_and_summary(self, org_env):
+        out_dir = org_env
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", None)
+        assert exc.value.code == 0  # at least one account scanned
+
+        # Prod (assumable) got a per-account run report; Dev (role failed) did not.
+        prod_reports = list(out_dir.glob("Prod-222222222222-audit-run-report*.xlsx"))
+        dev_reports = list(out_dir.glob("Dev-333333333333-audit-run-report*.xlsx"))
+        assert len(prod_reports) == 1
+        assert dev_reports == []
+
+        summaries = list(out_dir.glob("*org-audit-summary*.xlsx"))
+        assert len(summaries) == 1
+        df = pd.read_excel(summaries[0])
+        rows = {r["Account"]: r for r in df.to_dict("records")}
+        assert rows["Prod"]["Status"] == utils.ACCOUNT_STATUS_SCANNED
+        assert rows["Prod"]["Total Assets"] == 7
+        assert rows["Dev"]["Status"] == utils.ACCOUNT_STATUS_ROLE_FAILED
+
+    def test_all_role_failed_exits_one(self, org_env, monkeypatch):
+        monkeypatch.setattr(utils, "verify_assume_role", lambda role_arn, region_name=None: (False, "AccessDenied"))
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", None)
+        assert exc.value.code == 1
+
+    def test_exclude_accounts(self, org_env):
+        out_dir = org_env
+        with pytest.raises(SystemExit):
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", "222222222222")
+        # Prod excluded → only Dev considered (role-failed) → no Prod report
+        assert list(out_dir.glob("Prod-*audit-run-report*.xlsx")) == []

--- a/utils.py
+++ b/utils.py
@@ -1605,6 +1605,116 @@ def build_run_report_dataframe(
     return df
 
 
+# ---------------------------------------------------------------------------
+# Organization-wide scanning (--org-scan): account enumeration + roll-up
+# ---------------------------------------------------------------------------
+#
+# The headless org audit runs from one account (the Audit account), enumerates
+# every active account in the AWS Organization, assumes a uniformly-named
+# read-only scan role in each, and runs the full exporter set per account. This
+# matches the StackSet model where one role name exists org-wide.
+
+# Org-account scan outcomes for the roll-up summary.
+ACCOUNT_STATUS_SCANNED = "SCANNED"        # role assumed, exporters ran
+ACCOUNT_STATUS_ROLE_FAILED = "ROLE FAILED"  # could not assume the scan role — skipped
+
+
+def list_organization_accounts(active_only: bool = True) -> list[dict[str, str]]:
+    """
+    Enumerate accounts in the AWS Organization via ``organizations:ListAccounts``.
+
+    Runs from the management or a delegated-admin account. Library code: returns
+    structured data and never prints.
+
+    Args:
+        active_only: When True (default), only ``ACTIVE`` accounts are returned
+            (SUSPENDED / PENDING_CLOSURE accounts are skipped).
+
+    Returns:
+        list of ``{"id", "name", "email", "status"}`` dicts.
+
+    Raises:
+        Propagates botocore errors (e.g. AccessDenied when the caller lacks
+        Organizations read access) so the caller can report them verbatim.
+    """
+    client = get_boto3_client("organizations")
+    accounts: list[dict[str, str]] = []
+    paginator = client.get_paginator("list_accounts")
+    for page in paginator.paginate():
+        for a in page.get("Accounts", []):
+            status = a.get("Status", "")
+            if active_only and status != "ACTIVE":
+                continue
+            accounts.append({
+                "id": a.get("Id", ""),
+                "name": a.get("Name", ""),
+                "email": a.get("Email", ""),
+                "status": status,
+            })
+    return accounts
+
+
+def verify_assume_role(role_arn: str, region_name: Optional[str] = None) -> tuple[bool, Optional[str]]:
+    """
+    Pre-flight an STS AssumeRole so a non-assumable account can be skipped before
+    launching 100+ doomed exporter subprocesses.
+
+    Args:
+        role_arn: The scan role ARN to assume.
+        region_name: Optional region (drives FIPS endpoint selection in GovCloud).
+
+    Returns:
+        ``(True, None)`` if the role is assumable, else ``(False, error_string)``
+        with the verbatim error for the run report.
+    """
+    try:
+        sts = get_boto3_client("sts", region_name, role_arn=role_arn)
+        sts.get_caller_identity()
+        return True, None
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+
+
+def build_org_summary_dataframe(account_summaries: list[dict[str, Any]]):
+    """
+    Roll up per-account audit outcomes into one org-level summary DataFrame —
+    one row per account, the top-level index over the per-account run reports.
+
+    Args:
+        account_summaries: list of dicts with keys ``account_id``,
+            ``account_name``, ``status`` (ACCOUNT_STATUS_*), ``exporters``,
+            ``ok``, ``empty``, ``no_output``, ``failed``, ``total_assets``,
+            ``report`` (delivered location or ""), and optional ``detail``.
+
+    Returns:
+        pandas.DataFrame sorted by account name.
+    """
+    import pandas as pd
+
+    rows = []
+    for s in account_summaries:
+        rows.append({
+            "Account ID": s.get("account_id", ""),
+            "Account": s.get("account_name", ""),
+            "Status": s.get("status", ""),
+            "Exporters": s.get("exporters", 0),
+            "With Data": s.get("ok", 0),
+            "Empty": s.get("empty", 0),
+            "No Output": s.get("no_output", 0),
+            "Failed": s.get("failed", 0),
+            "Total Assets": s.get("total_assets", 0),
+            "Report": s.get("report", ""),
+            "Detail": s.get("detail", ""),
+        })
+
+    columns = ["Account ID", "Account", "Status", "Exporters", "With Data",
+               "Empty", "No Output", "Failed", "Total Assets", "Report", "Detail"]
+    df = pd.DataFrame(rows, columns=columns)
+    if not df.empty:
+        df = df.sort_values("Account").reset_index(drop=True)
+    return df
+
+
 def detect_default_format() -> str:
     """
     Detect the default export format based on available dependencies.


### PR DESCRIPTION
## Summary

The multi-account wrapper around the `--run-all` orchestrator — the **full v1.0 scheduled command**:

```
stratusscan --org-scan --scan-role StratusScanReadOnly --output s3 --regions us-east-1
```

From the audit account: enumerate every active org account → assume the uniformly-named read-only scan role in each (the StackSet model) → run the full exporter set per account → deliver a **per-account run report** → deliver an **org-level summary** rolling up all accounts.

**`utils.py`**
- `list_organization_accounts(active_only)` — `organizations:ListAccounts` paginator, partition-aware, structured return, no print.
- `verify_assume_role(role_arn)` — STS **preflight** so a non-assumable account is skipped (recorded `ROLE FAILED`) instead of failing 100+ doomed exporter subprocesses. The StackSet may still be rolling out — that's expected and non-fatal.
- `build_org_summary_dataframe()` — one row per account (status, per-status counts, total assets, report location): the top-level index over the per-account reports.

**`stratusscan.py`**
- Extracted the per-account exporter loop into `_run_exporters_for_account` (shared by single-account and org runs); `_run_full_audit` refactored onto it.
- `_run_org_audit`: enumerate → exclude filter → per-account assume-preflight → run → per-account report → org summary. A role-failed account or a failed exporter never aborts the run. Exit `1` on creds/enumeration failure or zero accounts scanned, `2` on `--output s3` with no bucket, else `0`.
- Flags `--org-scan`, `--scan-role`, `--exclude-accounts`; `--org-scan` requires `--scan-role`.

## Why

Completes the headless interface the v1.0 buildspec invokes, layering Organizations enumeration + per-account role assumption over the orchestrator (#203) and safety layer (#202). Customer-agnostic: uniform role name + Organizations discovery, no hardcoded account IDs.

## Validation

- [x] `tests/test_org_scan.py` (9) — enumeration active-filter, assume-role preflight (success/failure), summary roll-up, and end-to-end `_run_org_audit`: per-account reports + summary, role-failed skip, `--exclude-accounts`
- [x] 154 passed across the combined feature + smoke regression
- [x] No new ruff F/E9; `--org-scan` without `--scan-role` exits 2

## Note

- Stacked on **#203** → #202 → #199. Review/merge order: #199 → #202 → #203 → this. Will retarget to `dev` as the stack lands.
- **Found (out of scope, separate fix):** 5 pre-existing printf-style `utils.log_error("…%s", x)` misuses in `run_org_scan`/resume (stratusscan.py:908/911/914/1056/1059) — latent because they only fire on rare subprocess-exception branches. `log_error` takes `(message, exception)`, not %-args. Worth a small standalone fix.

## Remaining Phase 1
- Version-drift detection (warn when the pinned release tag is behind latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)