### PR TITLE
Fix NameError in cross-account session env-var path

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -212,6 +212,36 @@ class TestBoto3ClientCreation:
         assert hasattr(config, 'retries')
 
 
+class TestCrossAccountSession:
+    """Test the STRATUSSCAN_ROLE_ARN env-var injection path in get_aws_session."""
+
+    @patch('utils._assume_role_cached')
+    @patch('utils.boto3.Session')
+    def test_role_arn_env_var_does_not_raise(self, mock_session, mock_assume, monkeypatch):
+        """
+        Regression: get_aws_session() must not NameError on the
+        STRATUSSCAN_ROLE_ARN branch (org-scan / cross-account subprocess path).
+
+        Exporters call get_boto3_client() without role_arn, so role_arn arrives
+        as None; org-scan injects the role via the env var. The debug-log line
+        on that branch previously referenced an undefined ``log`` symbol.
+        """
+        role = "arn:aws:iam::123456789012:role/CrossAccountAudit"
+        monkeypatch.setenv("STRATUSSCAN_ROLE_ARN", role)
+
+        mock_assume.return_value = {
+            "AccessKeyId": "AKIA_TEST",
+            "SecretAccessKey": "secret",
+            "SessionToken": "token",
+        }
+
+        # Should complete without NameError and assume the env-supplied role.
+        utils.get_aws_session(region_name="us-east-1")
+
+        mock_assume.assert_called_once()
+        assert mock_assume.call_args[0][0] == role
+
+
 class TestLogging:
     """Test logging functions."""
 

--- a/utils.py
+++ b/utils.py
@@ -3119,7 +3119,9 @@ def get_aws_session(
         env_role = os.environ.get("STRATUSSCAN_ROLE_ARN", "").strip()
         if env_role:
             role_arn = env_role
-            log.debug("STRATUSSCAN_ROLE_ARN env var active: %s", role_arn)
+            logging.getLogger(__name__).debug(
+                "STRATUSSCAN_ROLE_ARN env var active: %s", role_arn
+            )
 
     if role_arn:
         creds = _assume_role_cached(role_arn, region_name=region_name, profile_name=profile_name)


### PR DESCRIPTION
## Problem

`get_aws_session()` referenced an undefined `log` symbol on the `STRATUSSCAN_ROLE_ARN` branch:

```python
if role_arn is None:
    env_role = os.environ.get("STRATUSSCAN_ROLE_ARN", "").strip()
    if env_role:
        role_arn = env_role
        log.debug(...)   # NameError: name 'log' is not defined
```

That branch is the **only** path exercised by org-scan / cross-account subprocess launches (`stratusscan.py` injects `STRATUSSCAN_ROLE_ARN` per account). Since every exporter calls `get_boto3_client()` **without** `role_arn`, the value arrives as `None`, the env var is read, and the `NameError` fires on the first AWS client creation — breaking cross-account scans entirely.

It stayed latent because the smoke suite never sets `STRATUSSCAN_ROLE_ARN`, and recent testing has been single-account. Surfaced by ruff `F821` (undefined-name).

## Fix

Use `logging.getLogger(__name__).debug(...)`, matching the sibling `_assume_role_cached`.

## Test

Adds `TestCrossAccountSession` driving the env-var branch with a mocked assume-role, asserting it completes without `NameError` and assumes the env-supplied role. Fails before the fix, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)