### PR TITLE
Remove deferred ruff ignores and fix the underlying findings

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -151,16 +151,12 @@ def print_status_line(label: str, status: str, width: int = 70):
 
 def get_status_icon(status: str) -> str:
     """Get status icon based on status string."""
-    if status == "ok":
-        return "✅"
-    elif status == "warning":
-        return "⚠️ "
-    elif status == "error":
-        return "❌"
-    elif status == "unknown":
-        return "❓"
-    else:
-        return "  "
+    return {
+        "ok": "✅",
+        "warning": "⚠️ ",
+        "error": "❌",
+        "unknown": "❓",
+    }.get(status, "  ")
 
 # ============================================================================
 # BACKGROUND CHECKS
@@ -216,9 +212,7 @@ def check_permissions_silent() -> dict:
             'error': 'No AWS credentials configured'
         }
 
-    partition = identity['partition']
     test_region = identity['default_region']
-    is_govcloud = partition == 'aws-us-gov'
 
     # Simplified permission tests (subset for speed)
     permission_tests = {
@@ -1079,7 +1073,7 @@ def install_dependencies(missing_packages: list[dict]) -> bool:
     for package in missing_packages:
         print(f"\n[INSTALLING] {package['name']}...")
         try:
-            result = subprocess.run([
+            subprocess.run([
                 sys.executable, "-m", "pip", "install", package['name']
             ], capture_output=True, text=True, check=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,16 +152,6 @@ ignore = [
     "B008",  # do not perform function calls in argument defaults
     "N806",  # SCRIPT_START_TIME is an intentional UPPERCASE local constant convention across all exporters
     "N818",  # navigation/control-flow signals (BackSignal, ExitToMainSignal, QuitSignal, …) are intentionally not *Error
-    # --- Deferred: pre-existing style debt, not remediated in the CI-gate PR. ---
-    # CI enforces a clean floor today; these rules are silenced only because
-    # findings remain. Remove each code (and fix the findings) in a follow-up
-    # ratchet. None of these affect runtime behavior.
-    "SIM102",  # collapsible-if
-    "SIM113",  # enumerate-for-loop
-    "SIM116",  # if-else-block-instead-of-dict-lookup
-    "SIM117",  # multiple-with-statements
-    "B904",    # raise-without-from-inside-except
-    "F841",    # unused local variable (mostly in tests / config wizard)
 ]
 
 # Ruff per-file ignores

--- a/scripts/access_analyzer_export.py
+++ b/scripts/access_analyzer_export.py
@@ -552,10 +552,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Access Analyzer data
         export_access_analyzer_data(account_id, account_name)

--- a/scripts/acm_export.py
+++ b/scripts/acm_export.py
@@ -401,10 +401,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export ACM data
         export_acm_data(account_id, account_name)

--- a/scripts/ami_export.py
+++ b/scripts/ami_export.py
@@ -264,10 +264,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export AMI data
         export_ami_data(account_id, account_name)

--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -464,10 +464,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export API Gateway data
         export_api_gateway_data(account_id, account_name)

--- a/scripts/autoscaling_export.py
+++ b/scripts/autoscaling_export.py
@@ -489,10 +489,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Auto Scaling data
         export_autoscaling_data(account_id, account_name)

--- a/scripts/backup_export.py
+++ b/scripts/backup_export.py
@@ -431,10 +431,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export AWS Backup data
         export_backup_data(account_id, account_name)

--- a/scripts/budgets_export.py
+++ b/scripts/budgets_export.py
@@ -356,10 +356,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Budgets data
         export_budgets_data(account_id, account_name)

--- a/scripts/cloudfront_export.py
+++ b/scripts/cloudfront_export.py
@@ -501,10 +501,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export CloudFront data
         export_cloudfront_data(account_id, account_name)

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -541,10 +541,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export CloudTrail data
         export_cloudtrail_data(account_id, account_name)

--- a/scripts/cloudwatch_export.py
+++ b/scripts/cloudwatch_export.py
@@ -437,10 +437,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export CloudWatch data
         export_cloudwatch_data(account_id, account_name)

--- a/scripts/config_export.py
+++ b/scripts/config_export.py
@@ -558,10 +558,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export AWS Config data
         export_config_data(account_id, account_name)

--- a/scripts/directconnect_export.py
+++ b/scripts/directconnect_export.py
@@ -710,10 +710,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Direct Connect data
         export_directconnect_data(account_id, account_name)

--- a/scripts/dynamodb_export.py
+++ b/scripts/dynamodb_export.py
@@ -540,10 +540,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export DynamoDB data
         export_dynamodb_data(account_id, account_name)

--- a/scripts/ebs_snapshots_export.py
+++ b/scripts/ebs_snapshots_export.py
@@ -205,10 +205,9 @@ def main():
         # Now import pandas (after dependency check)
         import pandas as pd
 
-        if account_name == "UNKNOWN-ACCOUNT":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "UNKNOWN-ACCOUNT" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         regions = utils.prompt_region_selection()
 

--- a/scripts/ecr_export.py
+++ b/scripts/ecr_export.py
@@ -448,10 +448,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export ECR data
         export_ecr_data(account_id, account_name)

--- a/scripts/efs_export.py
+++ b/scripts/efs_export.py
@@ -480,10 +480,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export EFS data
         export_efs_data(account_id, account_name)

--- a/scripts/elasticache_export.py
+++ b/scripts/elasticache_export.py
@@ -571,10 +571,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export ElastiCache data
         export_elasticache_data(account_id, account_name)

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -319,10 +319,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export EventBridge data
         export_eventbridge_data(account_id, account_name)

--- a/scripts/fsx_export.py
+++ b/scripts/fsx_export.py
@@ -377,10 +377,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export FSx data
         export_fsx_data(account_id, account_name)

--- a/scripts/globalaccelerator_export.py
+++ b/scripts/globalaccelerator_export.py
@@ -753,10 +753,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Global Accelerator data
         export_globalaccelerator_data(account_id, account_name)

--- a/scripts/guardduty_export.py
+++ b/scripts/guardduty_export.py
@@ -607,10 +607,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export GuardDuty data
         export_guardduty_data(account_id, account_name)

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -507,10 +507,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export EC2 Image Builder data
         export_image_builder_data(account_id, account_name)

--- a/scripts/kms_export.py
+++ b/scripts/kms_export.py
@@ -460,10 +460,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export KMS data
         export_kms_data(account_id, account_name)

--- a/scripts/lambda_export.py
+++ b/scripts/lambda_export.py
@@ -495,10 +495,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Lambda data
         export_lambda_data(account_id, account_name)

--- a/scripts/network_firewall_export.py
+++ b/scripts/network_firewall_export.py
@@ -582,10 +582,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Network Firewall data
         export_network_firewall_data(account_id, account_name)

--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -356,9 +356,7 @@ def get_rds_instances(region):
         utils.log_info(f"Found {total_instances} RDS instances in {region} to process")
 
     # Process each instance
-    processed = 0
-    for instance in all_instances:
-        processed += 1
+    for processed, instance in enumerate(all_instances, start=1):
         instance_id = instance.get('DBInstanceIdentifier', 'Unknown')
         progress = (processed / total_instances) * 100 if total_instances > 0 else 0
 

--- a/scripts/route53_export.py
+++ b/scripts/route53_export.py
@@ -774,10 +774,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Prompt for regions (for Resolver resources)
         print("\nRoute 53 is a global service, but Resolver is regional.")

--- a/scripts/savings_plans_export.py
+++ b/scripts/savings_plans_export.py
@@ -277,10 +277,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Savings Plans data
         export_savings_plans_data(account_id, account_name)

--- a/scripts/secrets_manager_export.py
+++ b/scripts/secrets_manager_export.py
@@ -463,10 +463,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Secrets Manager data
         export_secrets_data(account_id, account_name)

--- a/scripts/sqs_sns_export.py
+++ b/scripts/sqs_sns_export.py
@@ -338,10 +338,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export SQS/SNS data
         export_sqs_sns_data(account_id, account_name)

--- a/scripts/ssm_fleet_export.py
+++ b/scripts/ssm_fleet_export.py
@@ -460,10 +460,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export SSM Fleet data
         export_ssm_fleet_data(account_id, account_name)

--- a/scripts/transit_gateway_export.py
+++ b/scripts/transit_gateway_export.py
@@ -571,10 +571,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export Transit Gateway data
         export_transit_gateway_data(account_id, account_name)

--- a/scripts/trusted_advisor_cost_optimization_export.py
+++ b/scripts/trusted_advisor_cost_optimization_export.py
@@ -153,10 +153,9 @@ def extract_savings(metadata, index):
         float: The extracted savings value, or 0 if not found
     """
     try:
-        if len(metadata) > index and metadata[index] and isinstance(metadata[index], str):
-            if "$" in metadata[index]:
-                savings_text = metadata[index].replace("$", "").replace(",", "")
-                return float(savings_text)
+        if len(metadata) > index and metadata[index] and isinstance(metadata[index], str) and "$" in metadata[index]:
+            savings_text = metadata[index].replace("$", "").replace(",", "")
+            return float(savings_text)
     except (ValueError, IndexError, AttributeError):
         pass
     return 0

--- a/scripts/vpc_data_export.py
+++ b/scripts/vpc_data_export.py
@@ -948,10 +948,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export VPC, subnet, NAT Gateway, VPC Peering, and Elastic IP information
         export_vpc_subnet_natgw_peering_info(account_id, account_name)

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -854,10 +854,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Detect partition for region examples
         regions = utils.prompt_region_selection()

--- a/scripts/waf_export.py
+++ b/scripts/waf_export.py
@@ -640,10 +640,9 @@ def main():
             sys.exit(1)
 
         # Check if account name is unknown
-        if account_name == "unknown":
-            if not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
-                print("Exiting script...")
-                sys.exit(0)
+        if account_name == "unknown" and not utils.prompt_for_confirmation("Unable to determine account name. Proceed anyway?", default=False):
+            print("Exiting script...")
+            sys.exit(0)
 
         # Export WAF data
         export_waf_data(account_id, account_name)

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -312,9 +312,9 @@ def execute_script(script_path):
 
     except subprocess.CalledProcessError as e:
         if e.returncode == 10:
-            raise BackSignal
+            raise BackSignal from None
         if e.returncode == 11:
-            raise ExitToMainSignal
+            raise ExitToMainSignal from None
         print(f"Error executing script: {e}")
         utils.log_error(f"Script execution error: {script_name}", e)
         return False

--- a/tests/smart_scan/test_analyzer.py
+++ b/tests/smart_scan/test_analyzer.py
@@ -315,7 +315,7 @@ class TestServiceAnalyzerIntegration:
         analyzer = ServiceAnalyzer()
 
         services = {"Amazon Elastic Compute Cloud", "Amazon Simple Storage Service"}
-        service_map = analyzer.map_services_to_scripts(services)
+        analyzer.map_services_to_scripts(services)
         recommendations = analyzer.generate_recommendations(include_always_run=True)
 
         assert recommendations["coverage_stats"]["services_with_scripts"] == 2

--- a/tests/smart_scan/test_executor.py
+++ b/tests/smart_scan/test_executor.py
@@ -205,11 +205,10 @@ class TestScriptExecutorMethods:
         output/ directory being empty (which leaks state between runs).
         """
         import utils
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.object(utils, "get_output_dir", return_value=Path(tmpdir)):
-                executor = ScriptExecutor({"ec2_export.py"})
-                result = executor._find_output_file("ec2_export")
-                assert result is None
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(utils, "get_output_dir", return_value=Path(tmpdir)):
+            executor = ScriptExecutor({"ec2_export.py"})
+            result = executor._find_output_file("ec2_export")
+            assert result is None
 
     def test_find_output_file_not_found(self):
         """A pre-existing file present before the run is not attributed to it.

--- a/tests/sslib/test_aws_client.py
+++ b/tests/sslib/test_aws_client.py
@@ -117,9 +117,8 @@ class TestGetBoto3ClientFips:
         mock_client = MagicMock()
         mock_session.client.return_value = mock_client
 
-        with patch("utils.boto3.Session", return_value=mock_session):
-            with patch("utils.config_value", return_value={}):
-                get_boto3_client("ec2", region_name="us-gov-west-1")
+        with patch("utils.boto3.Session", return_value=mock_session), patch("utils.config_value", return_value={}):
+            get_boto3_client("ec2", region_name="us-gov-west-1")
 
         call_kwargs = mock_session.client.call_args[1]
         assert "use_fips_endpoint" not in call_kwargs, (
@@ -134,9 +133,8 @@ class TestGetBoto3ClientFips:
         mock_session = MagicMock()
         mock_session.client.return_value = MagicMock()
 
-        with patch("utils.boto3.Session", return_value=mock_session):
-            with patch("utils.config_value", return_value={}):
-                get_boto3_client("s3", region_name="us-gov-east-1")
+        with patch("utils.boto3.Session", return_value=mock_session), patch("utils.config_value", return_value={}):
+            get_boto3_client("s3", region_name="us-gov-east-1")
 
         call_kwargs = mock_session.client.call_args[1]
         assert "use_fips_endpoint" not in call_kwargs
@@ -147,9 +145,8 @@ class TestGetBoto3ClientFips:
         mock_session = MagicMock()
         mock_session.client.return_value = MagicMock()
 
-        with patch("utils.boto3.Session", return_value=mock_session):
-            with patch("utils.config_value", return_value={}):
-                get_boto3_client("ec2", region_name="us-east-1")
+        with patch("utils.boto3.Session", return_value=mock_session), patch("utils.config_value", return_value={}):
+            get_boto3_client("ec2", region_name="us-east-1")
 
         call_kwargs = mock_session.client.call_args[1]
         assert "use_fips_endpoint" not in call_kwargs
@@ -159,9 +156,8 @@ class TestGetBoto3ClientFips:
         mock_session = MagicMock()
         mock_session.client.return_value = MagicMock()
 
-        with patch("utils.boto3.Session", return_value=mock_session):
-            with patch("utils.config_value", return_value={}):
-                get_boto3_client("iam")
+        with patch("utils.boto3.Session", return_value=mock_session), patch("utils.config_value", return_value={}):
+            get_boto3_client("iam")
 
         call_kwargs = mock_session.client.call_args[1]
         assert "config" in call_kwargs
@@ -277,11 +273,8 @@ class TestGetCachedAccountInfo:
         mock_sts = Mock()
         mock_sts.get_caller_identity.return_value = {"Account": "999999999999"}
 
-        with patch.object(aws_mod, "_account_info_cache", None):
-            with patch("utils.get_boto3_client", return_value=mock_sts):
-                with patch("utils.get_account_name", return_value="PROD"):
-                    with patch("utils.detect_partition", return_value="aws"):
-                        account_id, account_name, partition = get_cached_account_info()
+        with patch.object(aws_mod, "_account_info_cache", None), patch("utils.get_boto3_client", return_value=mock_sts), patch("utils.get_account_name", return_value="PROD"), patch("utils.detect_partition", return_value="aws"):
+            account_id, account_name, partition = get_cached_account_info()
 
         assert account_id == "999999999999"
         assert account_name == "PROD"
@@ -290,9 +283,8 @@ class TestGetCachedAccountInfo:
         aws_mod._account_info_cache = None
 
     def test_returns_defaults_on_failure(self):
-        with patch.object(aws_mod, "_account_info_cache", None):
-            with patch("utils.get_boto3_client", side_effect=Exception("boom")):
-                account_id, account_name, partition = get_cached_account_info()
+        with patch.object(aws_mod, "_account_info_cache", None), patch("utils.get_boto3_client", side_effect=Exception("boom")):
+            account_id, account_name, partition = get_cached_account_info()
 
         assert account_id == "UNKNOWN"
         assert account_name == "UNKNOWN-ACCOUNT"

--- a/tests/sslib/test_concurrency.py
+++ b/tests/sslib/test_concurrency.py
@@ -98,14 +98,13 @@ class TestScanRegionsConcurrent:
     def test_disabled_config_falls_back_to_sequential(self):
         config_with_disabled = {"advanced_settings": {"concurrent_scanning": {"enabled": False}}}
 
-        with patch("utils.get_config", return_value=({}, config_with_disabled)):
-            with patch("utils._scan_regions_sequential", side_effect=lambda r, f, p: []) as mock_seq:
-                scan_regions_concurrent(
-                    ["us-east-1"],
-                    lambda r: r,
-                    show_progress=False,
-                )
-                mock_seq.assert_called_once()
+        with patch("utils.get_config", return_value=({}, config_with_disabled)), patch("utils._scan_regions_sequential", side_effect=lambda r, f, p: []) as mock_seq:
+            scan_regions_concurrent(
+                ["us-east-1"],
+                lambda r: r,
+                show_progress=False,
+            )
+            mock_seq.assert_called_once()
 
     def test_fallback_on_all_errors(self):
         """If every worker fails, fallback_on_error triggers sequential."""

--- a/tests/sslib/test_config.py
+++ b/tests/sslib/test_config.py
@@ -98,11 +98,10 @@ class TestLoadConfig:
             call_count["n"] += 1
             return original_load()
 
-        with patch.object(cfg_mod, "_config_path", return_value=cfg_file):
-            with patch.object(cfg_mod, "load_config", side_effect=counting_load):
-                get_config()
-                get_config()
-                get_config()
+        with patch.object(cfg_mod, "_config_path", return_value=cfg_file), patch.object(cfg_mod, "load_config", side_effect=counting_load):
+            get_config()
+            get_config()
+            get_config()
 
         assert call_count["n"] == 1, "load_config should only be called once"
 
@@ -155,9 +154,8 @@ class TestGetResourcePreference:
 
 class TestGetAccountName:
     def test_returns_mapped_name(self):
-        with patch.object(cfg_mod, "ACCOUNT_MAPPINGS", {"123456789012": "PROD"}):
-            with patch.object(cfg_mod, "get_config", return_value=({"123456789012": "PROD"}, {})):
-                assert get_account_name("123456789012") == "PROD"
+        with patch.object(cfg_mod, "ACCOUNT_MAPPINGS", {"123456789012": "PROD"}), patch.object(cfg_mod, "get_config", return_value=({"123456789012": "PROD"}, {})):
+            assert get_account_name("123456789012") == "PROD"
 
     def test_returns_default_when_unmapped(self):
         with patch.object(cfg_mod, "get_config", return_value=({}, {})):

--- a/tests/test_dataframe_export.py
+++ b/tests/test_dataframe_export.py
@@ -168,7 +168,7 @@ class TestPrepareDataFrameForExport(unittest.TestCase):
         df_copy = df.copy()
 
         # Prepare for export
-        result = utils.prepare_dataframe_for_export(df)
+        utils.prepare_dataframe_for_export(df)
 
         # Verify original DataFrame is unchanged
         pd.testing.assert_frame_equal(df, df_copy)
@@ -331,7 +331,7 @@ class TestSanitizeForExport(unittest.TestCase):
         df_copy = df.copy()
 
         # Sanitize for export
-        result = utils.sanitize_for_export(df)
+        utils.sanitize_for_export(df)
 
         # Verify original DataFrame is unchanged
         pd.testing.assert_frame_equal(df, df_copy)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -41,7 +41,7 @@ def test_decorator_reraise() -> str:
     """Test decorator that reraises exceptions."""
     # This will fail with NoCredentialsError if not configured
     ec2 = utils.get_boto3_client('ec2', region_name='us-east-1')
-    response = ec2.describe_instances(InstanceIds=['i-invalid12345'])
+    ec2.describe_instances(InstanceIds=['i-invalid12345'])
     return "Success"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,7 +181,7 @@ class TestBoto3ClientCreation:
         mock_session.return_value = mock_boto_session
 
         # Test
-        client = utils.get_boto3_client('ec2', region_name='us-east-1')
+        utils.get_boto3_client('ec2', region_name='us-east-1')
 
         # Verify
         mock_boto_session.client.assert_called_once()
@@ -203,7 +203,7 @@ class TestBoto3ClientCreation:
         mock_session.return_value = mock_boto_session
 
         # Test
-        client = utils.get_boto3_client('s3')
+        utils.get_boto3_client('s3')
 
         # Verify config was created with retries
         call_args = mock_boto_session.client.call_args
@@ -527,7 +527,7 @@ class TestParseScriptArgs:
     def test_sets_module_global(self, monkeypatch):
         """parse_script_args() must populate utils._SCRIPT_ARGS."""
         utils._SCRIPT_ARGS = None
-        args = self._parse(["--region", "eu-west-1"], monkeypatch)
+        self._parse(["--region", "eu-west-1"], monkeypatch)
         assert utils._SCRIPT_ARGS is not None
         assert utils._SCRIPT_ARGS.region == "eu-west-1"
         assert utils.get_script_args() is utils._SCRIPT_ARGS
@@ -539,13 +539,13 @@ class TestParseScriptArgs:
 
     def test_prompt_region_selection_respects_region_flag(self, monkeypatch):
         """prompt_region_selection() must return single-item list when --region set."""
-        args = self._parse(["--region", "ap-southeast-1"], monkeypatch)
+        self._parse(["--region", "ap-southeast-1"], monkeypatch)
         result = utils.prompt_region_selection()
         assert result == ["ap-southeast-1"]
 
     def test_prompt_region_selection_respects_regions_flag(self, monkeypatch):
         """prompt_region_selection() must return list when --regions set."""
-        args = self._parse(["--regions", "us-east-1,eu-west-1"], monkeypatch)
+        self._parse(["--regions", "us-east-1,eu-west-1"], monkeypatch)
         result = utils.prompt_region_selection()
         assert result == ["us-east-1", "eu-west-1"]
 

--- a/utils.py
+++ b/utils.py
@@ -278,7 +278,7 @@ def prompt_menu(
         except KeyboardInterrupt:
             print()
             if allow_exit:
-                raise QuitSignal
+                raise QuitSignal from None
             continue
 
         if choice in valid:
@@ -2588,7 +2588,9 @@ def scan_regions_concurrent(
                         logging.getLogger(__name__).warning(
                             "Multiple concurrent scanning errors detected (%d errors)", error_count
                         )
-                        raise ConcurrentScanningError(f"Too many concurrent errors: {error_count}")
+                        raise ConcurrentScanningError(
+                            f"Too many concurrent errors: {error_count}"
+                        ) from e
 
                     completed += 1
 


### PR DESCRIPTION
## Summary

Ratchet PR following up #220 (the ruff CI gate). Removes the six style-debt ignores that were parked in `pyproject.toml` and fixes the 62 underlying findings, so the CI gate now enforces these rules too. `ruff check .` stays clean on 3.9 + 3.12 with the ignores gone.

Rules cleared: `SIM102`, `SIM113`, `SIM116`, `SIM117`, `B904`, `F841`.

## What changed

- **B904 (4)** — control-flow signal re-raises use `raise ... from None` (`BackSignal`/`ExitToMainSignal`/`QuitSignal`); the `ConcurrentScanningError` wrap uses `from e` to preserve the real cause.
- **SIM116 (1)** — `configure.get_status_icon` → dict lookup.
- **SIM113 (1)** — `rds_export` `processed` counter → `enumerate(start=1)`.
- **SIM117 (10)** — nested test `with` blocks → comma form. Deliberately **not** the 3.10+ parenthesized form, to preserve the 3.9 CloudShell floor.
- **SIM102 (35)** — collapsible `if` → `and`-chained; short-circuit semantics preserved. Mostly the `account_name`-unknown guard repeated across exporters.
- **F841 (11)** — dropped unused assignments (mostly in tests / the config wizard); calls with side effects are kept.

No runtime behavior change — purely style/idiom.

## Verification

- `ruff check .` → All checks passed (with the six ignores removed)
- Full suite: **698 passed, 2 skipped** (unchanged from baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)