### PR TITLE
fix(verifiedaccess): use 'ec2' client, not invalid 'verifiedaccess' (#208)

### DIFF
--- a/scripts/verifiedaccess_export.py
+++ b/scripts/verifiedaccess_export.py
@@ -49,7 +49,9 @@ def collect_verified_access_instances(region: str) -> List[Dict[str, Any]]:
     """Collect Verified Access Instances in a region."""
     utils.log_info(f"Collecting Verified Access Instances in {region}...")
 
-    va_client = utils.get_boto3_client('verifiedaccess', region_name=region)
+    # Verified Access APIs are part of EC2 — there is no 'verifiedaccess' boto3
+    # client (issue #208). All describe_verified_access_* operations are EC2.
+    va_client = utils.get_boto3_client('ec2', region_name=region)
     instances = []
 
     try:
@@ -86,7 +88,7 @@ def collect_trust_providers(region: str) -> List[Dict[str, Any]]:
     """Collect Verified Access Trust Providers in a region."""
     utils.log_info(f"Collecting Trust Providers in {region}...")
 
-    va_client = utils.get_boto3_client('verifiedaccess', region_name=region)
+    va_client = utils.get_boto3_client('ec2', region_name=region)
     trust_providers = []
 
     try:
@@ -144,7 +146,7 @@ def collect_verified_access_groups(region: str) -> List[Dict[str, Any]]:
     """Collect Verified Access Groups in a region."""
     utils.log_info(f"Collecting Verified Access Groups in {region}...")
 
-    va_client = utils.get_boto3_client('verifiedaccess', region_name=region)
+    va_client = utils.get_boto3_client('ec2', region_name=region)
     groups = []
 
     try:
@@ -201,7 +203,7 @@ def collect_verified_access_endpoints(region: str) -> List[Dict[str, Any]]:
     """Collect Verified Access Endpoints in a region."""
     utils.log_info(f"Collecting Verified Access Endpoints in {region}...")
 
-    va_client = utils.get_boto3_client('verifiedaccess', region_name=region)
+    va_client = utils.get_boto3_client('ec2', region_name=region)
     endpoints = []
 
     try:
@@ -286,7 +288,7 @@ def collect_access_logs_config(region: str, instances: List[Dict]) -> List[Dict[
     """Collect Access Logs configuration for Verified Access instances."""
     utils.log_info(f"Collecting Access Logs configurations in {region}...")
 
-    va_client = utils.get_boto3_client('verifiedaccess', region_name=region)
+    va_client = utils.get_boto3_client('ec2', region_name=region)
     logs_configs = []
 
     for instance in instances:

--- a/tests/test_exporters/test_verifiedaccess_export.py
+++ b/tests/test_exporters/test_verifiedaccess_export.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Tests for verifiedaccess_export.py.
+
+Regression coverage for issue #208: the exporter created its client with the
+non-existent boto3 service name 'verifiedaccess'. Verified Access APIs live
+under 'ec2'. Because every collector is wrapped in @aws_error_handler, the
+invalid client surfaced as a silently empty export rather than a crash — so the
+import-only smoke test never caught it. These tests assert every collector
+creates its client with a *real* boto3 service.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.session
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import verifiedaccess_export as va  # noqa: E402
+
+REGION = "us-east-1"
+
+# Every collector and how to invoke it (collect_access_logs_config needs the
+# already-collected instances list).
+COLLECTORS = [
+    ("collect_verified_access_instances", lambda f: f(REGION)),
+    ("collect_trust_providers", lambda f: f(REGION)),
+    ("collect_verified_access_groups", lambda f: f(REGION)),
+    ("collect_verified_access_endpoints", lambda f: f(REGION)),
+    ("collect_access_logs_config", lambda f: f(REGION, [])),
+]
+
+
+def _empty_client():
+    """A mock client that yields no resources for any paginated/direct call."""
+    m = MagicMock()
+    m.get_paginator.return_value.paginate.return_value = []
+    m.describe_verified_access_instance_logging_configurations.return_value = {}
+    return m
+
+
+@pytest.mark.parametrize("fn_name,invoke", COLLECTORS)
+def test_collectors_use_valid_boto3_service(monkeypatch, fn_name, invoke):
+    """Each collector must build its client from a real boto3 service (issue #208)."""
+    valid_services = set(botocore.session.get_session().get_available_services())
+    requested = []
+
+    def spy(service, region_name=None, **kwargs):
+        requested.append(service)
+        return _empty_client()
+
+    monkeypatch.setattr(va.utils, "get_boto3_client", spy)
+
+    invoke(getattr(va, fn_name))
+
+    assert requested, f"{fn_name} never created a client"
+    invalid = [s for s in requested if s not in valid_services]
+    assert not invalid, (
+        f"{fn_name} created a client with invalid boto3 service(s): {invalid}. "
+        "Verified Access APIs live under 'ec2'."
+    )
+    # Verified Access is specifically an EC2 API surface.
+    assert all(s == "ec2" for s in requested), (
+        f"{fn_name} should use the 'ec2' client; got {requested}"
+    )
+
+
+def test_collect_instances_parses_data(monkeypatch):
+    """With the corrected client, instance data is parsed end to end."""
+    page = {
+        "VerifiedAccessInstances": [
+            {
+                "VerifiedAccessInstanceId": "vai-0123456789abcdef0",
+                "Description": "prod zero-trust",
+                "VerifiedAccessTrustProviders": [{"VerifiedAccessTrustProviderId": "vatp-1"}],
+                "Tags": [{"Key": "env", "Value": "prod"}],
+            }
+        ]
+    }
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.return_value = [page]
+
+    captured = {}
+
+    def spy(service, region_name=None, **kwargs):
+        captured["service"] = service
+        return client
+
+    monkeypatch.setattr(va.utils, "get_boto3_client", spy)
+
+    rows = va.collect_verified_access_instances(REGION)
+
+    assert captured["service"] == "ec2"
+    assert len(rows) == 1
+    assert rows[0]["Instance ID"] == "vai-0123456789abcdef0"
+    assert rows[0]["Trust Provider Count"] == 1
+    assert rows[0]["Tags"] == "env=prod"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #208.

## Problem

`verifiedaccess_export.py` built its boto3 client with the service name `'verifiedaccess'` (5 call sites). That is **not a real boto3 service** — Verified Access APIs (`describe_verified_access_instances`, `...trust_providers`, `...groups`, `...endpoints`, `...instance_logging_configurations`) all live under **`ec2`**. `get_boto3_client` passes the name straight to `session.client()`, so each call raised `UnknownServiceError`.

Every collector is wrapped in `@aws_error_handler(default_return=[])`, so the error was **swallowed into an empty export** rather than a crash — and the import-only smoke test never ran the collectors. Net effect: the script has silently produced empty Verified Access exports since it was added. For an audit tool, a control that reports "nothing found" when resources exist is a serious correctness problem.

Verified offline:
```
python3 -c "import botocore.session as s; print('verifiedaccess' in s.get_session().get_available_services())"  # False
```

## Fix

- Swap all 5 `get_boto3_client('verifiedaccess', ...)` → `'ec2'`. Operation names are unchanged (already EC2 operations).

## Tests

New `tests/test_exporters/test_verifiedaccess_export.py`:
- **Regression** (parametrized over all 5 collectors): asserts each builds its client from a real boto3 service and specifically uses `ec2`. Confirmed this **fails on the pre-fix code** (all 6 fail) and passes after.
- **Parsing**: a Verified Access instance flows through `collect_verified_access_instances` end to end.

moto does not implement Verified Access, so the regression spies on `get_boto3_client` and validates the requested service against botocore's real service list — which is exactly what catches the invalid-name class of bug.

128 exporter+smoke tests pass; no new ruff violations.

## Note

The original-reporter follow-up still stands: the smoke suite only *imports* exporters, so runtime-only failures like this hide. Worth a broader mocked-execution smoke pass across exporters (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)