### PR TITLE
Ignore output/ exports and Syncthing conflict artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ build/
 
 # Generated Smart Scan reports (Markdown — keep .gitkeep but not report content)
 reports/*.md
+
+# Generated resource exports
+output/
+
+# Syncthing conflict artifacts
+*.sync-conflict-*


### PR DESCRIPTION
## What

Adds two `.gitignore` rules:
- `output/` — the destination for every export per CLAUDE.md, but it was never ignored, so generated workbooks showed up as untracked noise.
- `*.sync-conflict-*` — Syncthing conflict artifacts (this repo lives under Syncthing); the existing literal `.coverage` rule missed the conflict-file variants.

## Why

Housekeeping. The working tree had accumulated 2,234 test-export files under `output/` plus a batch of stale `*.sync-conflict-*` copies (all pre-#220/#221 snapshots, superseded by HEAD). Those were purged locally; this change stops both classes from recurring.

## Scope

`.gitignore` only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)