### PR TITLE
feat(smart-scan): bill cross-check — reconcile Cost Explorer spend vs discovery (#209)

### DIFF
--- a/scripts/smart_scan/bill_crosscheck.py
+++ b/scripts/smart_scan/bill_crosscheck.py
@@ -1,0 +1,239 @@
+"""
+Bill Cross-Check — reconcile Cost Explorer spend against discovered services.
+
+Service discovery probes a fixed catalog of APIs. Spend is the one signal that
+does not lie about what is actually running: almost anything live in AWS shows
+up on the bill. This module queries Cost Explorer for per-service spend over the
+last full month and reconciles it against the services discovery found, so an
+audit can surface "spend detected, never collected" gaps.
+
+Design (issue #209):
+- Cost Explorer (`ce`) is us-east-1 only and unavailable in GovCloud — the
+  cross-check skips cleanly (with a reason) outside the commercial partition.
+- Needs `ce:GetCostAndUsage` (read-only). Missing permission is a clean skip,
+  not a failure — billing perms must never sink an audit run.
+- Every CE service with spend is surfaced. Known non-resource billing line
+  items (tax, support, refunds, credits) are filtered to an "ignored" bucket;
+  anything we cannot map to a known service is reported as "unmapped" rather
+  than hidden, so nothing silently disappears.
+
+This module is library code: it returns structured results and logs via
+utils.log_* — it never prints.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+try:
+    import utils
+except ImportError:
+    sys.path.append(str(Path(__file__).parent.parent))
+    import utils
+
+from .mapping import SERVICE_SCRIPT_MAP, get_canonical_service_name, get_scripts_for_service
+
+
+class BillCrossCheckUnavailable(Exception):
+    """Raised when the bill cross-check cannot run (skip, not a failure)."""
+
+# Cost Explorer line items that are not collectable AWS resources. Matched as
+# lowercase substrings against the CE service name. Kept deliberately tight to
+# avoid suppressing real services.
+_IGNORED_LINE_ITEM_FRAGMENTS = (
+    "tax",
+    "refund",
+    "credit",
+    "aws support",
+    "premium support",
+    "aws cost explorer",
+    "savings plans negation",
+    "savings plans for",  # the netting line item, not the Savings Plans service
+)
+
+# Status constants for the cross-check result.
+STATUS_OK = "ok"
+STATUS_SKIPPED = "skipped"
+
+
+def _last_full_month(reference_date: Optional[datetime.date] = None) -> Tuple[str, str]:
+    """Return (start, end) ISO dates spanning the last full calendar month.
+
+    Cost Explorer's TimePeriod end is exclusive, so end is the first day of the
+    current month and start is the first day of the previous month.
+    """
+    today = reference_date or datetime.date.today()
+    first_of_this_month = today.replace(day=1)
+    last_month_end = first_of_this_month  # exclusive
+    prev = first_of_this_month - datetime.timedelta(days=1)
+    last_month_start = prev.replace(day=1)
+    return last_month_start.isoformat(), last_month_end.isoformat()
+
+
+def map_ce_service(ce_name: str) -> Tuple[Optional[str], bool]:
+    """Map a Cost Explorer service name to a canonical StratusScan service.
+
+    Returns (canonical_name_or_None, is_ignored_line_item).
+      - (canonical, False): mapped to a known service in SERVICE_SCRIPT_MAP
+      - (None, True):       a non-resource billing line item (tax/support/...)
+      - (None, False):      real spend we could not map to a known service
+    """
+    low = ce_name.lower().strip()
+    if any(frag in low for frag in _IGNORED_LINE_ITEM_FRAGMENTS):
+        return None, True
+
+    # CE often suffixes the service ("Amazon Elastic Compute Cloud - Compute",
+    # "EC2 - Other"). Try the full name first, then the part before " - ".
+    for candidate in (ce_name, ce_name.split(" - ")[0].strip()):
+        canonical = get_canonical_service_name(candidate)
+        if canonical in SERVICE_SCRIPT_MAP:
+            return canonical, False
+
+    return None, False
+
+
+def reconcile(
+    spend: Dict[str, float],
+    discovered_services: Set[str],
+    min_cost: float = 0.0,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Reconcile per-service CE spend against discovered services.
+
+    Args:
+        spend: CE service name -> cost for the period.
+        discovered_services: service names discovery found in use (catalog names).
+        min_cost: ignore spend at or below this amount (default: keep all > 0).
+
+    Returns a dict with four buckets, each a list of row dicts:
+        confirmed       - spend AND discovered (collected)
+        not_collected   - spend mapped to a known service that was NOT discovered
+        unmapped        - real spend we could not map to any known service
+        ignored         - non-resource billing line items (tax/support/...)
+    """
+    # Normalise discovered names to canonical for comparison.
+    discovered_canonical = {get_canonical_service_name(s) for s in discovered_services}
+
+    confirmed: List[Dict[str, Any]] = []
+    not_collected: List[Dict[str, Any]] = []
+    unmapped: List[Dict[str, Any]] = []
+    ignored: List[Dict[str, Any]] = []
+
+    for ce_name, cost in sorted(spend.items(), key=lambda kv: kv[1], reverse=True):
+        if cost <= min_cost:
+            continue
+        canonical, is_ignored = map_ce_service(ce_name)
+        if is_ignored:
+            ignored.append({"ce_service": ce_name, "monthly_cost": round(cost, 2)})
+            continue
+        if canonical is None:
+            unmapped.append({"ce_service": ce_name, "monthly_cost": round(cost, 2)})
+            continue
+        row = {
+            "ce_service": ce_name,
+            "service": canonical,
+            "monthly_cost": round(cost, 2),
+            "exporters": get_scripts_for_service(canonical),
+        }
+        if canonical in discovered_canonical:
+            confirmed.append(row)
+        else:
+            not_collected.append(row)
+
+    return {
+        "confirmed": confirmed,
+        "not_collected": not_collected,
+        "unmapped": unmapped,
+        "ignored": ignored,
+    }
+
+
+def get_service_spend(
+    partition: Optional[str] = None,
+    reference_date: Optional[datetime.date] = None,
+) -> Dict[str, float]:
+    """Query Cost Explorer for per-service blended cost over the last full month.
+
+    Returns a dict of CE service name -> cost. Raises BillCrossCheckUnavailable
+    when the cross-check cannot run (GovCloud, missing permission, API error)
+    with a human-readable reason — callers should treat that as a clean skip.
+    """
+    if partition is None:
+        partition = utils.detect_partition()
+
+    if not utils.is_service_available_in_partition("ce", partition):
+        raise BillCrossCheckUnavailable(
+            "Cost Explorer is not available in this partition (GovCloud)."
+        )
+
+    region = utils.get_partition_default_region(partition)
+    client = utils.get_boto3_client("ce", region_name=region)
+
+    start, end = _last_full_month(reference_date)
+
+    try:
+        spend: Dict[str, float] = {}
+        next_token: Optional[str] = None
+        while True:
+            kwargs: Dict[str, Any] = {
+                "TimePeriod": {"Start": start, "End": end},
+                "Granularity": "MONTHLY",
+                "Metrics": ["BlendedCost"],
+                "GroupBy": [{"Type": "DIMENSION", "Key": "SERVICE"}],
+            }
+            if next_token:
+                kwargs["NextPageToken"] = next_token
+            response = client.get_cost_and_usage(**kwargs)
+            for result in response.get("ResultsByTime", []):
+                for group in result.get("Groups", []):
+                    name = group["Keys"][0]
+                    amount = float(group["Metrics"]["BlendedCost"]["Amount"])
+                    spend[name] = spend.get(name, 0.0) + amount
+            next_token = response.get("NextPageToken")
+            if not next_token:
+                break
+        return spend
+    except Exception as e:  # noqa: BLE001 - classify and re-raise as skip reason
+        code = ""
+        resp = getattr(e, "response", None)
+        if isinstance(resp, dict):
+            code = resp.get("Error", {}).get("Code", "")
+        if code in ("AccessDeniedException", "AccessDenied", "UnauthorizedOperation"):
+            raise BillCrossCheckUnavailable(
+                "Missing Cost Explorer permission — grant ce:GetCostAndUsage "
+                "(read-only) to enable the bill cross-check."
+            ) from e
+        raise BillCrossCheckUnavailable(f"Cost Explorer query failed: {e}") from e
+
+
+def run_crosscheck(
+    discovered_services: Set[str],
+    partition: Optional[str] = None,
+    reference_date: Optional[datetime.date] = None,
+    min_cost: float = 0.0,
+) -> Dict[str, Any]:
+    """Run the full bill cross-check, returning a status-tagged result.
+
+    Never raises: an unavailable cross-check returns {"status": "skipped",
+    "reason": ...} so callers can record it without special-casing.
+    """
+    try:
+        spend = get_service_spend(partition=partition, reference_date=reference_date)
+    except BillCrossCheckUnavailable as e:
+        utils.log_warning(f"Bill cross-check skipped: {e}")
+        return {"status": STATUS_SKIPPED, "reason": str(e)}
+
+    buckets = reconcile(spend, discovered_services, min_cost=min_cost)
+    start, end = _last_full_month(reference_date)
+    buckets.update({
+        "status": STATUS_OK,
+        "period": {"start": start, "end": end},
+        "total_services_billed": len(spend),
+    })
+    if buckets["not_collected"]:
+        names = ", ".join(r["service"] for r in buckets["not_collected"])
+        utils.log_warning(
+            f"Bill cross-check: {len(buckets['not_collected'])} service(s) with "
+            f"spend were not collected by discovery: {names}"
+        )
+    return buckets

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -171,6 +171,7 @@ def _write_markdown_report(
     account_id: str,
     regions: List[str],
     mode: str,
+    crosscheck: Optional[Dict[str, Any]] = None,
 ) -> Optional[Path]:
     """
     Write discovery report as Markdown to reports/ directory.
@@ -275,6 +276,8 @@ def _write_markdown_report(
             lines.append(f"- `{script}`")
         lines.append("")
 
+    lines += _crosscheck_markdown_lines(crosscheck)
+
     try:
         filepath.write_text('\n'.join(lines), encoding='utf-8')
         return filepath
@@ -364,6 +367,123 @@ def _resume_from_session(session_path: str) -> None:
     )
 
 
+def _run_bill_crosscheck(
+    services: Dict[str, Any], regions: List[str]
+) -> Optional[Dict[str, Any]]:
+    """Run the Cost Explorer ground-truth cross-check unless opted out.
+
+    Never raises — returns the cross-check result, a skip status dict, or None
+    when disabled/unavailable so callers can always proceed.
+    """
+    if os.environ.get("STRATUSSCAN_SKIP_BILL_CROSSCHECK") == "1":
+        utils.log_info("Bill cross-check disabled (STRATUSSCAN_SKIP_BILL_CROSSCHECK=1)")
+        return None
+    try:
+        from smart_scan.bill_crosscheck import run_crosscheck
+    except ImportError as exc:
+        utils.log_warning(f"Bill cross-check unavailable: {exc}")
+        return None
+    partition = utils.detect_partition(regions[0]) if regions else None
+    return run_crosscheck(set(services.keys()), partition=partition)
+
+
+# (result bucket, human label) in audit-priority order.
+_CROSSCHECK_STATUS_ORDER = [
+    ('not_collected', 'SPEND, NOT COLLECTED'),
+    ('confirmed', 'CONFIRMED'),
+    ('unmapped', 'SPEND, UNMAPPED'),
+    ('ignored', 'IGNORED (billing line item)'),
+]
+
+
+def _crosscheck_dataframe(result: Dict[str, Any]) -> "pd.DataFrame":
+    """Flatten a cross-check result into a single status-tagged DataFrame."""
+    rows = []
+    for bucket, label in _CROSSCHECK_STATUS_ORDER:
+        for r in result.get(bucket, []):
+            rows.append({
+                'Status': label,
+                'Billed Service (Cost Explorer)': r['ce_service'],
+                'Mapped Service': r.get('service', ''),
+                'Monthly Cost (USD)': r['monthly_cost'],
+                'Exporters': ', '.join(r.get('exporters', [])),
+            })
+    return pd.DataFrame(rows)
+
+
+def _crosscheck_markdown_lines(result: Optional[Dict[str, Any]]) -> List[str]:
+    """Render the cross-check as a Markdown report section."""
+    if not result:
+        return []
+    lines = ["---", "", "## Bill Cross-Check", ""]
+    if result.get('status') != 'ok':
+        return lines + [f"_Skipped: {result.get('reason', 'unavailable')}_", ""]
+
+    p = result['period']
+    lines += [
+        f"Cost Explorer spend for {p['start']} to {p['end']} "
+        f"({result['total_services_billed']} billed services), reconciled against discovery.",
+        "",
+    ]
+    not_collected = result.get('not_collected', [])
+    if not_collected:
+        lines += [
+            "### ⚠ Spend detected but NOT collected",
+            "",
+            "| Billed Service | Mapped Service | Monthly Cost (USD) | Exporter(s) |",
+            "|---|---|---|---|",
+        ]
+        for r in not_collected:
+            lines.append(
+                f"| {r['ce_service']} | {r['service']} | {r['monthly_cost']:,.2f} "
+                f"| {', '.join(r['exporters'])} |"
+            )
+        lines.append("")
+    else:
+        lines += ["Every billed service was discovered. ✅", ""]
+
+    unmapped = result.get('unmapped', [])
+    if unmapped:
+        lines += [
+            "### Billed but unmapped (no known service)",
+            "",
+            "| Billed Service | Monthly Cost (USD) |",
+            "|---|---|",
+        ]
+        for r in unmapped:
+            lines.append(f"| {r['ce_service']} | {r['monthly_cost']:,.2f} |")
+        lines.append("")
+    return lines
+
+
+def _print_crosscheck_summary(result: Optional[Dict[str, Any]]) -> None:
+    """Print a concise cross-check summary to the console."""
+    if not result:
+        return
+    if result.get('status') != 'ok':
+        print(f"\n  Bill cross-check skipped: {result.get('reason', 'unavailable')}")
+        return
+    not_collected = result.get('not_collected', [])
+    unmapped = result.get('unmapped', [])
+    print()
+    print("  ─── BILL CROSS-CHECK ────────────────────────────────────────")
+    print(
+        f"  Period {result['period']['start']} → {result['period']['end']}  "
+        f"({result['total_services_billed']} billed services)"
+    )
+    if not_collected:
+        print(f"  ⚠ {len(not_collected)} service(s) with spend NOT collected by discovery:")
+        for r in not_collected[:10]:
+            print(f"      ${r['monthly_cost']:>12,.2f}  {r['service']}")
+        if len(not_collected) > 10:
+            print(f"      ... and {len(not_collected) - 10} more (see report)")
+    else:
+        print("  ✓ Every billed service was discovered.")
+    if unmapped:
+        print(f"  • {len(unmapped)} billed service(s) could not be mapped (see report).")
+    print("  ─────────────────────────────────────────────────────────────")
+
+
 def main() -> None:
     """Main Smart Scan workflow."""
     utils.log_script_start('smart-scan')
@@ -417,10 +537,16 @@ def main() -> None:
         f"  ({n_baseline} security baseline + {n_service} service-specific)"
     )
 
+    # Bill cross-check (Cost Explorer ground truth). Opt out with
+    # STRATUSSCAN_SKIP_BILL_CROSSCHECK=1; skips cleanly in GovCloud / without perms.
+    crosscheck = _run_bill_crosscheck(services, regions)
+    _print_crosscheck_summary(crosscheck)
+
     # Quick Scan: write lightweight reports and exit
     if scan_mode == 'quick':
         md_path = _write_markdown_report(
-            services, recommendations, account_name, account_id, regions, scan_mode
+            services, recommendations, account_name, account_id, regions, scan_mode,
+            crosscheck=crosscheck,
         )
         if md_path:
             utils.log_success(f"  Report saved: {md_path}")
@@ -440,7 +566,8 @@ def main() -> None:
 
     # Write Markdown report
     md_path = _write_markdown_report(
-        services, recommendations, account_name, account_id, regions, scan_mode
+        services, recommendations, account_name, account_id, regions, scan_mode,
+        crosscheck=crosscheck,
     )
     if md_path:
         utils.log_success(f"  Report saved: {md_path}")
@@ -467,6 +594,11 @@ def main() -> None:
         for category, df in category_sheets.items():
             sheet_name = category.replace(' Resources', '').replace('&', 'and')[:31]
             dataframes[sheet_name] = utils.prepare_dataframe_for_export(df)
+
+        if crosscheck and crosscheck.get('status') == 'ok':
+            df_cc = _crosscheck_dataframe(crosscheck)
+            if not df_cc.empty:
+                dataframes['Bill Cross-Check'] = utils.prepare_dataframe_for_export(df_cc)
 
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'services-in-use', region_suffix)

--- a/tests/smart_scan/test_bill_crosscheck.py
+++ b/tests/smart_scan/test_bill_crosscheck.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Tests for smart_scan.bill_crosscheck — the Cost Explorer ground-truth
+cross-check (issue #209).
+"""
+
+import datetime
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "scripts"))
+if scripts_dir not in sys.path:
+    sys.path.insert(0, scripts_dir)
+
+from smart_scan import bill_crosscheck as bc  # noqa: E402
+
+
+class TestLastFullMonth:
+    def test_mid_month(self):
+        start, end = bc._last_full_month(datetime.date(2026, 3, 15))
+        assert start == "2026-02-01"
+        assert end == "2026-03-01"
+
+    def test_january_rolls_to_december(self):
+        start, end = bc._last_full_month(datetime.date(2026, 1, 5))
+        assert start == "2025-12-01"
+        assert end == "2026-01-01"
+
+
+class TestMapCeService:
+    def test_canonical_full_name(self):
+        # CE often emits the full canonical name directly.
+        assert bc.map_ce_service("Amazon Relational Database Service") == (
+            "Amazon Relational Database Service",
+            False,
+        )
+
+    def test_suffixed_name_strips_to_base(self):
+        canonical, ignored = bc.map_ce_service("Amazon Elastic Compute Cloud - Compute")
+        assert canonical == "Amazon Elastic Compute Cloud"
+        assert ignored is False
+
+    def test_short_alias_with_suffix(self):
+        # "EC2 - Other" -> "EC2" -> alias -> canonical.
+        canonical, ignored = bc.map_ce_service("EC2 - Other")
+        assert canonical == "Amazon Elastic Compute Cloud"
+        assert ignored is False
+
+    @pytest.mark.parametrize(
+        "name",
+        ["Tax", "AWS Support (Business)", "Refund", "AWS Premium Support", "AWS Cost Explorer"],
+    )
+    def test_billing_line_items_are_ignored(self, name):
+        canonical, ignored = bc.map_ce_service(name)
+        assert ignored is True
+        assert canonical is None
+
+    def test_unmappable_real_service_returns_none_not_ignored(self):
+        canonical, ignored = bc.map_ce_service("Some Brand New Service")
+        assert canonical is None
+        assert ignored is False
+
+
+class TestReconcile:
+    def test_buckets_classify_correctly(self):
+        spend = {
+            "Amazon Relational Database Service": 120.0,  # billed + discovered
+            "Amazon Simple Storage Service": 5.0,         # billed, NOT discovered
+            "Tax": 9.99,                                  # ignored line item
+            "Some Brand New Service": 3.0,                # unmapped real spend
+            "Amazon Elastic Compute Cloud": 0.0,          # zero -> dropped
+        }
+        discovered = {"Amazon RDS"}  # alias for RDS canonical
+
+        result = bc.reconcile(spend, discovered)
+
+        assert [r["service"] for r in result["confirmed"]] == [
+            "Amazon Relational Database Service"
+        ]
+        assert [r["service"] for r in result["not_collected"]] == [
+            "Amazon Simple Storage Service"
+        ]
+        assert [r["ce_service"] for r in result["unmapped"]] == ["Some Brand New Service"]
+        assert [r["ce_service"] for r in result["ignored"]] == ["Tax"]
+
+    def test_not_collected_includes_exporters(self):
+        result = bc.reconcile({"Amazon Simple Storage Service": 10.0}, set())
+        row = result["not_collected"][0]
+        assert "s3_export.py" in row["exporters"]
+
+    def test_min_cost_filter(self):
+        spend = {"Amazon Simple Storage Service": 0.50}
+        result = bc.reconcile(spend, set(), min_cost=1.0)
+        assert result["not_collected"] == []
+
+    def test_sorted_by_cost_desc(self):
+        spend = {
+            "Amazon Simple Storage Service": 5.0,
+            "Amazon Relational Database Service": 50.0,
+        }
+        result = bc.reconcile(spend, set())
+        costs = [r["monthly_cost"] for r in result["not_collected"]]
+        assert costs == sorted(costs, reverse=True)
+
+
+class TestGetServiceSpend:
+    def test_govcloud_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(bc.utils, "is_service_available_in_partition", lambda *a, **k: False)
+        with pytest.raises(bc.BillCrossCheckUnavailable, match="GovCloud"):
+            bc.get_service_spend(partition="aws-us-gov")
+
+    def test_access_denied_becomes_skip(self, monkeypatch):
+        monkeypatch.setattr(bc.utils, "is_service_available_in_partition", lambda *a, **k: True)
+        monkeypatch.setattr(bc.utils, "get_partition_default_region", lambda *a, **k: "us-east-1")
+
+        client = MagicMock()
+        err = Exception("denied")
+        err.response = {"Error": {"Code": "AccessDeniedException"}}
+        client.get_cost_and_usage.side_effect = err
+        monkeypatch.setattr(bc.utils, "get_boto3_client", lambda *a, **k: client)
+
+        with pytest.raises(bc.BillCrossCheckUnavailable, match="ce:GetCostAndUsage"):
+            bc.get_service_spend(partition="aws")
+
+    def test_aggregates_grouped_costs(self, monkeypatch):
+        monkeypatch.setattr(bc.utils, "is_service_available_in_partition", lambda *a, **k: True)
+        monkeypatch.setattr(bc.utils, "get_partition_default_region", lambda *a, **k: "us-east-1")
+
+        client = MagicMock()
+        client.get_cost_and_usage.return_value = {
+            "ResultsByTime": [
+                {
+                    "Groups": [
+                        {"Keys": ["Amazon Relational Database Service"],
+                         "Metrics": {"BlendedCost": {"Amount": "12.50"}}},
+                        {"Keys": ["Amazon Simple Storage Service"],
+                         "Metrics": {"BlendedCost": {"Amount": "3.25"}}},
+                    ]
+                }
+            ]
+        }
+        monkeypatch.setattr(bc.utils, "get_boto3_client", lambda *a, **k: client)
+
+        spend = bc.get_service_spend(partition="aws")
+        assert spend == {
+            "Amazon Relational Database Service": 12.50,
+            "Amazon Simple Storage Service": 3.25,
+        }
+
+
+class TestRunCrosscheck:
+    def test_skip_is_status_tagged_not_raised(self, monkeypatch):
+        monkeypatch.setattr(bc.utils, "is_service_available_in_partition", lambda *a, **k: False)
+        result = bc.run_crosscheck({"Amazon RDS"}, partition="aws-us-gov")
+        assert result["status"] == bc.STATUS_SKIPPED
+        assert "GovCloud" in result["reason"]
+
+    def test_ok_result_has_buckets_and_period(self, monkeypatch):
+        monkeypatch.setattr(
+            bc, "get_service_spend",
+            lambda **k: {"Amazon Simple Storage Service": 7.0},
+        )
+        result = bc.run_crosscheck(
+            {"Amazon RDS"}, partition="aws", reference_date=datetime.date(2026, 3, 10)
+        )
+        assert result["status"] == bc.STATUS_OK
+        assert result["period"] == {"start": "2026-02-01", "end": "2026-03-01"}
+        assert result["not_collected"][0]["service"] == "Amazon Simple Storage Service"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #209. **Stacked on #207** (base: `feat/discovery-detector-coverage`), which is stacked on #206. Merge order: #206 → #207 → this.

## Why

Discovery probes a fixed catalog of APIs — it can only find what it's coded to look for (see #207, #214). **Spend is the one signal that doesn't lie about what's running.** This reconciles Cost Explorer per-service spend against what discovery found, so an audit surfaces *"spend detected, never collected"* gaps directly.

## Engine — `scripts/smart_scan/bill_crosscheck.py`

Library code (returns data, logs via `utils.log_*`, no `print`):
- **`get_service_spend()`** — `GetCostAndUsage` grouped by `SERVICE` for the last full month, pinned to the partition default region. CE is us-east-1 only / absent in GovCloud → clean skip; missing `ce:GetCostAndUsage` → clean skip with a clear reason (never a failure — a mandatory cross-check must not sink a run).
- **`map_ce_service()`** — maps CE billing names (incl. `- Compute`/`- Other` suffixes and short aliases) to canonical services.
- **`reconcile()`** — four buckets per the agreed design (*surface all, ignore-list artifacts*):
  - `confirmed` — billed **and** discovered
  - `not_collected` — billed, maps to a known service, **NOT** discovered ⚠ the audit signal
  - `unmapped` — real spend, no known service (surfaced, not hidden)
  - `ignored` — tax / support / refund / credit line items (explicit ignore-list only)
- **`run_crosscheck()`** — status-tagged result, never raises.

## Integration — `smart_scan.py`

Runs after discovery in **both Quick and Deep** scans (opt out: `STRATUSSCAN_SKIP_BILL_CROSSCHECK=1`):
- console summary of not-collected spend,
- a **Bill Cross-Check** section in the Markdown report,
- a **Bill Cross-Check** sheet in the Deep Scan workbook.

## Dependency note

Depends on the **#206** alias fix: discovery emits catalog names (`Amazon RDS`) while CE emits canonical names (`Amazon Relational Database Service`); both normalize through `get_canonical_service_name` to reconcile. That's why this is stacked on the discovery work rather than branched off `dev`.

## Tests

20 unit tests — mocked CE client (`get_cost_and_usage` pagination, AccessDenied→skip, GovCloud→skip) + pure `reconcile`/`map_ce_service`/period-math logic. 219 smart_scan + smoke tests pass; no new ruff violations beyond the codebase's existing house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)