### PR TITLE
feat(smart-scan): close discovery coverage gap — 27 detectors + mandatory billing

### DIFF
--- a/scripts/billing_export.py
+++ b/scripts/billing_export.py
@@ -217,6 +217,13 @@ def get_billing_data(start_date, end_date):
             print("   - Go to AWS Cost Management > Cost & Usage Reports")
             print("   - Set up a report to be delivered to an S3 bucket")
             sys.exit(1)
+        elif error_code in ('AccessDeniedException', 'AccessDenied', 'UnauthorizedOperation'):
+            # Billing runs as a mandatory script, so a missing-permission case
+            # must not fail the whole audit run. Explain it and skip cleanly.
+            print("\nSkipping billing export: this identity lacks Cost Explorer permissions.")
+            print(f"  Reason: {error_message}")
+            print("  Grant 'ce:GetCostAndUsage' (read-only) to include billing in the audit.")
+            sys.exit(0)
         else:
             print(f"\nError accessing Cost Explorer: {error_message}")
             sys.exit(1)

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -44,9 +44,97 @@ args = utils.parse_script_args("Discover AWS services in use and export inventor
 # Setup logging
 logger = utils.setup_logging('services-in-use-export')
 
+
+# ---------------------------------------------------------------------------
+# Detector helpers
+#
+# A detector's job is only to answer "is this service in use, and roughly how
+# much?" — not to collect data (that's the exporter's job). Counts are capped
+# for display by DISCOVERY_CAP, so these helpers stop early once the cap is
+# exceeded. Reference DISCOVERY_CAP (defined below) lazily at call time.
+# ---------------------------------------------------------------------------
+def _count_paginated(client, operation: str, key: str) -> int:
+    """Count items across all pages of a list/describe operation (cap-aware)."""
+    total = 0
+    for page in client.get_paginator(operation).paginate():
+        total += len(page.get(key, []) or [])
+        if total > DISCOVERY_CAP:
+            break
+    return total
+
+
+def _count_simple(client, operation: str, key: str) -> int:
+    """Count items from a single (non-paginated) list/describe call."""
+    return len(getattr(client, operation)().get(key, []) or [])
+
+
+def _shield_check(c, r) -> int:
+    """Shield Advanced is in use only when an active subscription exists.
+
+    describe_subscription raises ResourceNotFoundException when Shield Advanced
+    has never been subscribed — that is a clean 'not in use', not an error.
+    """
+    try:
+        return 1 if c.describe_subscription().get('Subscription') else 0
+    except Exception as e:
+        if 'resourcenotfound' in str(e).lower():
+            return 0
+        raise
+
+
+def _compute_optimizer_check(c, r) -> int:
+    """Compute Optimizer is in use only when the account is opted in (Active)."""
+    return 1 if c.get_enrollment_status().get('status') == 'Active' else 0
+
+
+def _cost_optimization_hub_check(c, r) -> int:
+    """Count accounts with an Active Cost Optimization Hub enrollment."""
+    total = 0
+    for page in c.get_paginator('list_enrollment_statuses').paginate():
+        total += sum(1 for i in page.get('items', []) if i.get('status') == 'Active')
+    return total
+
+
+def _marketplace_check(c, r) -> int:
+    """Best-effort detection of accepted AWS Marketplace agreements.
+
+    The Marketplace agreement API is restrictive and easy to mis-query; any
+    failure is treated as 'not detected' here. The bill cross-check is the
+    authoritative signal for Marketplace spend (see follow-up).
+    """
+    try:
+        resp = c.search_agreements(
+            catalog='AWSMarketplace',
+            filters=[{'name': 'PartyType', 'values': ['Proposer']}],
+            maxResults=20,
+        )
+        return len(resp.get('agreementViewSummaries', []) or [])
+    except Exception as e:
+        utils.log_debug(f"Marketplace agreement check skipped: {e}")
+        return 0
+
+
 # Service detection configuration - maps to your export scripts
 SERVICE_CHECKS = {
     'Compute Resources': {
+        'Amazon Elastic Container Registry': {
+            'client': 'ecr',
+            'check': lambda c, r: _count_paginated(c, 'describe_repositories', 'repositories'),
+            'unit': 'repositories',
+            'regional': True
+        },
+        'AWS Elastic Beanstalk': {
+            'client': 'elasticbeanstalk',
+            'check': lambda c, r: _count_simple(c, 'describe_applications', 'Applications'),
+            'unit': 'applications',
+            'regional': True
+        },
+        'Amazon EC2 Image Builder': {
+            'client': 'imagebuilder',
+            'check': lambda c, r: _count_simple(c, 'list_image_pipelines', 'imagePipelineList'),
+            'unit': 'pipelines',
+            'regional': True
+        },
         'Amazon EC2': {
             'client': 'ec2',
             'check': lambda c, r: sum(
@@ -159,6 +247,18 @@ SERVICE_CHECKS = {
         },
     },
     'Storage Resources': {
+        'AWS DataSync': {
+            'client': 'datasync',
+            'check': lambda c, r: _count_paginated(c, 'list_tasks', 'Tasks'),
+            'unit': 'tasks',
+            'regional': True
+        },
+        'AWS Transfer Family': {
+            'client': 'transfer',
+            'check': lambda c, r: _count_paginated(c, 'list_servers', 'Servers'),
+            'unit': 'servers',
+            'regional': True
+        },
         'Amazon S3': {
             'client': 's3',
             'check': lambda c, r: len(c.list_buckets()['Buckets']),
@@ -217,6 +317,20 @@ SERVICE_CHECKS = {
         },
     },
     'Network Resources': {
+        'AWS Cloud Map': {
+            'client': 'servicediscovery',
+            'check': lambda c, r: _count_paginated(c, 'list_namespaces', 'Namespaces'),
+            'unit': 'namespaces',
+            'regional': True
+        },
+        'AWS Network Manager': {
+            'client': 'networkmanager',
+            # Global service with a single partition endpoint — boto3 routes to
+            # it regardless of the client region, so a single check suffices.
+            'check': lambda c, r: _count_paginated(c, 'describe_global_networks', 'GlobalNetworks'),
+            'unit': 'global networks',
+            'regional': False
+        },
         'Amazon VPC': {
             'client': 'ec2',
             'check': lambda c, r: len([vpc for vpc in c.describe_vpcs()['Vpcs'] if not vpc.get('IsDefault', False)]),
@@ -327,6 +441,45 @@ SERVICE_CHECKS = {
         },
     },
     'Security & Identity': {
+        'AWS IAM Access Analyzer': {
+            'client': 'accessanalyzer',
+            'check': lambda c, r: _count_paginated(c, 'list_analyzers', 'analyzers'),
+            'unit': 'analyzers',
+            'regional': True
+        },
+        'AWS Certificate Manager Private Certificate Authority': {
+            'client': 'acm-pca',
+            'check': lambda c, r: _count_paginated(c, 'list_certificate_authorities', 'CertificateAuthorities'),
+            'unit': 'CAs',
+            'regional': True
+        },
+        'Amazon Detective': {
+            'client': 'detective',
+            'check': lambda c, r: _count_simple(c, 'list_graphs', 'GraphList'),
+            'unit': 'behavior graphs',
+            'regional': True
+        },
+        'AWS Shield': {
+            'client': 'shield',
+            'check': _shield_check,
+            'unit': 'subscription',
+            'regional': False,
+            'global_region': True
+        },
+        'AWS Verified Access': {
+            # Verified Access APIs live under EC2 — there is no 'verifiedaccess'
+            # boto3 client.
+            'client': 'ec2',
+            'check': lambda c, r: _count_paginated(c, 'describe_verified_access_instances', 'VerifiedAccessInstances'),
+            'unit': 'instances',
+            'regional': True
+        },
+        'Amazon Verified Permissions': {
+            'client': 'verifiedpermissions',
+            'check': lambda c, r: _count_paginated(c, 'list_policy_stores', 'policyStores'),
+            'unit': 'policy stores',
+            'regional': True
+        },
         'AWS IAM': {
             'client': 'iam',
             'check': lambda c, r: len(c.list_users()['Users']),
@@ -393,6 +546,29 @@ SERVICE_CHECKS = {
         },
     },
     'Management & Governance': {
+        'AWS License Manager': {
+            'client': 'license-manager',
+            'check': lambda c, r: _count_paginated(c, 'list_license_configurations', 'LicenseConfigurations'),
+            'unit': 'license configurations',
+            'regional': True
+        },
+        'AWS Health': {
+            'client': 'health',
+            # Global endpoint; requires Business/Enterprise Support — a missing
+            # support plan surfaces as 'subscription required' and is treated as
+            # not-in-use by _is_not_in_use_error.
+            'check': lambda c, r: _count_paginated(c, 'describe_events', 'events'),
+            'unit': 'events',
+            'regional': False,
+            'global_region': True
+        },
+        'AWS Marketplace': {
+            'client': 'marketplace-agreement',
+            'check': _marketplace_check,
+            'unit': 'agreements',
+            'regional': False,
+            'global_region': True
+        },
         'AWS CloudTrail': {
             'client': 'cloudtrail',
             'check': lambda c, r: len(c.describe_trails()['trailList']),
@@ -475,6 +651,12 @@ SERVICE_CHECKS = {
         },
     },
     'Integration & Messaging': {
+        'Amazon Simple Email Service': {
+            'client': 'sesv2',
+            'check': lambda c, r: _count_simple(c, 'list_email_identities', 'EmailIdentities'),
+            'unit': 'identities',
+            'regional': True
+        },
         'Amazon SNS': {
             'client': 'sns',
             'check': lambda c, r: len(c.list_topics()['Topics']),
@@ -583,6 +765,81 @@ SERVICE_CHECKS = {
             'regional': True
         },
     },
+    'Developer Tools': {
+        'AWS CodeBuild': {
+            'client': 'codebuild',
+            'check': lambda c, r: _count_paginated(c, 'list_projects', 'projects'),
+            'unit': 'projects',
+            'regional': True
+        },
+        'AWS CodeCommit': {
+            'client': 'codecommit',
+            'check': lambda c, r: _count_paginated(c, 'list_repositories', 'repositories'),
+            'unit': 'repositories',
+            'regional': True
+        },
+        'AWS CodeDeploy': {
+            'client': 'codedeploy',
+            'check': lambda c, r: _count_paginated(c, 'list_applications', 'applications'),
+            'unit': 'applications',
+            'regional': True
+        },
+        'AWS CodePipeline': {
+            'client': 'codepipeline',
+            'check': lambda c, r: _count_paginated(c, 'list_pipelines', 'pipelines'),
+            'unit': 'pipelines',
+            'regional': True
+        },
+    },
+    'Cost & Billing': {
+        'AWS Compute Optimizer': {
+            'client': 'compute-optimizer',
+            'check': _compute_optimizer_check,
+            'unit': 'enrollment',
+            'regional': False,
+            'global_region': True
+        },
+        'AWS Cost Anomaly Detection': {
+            'client': 'ce',
+            'check': lambda c, r: _count_simple(c, 'get_anomaly_monitors', 'AnomalyMonitors'),
+            'unit': 'monitors',
+            'regional': False,
+            'global_region': True
+        },
+        'AWS Cost Categories': {
+            'client': 'ce',
+            'check': lambda c, r: _count_simple(c, 'list_cost_category_definitions', 'CostCategoryReferences'),
+            'unit': 'cost categories',
+            'regional': False,
+            'global_region': True
+        },
+        'Cost Optimization Hub': {
+            'client': 'cost-optimization-hub',
+            'check': _cost_optimization_hub_check,
+            'unit': 'enrollment',
+            'regional': False,
+            'global_region': True
+        },
+        'Savings Plans': {
+            'client': 'savingsplans',
+            'check': lambda c, r: len(
+                c.describe_savings_plans(states=['active']).get('savingsPlans', []) or []
+            ),
+            'unit': 'savings plans',
+            'regional': False,
+            'global_region': True
+        },
+        'AWS Reserved Instances': {
+            'client': 'ec2',
+            'check': lambda c, r: len(
+                c.describe_reserved_instances(
+                    Filters=[{'Name': 'state', 'Values': ['active']}]
+                ).get('ReservedInstances', []) or []
+            ),
+            'unit': 'reserved instances',
+            'regional': True
+        },
+    },
 }
 
 
@@ -610,6 +867,8 @@ _NOT_IN_USE_FRAGMENTS = (
     "not subscribed to",                          # Security Hub: not enabled
     "not enabled",                                # Macie, others: not enabled
     "must create a landing zone",                 # Control Tower: not deployed
+    "subscriptionrequiredexception",              # Health: no Business/Enterprise Support
+    "subscription required",                       # Health: no premium support plan
     "endpoint discovery failed",                  # Timestream: endpoint issue
     "read timeout",                               # service took too long — treat as not detected
     "connect timeout",                            # connection too slow — treat as not detected
@@ -772,8 +1031,18 @@ def discover_services(
             completed += 1
             progress = (completed / total_services) * 100
 
-            # Check if regional or global service
-            check_regions = regions if config['regional'] else [regions[0]]
+            # Decide which region(s) to probe for this service.
+            if config['regional']:
+                check_regions = regions
+            elif config.get('global_region'):
+                # Account-global service that only answers in the partition's
+                # default region (Cost Explorer, Shield, Savings Plans, Health,
+                # etc.). Probing it in an arbitrary scanned region yields false
+                # negatives, so pin to the partition default.
+                partition = utils.detect_partition(regions[0])
+                check_regions = [utils.get_partition_default_region(partition)]
+            else:
+                check_regions = [regions[0]]
 
             # Use concurrent scanning for regional services
             if len(check_regions) > 1:

--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -23,6 +23,11 @@ ALWAYS_RUN_SCRIPTS = [
     "route_tables_export.py",
     "trusted_advisor_cost_optimization_export.py",
     "budgets_export.py",
+    # Every commercial account has a bill, so billing is always worth pulling —
+    # it doubles as a ground-truth cross-check on what is actually running.
+    # The script skips itself cleanly in GovCloud (no Cost Explorer) and on
+    # missing Cost Explorer permissions, so making it mandatory is safe.
+    "billing_export.py",
 ]
 
 # Service name aliases and variations

--- a/tests/smart_scan/test_mapping.py
+++ b/tests/smart_scan/test_mapping.py
@@ -7,6 +7,7 @@ Tests service-to-script mapping, aliases, and categorization.
 import sys
 import os
 import pytest
+from pathlib import Path
 
 # Add scripts directory to path
 scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "scripts"))
@@ -233,7 +234,11 @@ class TestMappingStatistics:
 
     def test_always_run_count(self):
         """Verify we have expected number of always-run scripts."""
-        assert len(ALWAYS_RUN_SCRIPTS) == 10
+        assert len(ALWAYS_RUN_SCRIPTS) == 11
+
+    def test_billing_is_mandatory(self):
+        """Billing must be an always-run script (every account has a bill)."""
+        assert "billing_export.py" in ALWAYS_RUN_SCRIPTS
 
     def test_no_duplicate_scripts_in_service_map(self):
         """Verify no service lists the same script twice."""
@@ -360,6 +365,104 @@ class TestDiscoveryCatalogResolves:
             "These services are in KNOWN_NO_EXPORTER but no longer exist in the "
             f"discovery catalog — remove them: {stale}"
         )
+
+
+class TestExporterReachability:
+    """
+    The inverse of TestDiscoveryCatalogResolves: every exporter that exists on
+    disk must be reachable through a Deep Scan — either the discovery catalog
+    detects its service, or it is in the always-run baseline. An exporter that
+    is neither can never run via smart scan, so its data silently never gets
+    collected. This is the broader version of the original RDS bug.
+    """
+
+    # Scripts that intentionally do NOT participate in discovery-driven runs:
+    #   - the discovery script itself (it produces the catalog; it must not
+    #     recommend running itself)
+    #   - legacy aggregate helpers kept for direct/manual invocation
+    NON_DISCOVERABLE = {
+        "services_in_use_export.py",
+        "compute_resources.py",
+        "network_resources.py",
+        "storage_resources.py",
+    }
+
+    @staticmethod
+    def _scripts_dir():
+        return Path(scripts_dir)
+
+    @staticmethod
+    def _reachable_scripts():
+        """Scripts a Deep Scan can run: catalog-detected services + always-run."""
+        import services_in_use_export
+
+        catalog = set()
+        for services in services_in_use_export.SERVICE_CHECKS.values():
+            catalog.update(services.keys())
+
+        reachable = set(ALWAYS_RUN_SCRIPTS)
+        for name in catalog:
+            reachable.update(get_scripts_for_service(name))
+        return reachable
+
+    def test_every_exporter_is_reachable(self):
+        """Every *_export.py on disk must be reachable via discovery or always-run."""
+        disk = {p.name for p in self._scripts_dir().glob("*_export.py")}
+        unreachable = sorted(
+            disk - self._reachable_scripts() - self.NON_DISCOVERABLE
+        )
+        assert not unreachable, (
+            "Exporters on disk that a Deep Scan can never run (no catalog "
+            f"detector and not always-run): {unreachable}. Add a detector to "
+            "SERVICE_CHECKS, add the script to ALWAYS_RUN_SCRIPTS, or list it in "
+            "NON_DISCOVERABLE if it is intentionally manual-only."
+        )
+
+    def test_non_discoverable_entries_exist(self):
+        """NON_DISCOVERABLE must only name scripts that actually exist on disk."""
+        missing = sorted(
+            s for s in self.NON_DISCOVERABLE if not (self._scripts_dir() / s).exists()
+        )
+        assert not missing, f"NON_DISCOVERABLE names nonexistent scripts: {missing}"
+
+
+class TestServiceCheckStructure:
+    """Validate every discovery-catalog detector is structurally well-formed."""
+
+    @staticmethod
+    def _all_configs():
+        import services_in_use_export
+
+        for category, services in services_in_use_export.SERVICE_CHECKS.items():
+            for name, config in services.items():
+                yield category, name, config
+
+    def test_required_keys_present(self):
+        """Every detector needs client, check (callable), unit, and regional flag."""
+        for _category, name, config in self._all_configs():
+            assert "client" in config, f"{name}: missing 'client'"
+            assert callable(config.get("check")), f"{name}: 'check' must be callable"
+            assert "unit" in config, f"{name}: missing 'unit'"
+            assert isinstance(config.get("regional"), bool), f"{name}: 'regional' must be bool"
+
+    def test_global_region_not_also_regional(self):
+        """A global_region service is account-global; it cannot also be regional."""
+        for _category, name, config in self._all_configs():
+            if config.get("global_region"):
+                assert config["regional"] is False, (
+                    f"{name}: global_region services must have regional=False"
+                )
+
+    def test_client_strings_are_valid_boto3_services(self):
+        """Every detector's client must be a real botocore service (offline check)."""
+        import botocore.session
+
+        session = botocore.session.get_session()
+        valid = set(session.get_available_services())
+        for _category, name, config in self._all_configs():
+            assert config["client"] in valid, (
+                f"{name}: '{config['client']}' is not a valid boto3 service"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Stacked on #206** (base: `fix/smart-scan-name-mismatch`). Review/merge #206 first.

## Problem

Follow-on from the RDS fix in #206. The discovery catalog (`SERVICE_CHECKS`) only knew how to detect **68 services**, but the project ships **100+ exporters**. A Deep Scan could therefore only ever auto-recommend ~72 of them — **29 exporters on disk had no detector at all**, so their services were never reported "in use" and never collected. Same silent under-collection class as the RDS bug, at larger scale.

## Detectors (27 new catalog entries)

SES covers two exporters; billing is handled via always-run — hence 27 entries for 29 scripts.

- **Validated every client/operation/response-key against botocore models offline** before writing each detector, so a detector queries the same API its exporter uses. This caught that `verifiedaccess` is **not** a real boto3 client (Verified Access lives under `ec2`) — the detector uses `ec2`. *(The exporter `verifiedaccess_export.py` still calls `get_boto3_client('verifiedaccess')` — a latent bug; see follow-ups.)*
- Two new catalog categories: **Developer Tools** and **Cost & Billing**.
- Coverage: Access Analyzer, ACM Private CA, Detective, Shield, Verified Access, Verified Permissions, CodeBuild/Commit/Deploy/Pipeline, Compute Optimizer, Cost Anomaly Detection, Cost Categories, Cost Optimization Hub, Savings Plans, Reserved Instances, DataSync, Transfer Family, ECR, Elastic Beanstalk, EC2 Image Builder, Cloud Map, Network Manager, SES, License Manager, Health, Marketplace.

## Framework

- New **`global_region`** detector flag. Account-global services (Cost Explorer, Shield, Savings Plans, Health, Compute Optimizer, Cost Optimization Hub, Marketplace) only answer in the partition's default region; probing them in an arbitrary scanned region gave false negatives. They now pin to `get_partition_default_region(detect_partition(...))` — GovCloud-aware.
- `_count_paginated` / `_count_simple` helpers + special-case checks for Shield (ResourceNotFound = not subscribed), Compute Optimizer / Cost Optimization Hub (enrollment), best-effort Marketplace agreements.
- Health's "subscription required" (no Business/Enterprise Support) now treated as a clean not-in-use, not an error.

## Billing made mandatory

- `billing_export.py` added to `ALWAYS_RUN_SCRIPTS` — every commercial account has a bill, and it doubles as a ground-truth signal for what's actually running.
- Missing Cost Explorer permissions now → graceful skip (exit 0) with a clear message naming the needed permission (`ce:GetCostAndUsage`), so a mandatory script never fails an entire run over billing perms. Already skips cleanly in GovCloud.

## Guard tests

- `TestExporterReachability` — every `*_export.py` on disk must be reachable via a catalog detector or always-run (explicit `NON_DISCOVERABLE` allowlist for the discovery script + legacy aggregate helpers). Locks the gap closed.
- `TestServiceCheckStructure` — every detector well-formed, `global_region` ⇒ `regional=False`, every client string a real boto3 service.

## Result

Catalog now **95 entries**; only `billing_export.py` is "unreachable" by detection (intentional — always-run). **199 tests pass**, 2 skipped. No new ruff violations.

## Follow-ups (not in this PR)

- **Bill as ground-truth cross-check**: read Cost Explorer spend grouped by service and reconcile against API-probe discovery to catch anything probing missed. (The strongest long-term fix — spend doesn't lie about what's running.)
- `verifiedaccess_export.py` uses the non-existent `verifiedaccess` boto3 client — needs to move to `ec2`.
- 7 catalog services still have no exporter (Lightsail, Batch, Timestream, EMR, Kinesis, CloudWatch Logs, Amplify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)