### PR TITLE
fix(smart-scan): Deep Scan silently dropping discovered services (RDS et al.)

### DIFF
--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -34,10 +34,8 @@ SERVICE_ALIASES: Dict[str, str] = {
     "elastic compute cloud": "Amazon Elastic Compute Cloud",
     "lambda": "AWS Lambda",
     "eks": "Amazon Elastic Kubernetes Service",
-    "Amazon EKS": "Amazon Elastic Kubernetes Service",
     "kubernetes": "Amazon Elastic Kubernetes Service",
     "ecs": "Amazon Elastic Container Service",
-    "Amazon ECS": "Amazon Elastic Container Service",
     "fargate": "AWS Fargate",
     "app runner": "AWS App Runner",
     "apprunner": "AWS App Runner",
@@ -147,6 +145,28 @@ SERVICE_ALIASES: Dict[str, str] = {
     "elastic container registry": "Amazon Elastic Container Registry",
     "elastic container service": "Amazon Elastic Container Service",
     "elastic kubernetes service": "Amazon Elastic Kubernetes Service",
+
+    # Short "marketing" names emitted by the service-discovery catalog in
+    # services_in_use_export.py. The catalog keys on friendly names (e.g.
+    # "Amazon RDS") for human-readable reports, while SERVICE_SCRIPT_MAP keys
+    # on full canonical names. Alias lookup is case-insensitive (input is
+    # lowercased), so these MUST be lowercase. Without them, discovered
+    # services map to zero scripts and are silently dropped from Deep Scan.
+    # The test_discovery_catalog_resolves guard keeps this list in sync.
+    "amazon rds": "Amazon Relational Database Service",
+    "amazon ecs": "Amazon Elastic Container Service",
+    "amazon eks": "Amazon Elastic Kubernetes Service",
+    "amazon ebs": "Amazon Elastic Block Store",
+    "amazon efs": "Amazon Elastic File System",
+    "amazon glacier": "Amazon S3 Glacier",
+    "amazon vpc": "Amazon Virtual Private Cloud",
+    "aws vpn": "AWS Virtual Private Network",
+    "aws iam": "AWS Identity and Access Management",
+    "aws kms": "AWS Key Management Service",
+    "amazon opensearch": "Amazon OpenSearch Service",
+    "amazon sns": "Amazon Simple Notification Service",
+    "amazon sqs": "Amazon Simple Queue Service",
+    "amazon appsync": "AWS AppSync",
 }
 
 # Primary mapping: Service name → list of export scripts

--- a/tests/smart_scan/test_mapping.py
+++ b/tests/smart_scan/test_mapping.py
@@ -286,5 +286,81 @@ class TestGetCategoryForScript:
         assert get_category_for_script("nonexistent_script.py") == "Other"
 
 
+class TestDiscoveryCatalogResolves:
+    """
+    Guard against silent drift between the service-discovery catalog
+    (SERVICE_CHECKS in services_in_use_export.py) and the script mapping
+    (SERVICE_SCRIPT_MAP / SERVICE_ALIASES).
+
+    The discovery catalog keys on friendly names ("Amazon RDS") while the
+    mapping keys on canonical names ("Amazon Relational Database Service").
+    If a discovered service does not resolve to at least one script, it is
+    silently dropped from Deep Scan execution — meaning the audit reports a
+    service as present but never collects its resources. That is the exact
+    failure this test exists to prevent.
+    """
+
+    # Services that the discovery catalog can detect but for which no exporter
+    # script exists yet. These are KNOWN coverage gaps, not naming bugs. Adding
+    # an exporter for any of these should also remove it from this allowlist.
+    KNOWN_NO_EXPORTER = {
+        "Amazon Lightsail",
+        "AWS Batch",
+        "Amazon Timestream",
+        "Amazon EMR",
+        "Amazon Kinesis",
+        "Amazon CloudWatch Logs",
+        "AWS Amplify",
+    }
+
+    @staticmethod
+    def _catalog_service_names():
+        """Flatten SERVICE_CHECKS (category -> {service: config}) to service names."""
+        import services_in_use_export
+
+        names = set()
+        for services in services_in_use_export.SERVICE_CHECKS.values():
+            names.update(services.keys())
+        return names
+
+    def test_every_discovered_service_resolves_to_a_script(self):
+        """Every discovery-catalog service must map to >=1 script (or be a known gap)."""
+        unresolved = sorted(
+            name
+            for name in self._catalog_service_names()
+            if not get_scripts_for_service(name)
+            and name not in self.KNOWN_NO_EXPORTER
+        )
+        assert not unresolved, (
+            "Discovery catalog services that resolve to NO export script "
+            "(they would be silently dropped from Deep Scan): "
+            f"{unresolved}. Add an alias in SERVICE_ALIASES mapping each to its "
+            "canonical name, or add it to KNOWN_NO_EXPORTER if no exporter exists yet."
+        )
+
+    def test_rds_specifically_resolves(self):
+        """Regression: 'Amazon RDS' must resolve to rds_export.py (the original bug)."""
+        assert "rds_export.py" in get_scripts_for_service("Amazon RDS")
+
+    def test_known_no_exporter_list_is_accurate(self):
+        """KNOWN_NO_EXPORTER must not list services that actually DO have a script."""
+        wrongly_listed = sorted(
+            name for name in self.KNOWN_NO_EXPORTER if get_scripts_for_service(name)
+        )
+        assert not wrongly_listed, (
+            "These services are in KNOWN_NO_EXPORTER but now resolve to a script "
+            f"— remove them from the allowlist: {wrongly_listed}"
+        )
+
+    def test_known_no_exporter_entries_are_in_catalog(self):
+        """KNOWN_NO_EXPORTER must only list services the catalog can actually detect."""
+        catalog = self._catalog_service_names()
+        stale = sorted(name for name in self.KNOWN_NO_EXPORTER if name not in catalog)
+        assert not stale, (
+            "These services are in KNOWN_NO_EXPORTER but no longer exist in the "
+            f"discovery catalog — remove them: {stale}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Running **Service Discovery → Deep Scan** discovered RDS as in-use in several accounts but never ran `rds_export.py`. Investigation found this is not RDS-specific — **12 services were discovered yet silently dropped** from Deep Scan execution, so the audit reported them present but never collected their resources. For an audit tool, that makes output untrustworthy.

## Root cause

The discovery catalog (`SERVICE_CHECKS` in `services_in_use_export.py`) keys on friendly names like `"Amazon RDS"`, while `SERVICE_SCRIPT_MAP` keys on full canonical names (`"Amazon Relational Database Service"`). Alias lookup lowercases its input, but `SERVICE_ALIASES` only carried bare abbreviations (`"rds"`) — so `"Amazon RDS"` → `"amazon rds"` matched nothing → resolved to zero scripts → dropped.

**Affected services:** RDS, ECS, EKS, EBS, EFS, Glacier, VPN, KMS, OpenSearch, SNS, SQS, AppSync. IAM and VPC were masked by the `ALWAYS_RUN` list, which hid the bug until RDS surfaced as the canary.

## Changes

- `scripts/smart_scan/mapping.py` — add lowercase short-name aliases for every mismatched catalog service; remove two dead mixed-case alias keys (`"Amazon EKS"`/`"Amazon ECS"`) that the lowercasing lookup could never match.
- `tests/smart_scan/test_mapping.py` — add `TestDiscoveryCatalogResolves`: asserts **every** discovery-catalog service resolves to ≥1 script, with an explicit `KNOWN_NO_EXPORTER` allowlist for the 7 services that genuinely have no exporter yet (Lightsail, Batch, Timestream, EMR, Kinesis, CloudWatch Logs, Amplify). Fails CI on future drift instead of dropping silently.

## Verification

- 42/42 mapping tests pass; full smart_scan + smoke suite green (193 passed, 2 skipped).
- Re-ran the original drop analysis: only the 7 genuine no-exporter services remain dropped, now documented rather than silent.
- `get_scripts_for_service("Amazon RDS")` → `['rds_export.py']`.

## Follow-ups (separate from this bug)

- The 7 `KNOWN_NO_EXPORTER` services are real coverage gaps worth tracking.
- `--run-all` / org-scan orchestrators don't use this discovery→mapping path, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)