### PR TITLE
Fix non-pageable get_paginator calls across 18 exporters

### DIFF
--- a/scripts/acm_privateca_export.py
+++ b/scripts/acm_privateca_export.py
@@ -170,100 +170,24 @@ def collect_private_cas(regions: list[str]) -> list[dict[str, Any]]:
     return all_cas
 
 
-def _scan_issued_certificates_region(region: str) -> list[dict[str, Any]]:
-    """Scan issued certificates in a single region."""
-    regional_certificates = []
-    acmpca_client = utils.get_boto3_client('acm-pca', region_name=region)
-
-    try:
-        # First get all CAs
-        ca_paginator = acmpca_client.get_paginator('list_certificate_authorities')
-        for ca_page in ca_paginator.paginate():
-            cas = ca_page.get('CertificateAuthorities', [])
-
-            for ca in cas:
-                ca_arn = ca.get('Arn', 'N/A')
-                ca_status = ca.get('Status', 'N/A')
-
-                # Skip if CA is not active
-                if ca_status != 'ACTIVE':
-                    continue
-
-                try:
-                    # List certificates for this CA (limit to first 50)
-                    cert_count = 0
-                    cert_paginator = acmpca_client.get_paginator('list_certificates')
-                    for cert_page in cert_paginator.paginate(
-                        CertificateAuthorityArn=ca_arn,
-                        PaginationConfig={'MaxItems': 50}
-                    ):
-                        certificates = cert_page.get('Certificates', [])
-
-                        for cert in certificates:
-                            cert_arn = cert.get('CertificateArn', 'N/A')
-                            serial = cert.get('Serial', 'N/A')
-                            status = cert.get('Status', 'N/A')
-
-                            created_at = cert.get('CreatedAt', 'N/A')
-                            if created_at != 'N/A':
-                                created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
-
-                            not_before = cert.get('NotBefore', 'N/A')
-                            if not_before != 'N/A':
-                                not_before = not_before.strftime('%Y-%m-%d %H:%M:%S')
-
-                            not_after = cert.get('NotAfter', 'N/A')
-                            if not_after != 'N/A':
-                                not_after = not_after.strftime('%Y-%m-%d %H:%M:%S')
-
-                            # Try to get certificate details
-                            try:
-                                cert_response = acmpca_client.get_certificate(
-                                    CertificateAuthorityArn=ca_arn,
-                                    CertificateArn=cert_arn
-                                )
-                                certificate_pem = cert_response.get('Certificate', 'N/A')
-                                # Truncate PEM for display
-                                if certificate_pem != 'N/A':
-                                    certificate_pem = 'Present (PEM truncated)'
-                            except Exception:
-                                certificate_pem = 'N/A'
-
-                            regional_certificates.append({
-                                'Region': region,
-                                'CA ARN': ca_arn,
-                                'Certificate ARN': cert_arn,
-                                'Serial Number': serial,
-                                'Status': status,
-                                'Created At': created_at,
-                                'Not Before': not_before,
-                                'Not After': not_after,
-                                'Certificate': certificate_pem
-                            })
-
-                            cert_count += 1
-
-                        if cert_count >= 50:
-                            break
-
-                except Exception as e:
-                    utils.log_warning(f"Could not list certificates for CA {ca_arn}: {str(e)}")
-                    continue
-
-    except Exception as e:
-        utils.log_warning(f"Error collecting certificates in {region}: {str(e)}")
-
-    return regional_certificates
-
-
 @utils.aws_error_handler("Collecting issued certificates", default_return=[])
 def collect_issued_certificates(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect issued certificates from Private CAs (limited sample)."""
+    """Collect issued certificates from Private CAs.
+
+    NOTE: ACM Private CA exposes no API to enumerate the certificates a CA has
+    issued — there is no ``list_certificates`` operation. The only supported way
+    to obtain issued-certificate inventory is an asynchronous audit report
+    (``CreateCertificateAuthorityAuditReport``) delivered to a caller-supplied S3
+    bucket, which requires write access and is out of scope for this read-only
+    export. This collector therefore returns nothing; CA-level detail is captured
+    by the Private CA collector instead.
+    """
     print("\n=== COLLECTING ISSUED CERTIFICATES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_issued_certificates_region)
-    all_certificates = [cert for result in results for cert in result]
-    utils.log_success(f"Total certificates collected: {len(all_certificates)} (sample limited to 50 per CA)")
-    return all_certificates
+    utils.log_warning(
+        "ACM-PCA has no API to list issued certificates; skipping this sheet. "
+        "Use CreateCertificateAuthorityAuditReport for issued-certificate inventory."
+    )
+    return []
 
 
 

--- a/scripts/apprunner_export.py
+++ b/scripts/apprunner_export.py
@@ -36,8 +36,13 @@ def _scan_apprunner_services_region(region: str) -> list[dict[str, Any]]:
 
     try:
         apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
-        paginator = apprunner_client.get_paginator('list_services')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = apprunner_client.list_services(**params)
             service_summaries = page.get('ServiceSummaryList', [])
 
             for service_summary in service_summaries:
@@ -149,6 +154,10 @@ def _scan_apprunner_services_region(region: str) -> list[dict[str, Any]]:
                     utils.log_warning(f"Could not get details for service {service_name}: {str(e)}")
                     continue
 
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
+
     except Exception as e:
         utils.log_error(f"Error collecting App Runner services in {region}", e)
 
@@ -171,8 +180,13 @@ def _scan_auto_scaling_configs_region(region: str) -> list[dict[str, Any]]:
 
     try:
         apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
-        paginator = apprunner_client.get_paginator('list_auto_scaling_configurations')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = apprunner_client.list_auto_scaling_configurations(**params)
             config_summaries = page.get('AutoScalingConfigurationSummaryList', [])
 
             for config_summary in config_summaries:
@@ -215,6 +229,10 @@ def _scan_auto_scaling_configs_region(region: str) -> list[dict[str, Any]]:
                     utils.log_warning(f"Could not get details for auto scaling config {config_name}: {str(e)}")
                     continue
 
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
+
     except Exception as e:
         utils.log_error(f"Error collecting App Runner auto scaling configs in {region}", e)
 
@@ -237,8 +255,13 @@ def _scan_vpc_connectors_region(region: str) -> list[dict[str, Any]]:
 
     try:
         apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
-        paginator = apprunner_client.get_paginator('list_vpc_connectors')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = apprunner_client.list_vpc_connectors(**params)
             connector_summaries = page.get('VpcConnectors', [])
 
             for connector_summary in connector_summaries:
@@ -281,6 +304,10 @@ def _scan_vpc_connectors_region(region: str) -> list[dict[str, Any]]:
                 except Exception as e:
                     utils.log_warning(f"Could not get details for VPC connector {connector_name}: {str(e)}")
                     continue
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
     except Exception as e:
         utils.log_error(f"Error collecting App Runner VPC connectors in {region}", e)

--- a/scripts/bedrock_export.py
+++ b/scripts/bedrock_export.py
@@ -38,50 +38,50 @@ def collect_foundation_models(regions: list[str]) -> list[dict[str, Any]]:
         bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
 
         try:
-            paginator = bedrock_client.get_paginator('list_foundation_models')
-            for page in paginator.paginate():
-                models = page.get('modelSummaries', [])
+            # list_foundation_models is not paginated (no token) — single call.
+            response = bedrock_client.list_foundation_models()
+            models = response.get('modelSummaries', [])
 
-                for model in models:
-                    model_id = model.get('modelId', 'N/A')
-                    model_arn = model.get('modelArn', 'N/A')
-                    model_name = model.get('modelName', 'N/A')
-                    provider_name = model.get('providerName', 'N/A')
+            for model in models:
+                model_id = model.get('modelId', 'N/A')
+                model_arn = model.get('modelArn', 'N/A')
+                model_name = model.get('modelName', 'N/A')
+                provider_name = model.get('providerName', 'N/A')
 
-                    # Input/output modalities
-                    input_modalities = model.get('inputModalities', [])
-                    output_modalities = model.get('outputModalities', [])
-                    input_str = ', '.join(input_modalities) if input_modalities else 'N/A'
-                    output_str = ', '.join(output_modalities) if output_modalities else 'N/A'
+                # Input/output modalities
+                input_modalities = model.get('inputModalities', [])
+                output_modalities = model.get('outputModalities', [])
+                input_str = ', '.join(input_modalities) if input_modalities else 'N/A'
+                output_str = ', '.join(output_modalities) if output_modalities else 'N/A'
 
-                    # Response streaming
-                    response_streaming = model.get('responseStreamingSupported', False)
+                # Response streaming
+                response_streaming = model.get('responseStreamingSupported', False)
 
-                    # Customization supported
-                    customization_supported = model.get('customizationsSupported', [])
-                    customization_str = ', '.join(customization_supported) if customization_supported else 'None'
+                # Customization supported
+                customization_supported = model.get('customizationsSupported', [])
+                customization_str = ', '.join(customization_supported) if customization_supported else 'None'
 
-                    # Inference types
-                    inference_types = model.get('inferenceTypesSupported', [])
-                    inference_str = ', '.join(inference_types) if inference_types else 'N/A'
+                # Inference types
+                inference_types = model.get('inferenceTypesSupported', [])
+                inference_str = ', '.join(inference_types) if inference_types else 'N/A'
 
-                    # Model lifecycle status
-                    model_lifecycle = model.get('modelLifecycle', {})
-                    lifecycle_status = model_lifecycle.get('status', 'N/A')
+                # Model lifecycle status
+                model_lifecycle = model.get('modelLifecycle', {})
+                lifecycle_status = model_lifecycle.get('status', 'N/A')
 
-                    all_models.append({
-                        'Region': region,
-                        'Model ID': model_id,
-                        'Model Name': model_name,
-                        'Provider': provider_name,
-                        'ARN': model_arn,
-                        'Lifecycle Status': lifecycle_status,
-                        'Input Modalities': input_str,
-                        'Output Modalities': output_str,
-                        'Response Streaming': response_streaming,
-                        'Customization Supported': customization_str,
-                        'Inference Types': inference_str
-                    })
+                all_models.append({
+                    'Region': region,
+                    'Model ID': model_id,
+                    'Model Name': model_name,
+                    'Provider': provider_name,
+                    'ARN': model_arn,
+                    'Lifecycle Status': lifecycle_status,
+                    'Input Modalities': input_str,
+                    'Output Modalities': output_str,
+                    'Response Streaming': response_streaming,
+                    'Customization Supported': customization_str,
+                    'Inference Types': inference_str
+                })
 
         except Exception as e:
             utils.log_warning(f"Error listing foundation models in {region}: {str(e)}")
@@ -202,8 +202,18 @@ def collect_guardrails(regions: list[str]) -> list[dict[str, Any]]:
         bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
 
         try:
-            paginator = bedrock_client.get_paginator('list_guardrails')
-            for page in paginator.paginate():
+            # list_guardrails is absent in older botocore and unpaginated in newer —
+            # probe for the operation, then page manually via nextToken.
+            if 'list_guardrails' not in bedrock_client.meta.service_model.operation_names:
+                utils.log_info(f"Bedrock guardrails API unavailable in this SDK ({region}); skipping.")
+                continue
+
+            next_token = None
+            while True:
+                params: dict[str, Any] = {'maxResults': 100}
+                if next_token:
+                    params['nextToken'] = next_token
+                page = bedrock_client.list_guardrails(**params)
                 guardrails = page.get('guardrails', [])
 
                 for guardrail in guardrails:
@@ -233,6 +243,10 @@ def collect_guardrails(regions: list[str]) -> list[dict[str, Any]]:
                         'Created': created_at,
                         'Updated': updated_at
                     })
+
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
         except Exception as e:
             utils.log_warning(f"Error listing guardrails in {region}: {str(e)}")

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -405,8 +405,13 @@ def collect_event_data_stores_from_region(region: str) -> list[dict[str, Any]]:
 
     ct_client = utils.get_boto3_client('cloudtrail', region_name=region)
 
-    paginator = ct_client.get_paginator('list_event_data_stores')
-    for page in paginator.paginate():
+    next_token = None
+    while True:
+        params = {}
+        params['MaxResults'] = 50
+        if next_token:
+            params['NextToken'] = next_token
+        page = ct_client.list_event_data_stores(**params)
         for store in page.get('EventDataStores', []):
             stores_data.append({
                 'Region': region,
@@ -420,6 +425,9 @@ def collect_event_data_stores_from_region(region: str) -> list[dict[str, Any]]:
                 'Created': str(store.get('CreatedTimestamp', '')),
                 'Updated': str(store.get('UpdatedTimestamp', '')),
             })
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
 
     utils.log_info(f"Found {len(stores_data)} event data store(s) in {region}")
     return stores_data

--- a/scripts/compute_optimizer_export.py
+++ b/scripts/compute_optimizer_export.py
@@ -96,9 +96,13 @@ def get_ec2_recommendations(region):
     compute_optimizer = utils.get_boto3_client('compute-optimizer', region_name=region)
 
     # Use pagination to handle large number of recommendations
-    paginator = compute_optimizer.get_paginator('get_ec2_instance_recommendations')
-
-    for page in paginator.paginate():
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = compute_optimizer.get_ec2_instance_recommendations(**params)
         for recommendation in page.get('instanceRecommendations', []):
             current_instance = recommendation.get('currentInstanceType', 'Unknown')
             instance_id = recommendation.get('instanceArn', 'Unknown').split('/')[-1]
@@ -140,6 +144,10 @@ def get_ec2_recommendations(region):
 
             recommendations.append(rec_entry)
 
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
     utils.log_success(f"Found {len(recommendations)} EC2 instance recommendations in {region}")
     return recommendations
 
@@ -160,9 +168,13 @@ def get_asg_recommendations(region):
     compute_optimizer = utils.get_boto3_client('compute-optimizer', region_name=region)
 
     # Use pagination to handle large number of recommendations
-    paginator = compute_optimizer.get_paginator('get_auto_scaling_group_recommendations')
-
-    for page in paginator.paginate():
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = compute_optimizer.get_auto_scaling_group_recommendations(**params)
         for recommendation in page.get('autoScalingGroupRecommendations', []):
             asg_name = recommendation.get('autoScalingGroupName', 'Unknown')
             current_instances = recommendation.get('currentInstanceType', ['Unknown'])
@@ -201,6 +213,10 @@ def get_asg_recommendations(region):
 
             recommendations.append(rec_entry)
 
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
     utils.log_success(f"Found {len(recommendations)} Auto Scaling Group recommendations in {region}")
     return recommendations
 
@@ -221,9 +237,13 @@ def get_ebs_recommendations(region):
     compute_optimizer = utils.get_boto3_client('compute-optimizer', region_name=region)
 
     # Use pagination to handle large number of recommendations
-    paginator = compute_optimizer.get_paginator('get_ebs_volume_recommendations')
-
-    for page in paginator.paginate():
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = compute_optimizer.get_ebs_volume_recommendations(**params)
         for recommendation in page.get('volumeRecommendations', []):
             volume_arn = recommendation.get('volumeArn', 'Unknown')
             volume_id = volume_arn.split('/')[-1]
@@ -278,6 +298,10 @@ def get_ebs_recommendations(region):
             }
 
             recommendations.append(rec_entry)
+
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
 
     utils.log_success(f"Found {len(recommendations)} EBS volume recommendations in {region}")
     return recommendations
@@ -363,9 +387,13 @@ def get_ecs_recommendations(region):
     compute_optimizer = utils.get_boto3_client('compute-optimizer', region_name=region)
 
     # Use pagination to handle large number of recommendations
-    paginator = compute_optimizer.get_paginator('get_ecs_service_recommendations')
-
-    for page in paginator.paginate():
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = compute_optimizer.get_ecs_service_recommendations(**params)
         for recommendation in page.get('ecsServiceRecommendations', []):
             service_arn = recommendation.get('serviceArn', 'Unknown')
             service_name = service_arn.split('/')[-1]
@@ -415,6 +443,10 @@ def get_ecs_recommendations(region):
             }
 
             recommendations.append(rec_entry)
+
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
 
     utils.log_success(f"Found {len(recommendations)} ECS service recommendations in {region}")
     return recommendations

--- a/scripts/detective_export.py
+++ b/scripts/detective_export.py
@@ -121,9 +121,13 @@ def collect_members(region: str, graph_arn: str) -> list[dict[str, Any]]:
 
     try:
         # List members using paginator
-        paginator = client.get_paginator('list_members')
-
-        for page in paginator.paginate(GraphArn=graph_arn):
+        next_token = None
+        while True:
+            params = {'GraphArn': graph_arn}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = client.list_members(**params)
             members = page.get('MemberDetails', [])
 
             for member in members:
@@ -143,6 +147,10 @@ def collect_members(region: str, graph_arn: str) -> list[dict[str, Any]]:
                 }
 
                 members_data.append(member_info)
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
     except Exception as e:
         utils.log_error(f"Error collecting members for graph {graph_arn}", e)

--- a/scripts/elasticbeanstalk_export.py
+++ b/scripts/elasticbeanstalk_export.py
@@ -38,10 +38,8 @@ def collect_applications_from_region(region: str) -> list[dict[str, Any]]:
     applications = []
     eb_client = utils.get_boto3_client('elasticbeanstalk', region_name=region)
 
-    paginator = eb_client.get_paginator('describe_applications')
-    apps = []
-    for page in paginator.paginate():
-        apps.extend(page.get('Applications', []))
+    response = eb_client.describe_applications()
+    apps = response.get('Applications', [])
 
     for app in apps:
         app_name = app.get('ApplicationName', 'N/A')
@@ -230,10 +228,8 @@ def collect_application_versions_from_region(region: str) -> list[dict[str, Any]
     eb_client = utils.get_boto3_client('elasticbeanstalk', region_name=region)
 
     # First get all applications
-    apps_paginator = eb_client.get_paginator('describe_applications')
-    applications = []
-    for page in apps_paginator.paginate():
-        applications.extend(page.get('Applications', []))
+    response = eb_client.describe_applications()
+    applications = response.get('Applications', [])
 
     for app in applications:
         app_name = app.get('ApplicationName', '')
@@ -318,10 +314,8 @@ def collect_configuration_templates_from_region(region: str) -> list[dict[str, A
     eb_client = utils.get_boto3_client('elasticbeanstalk', region_name=region)
 
     # First get all applications
-    apps_paginator = eb_client.get_paginator('describe_applications')
-    applications = []
-    for page in apps_paginator.paginate():
-        applications.extend(page.get('Applications', []))
+    response = eb_client.describe_applications()
+    applications = response.get('Applications', [])
 
     for app in applications:
         app_name = app.get('ApplicationName', '')

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -51,9 +51,12 @@ def _scan_event_buses_region(region: str) -> list[dict[str, Any]]:
 
     try:
         events_client = utils.get_boto3_client('events', region_name=region)
-        paginator = events_client.get_paginator('list_event_buses')
-
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = events_client.list_event_buses(**params)
             for bus in page.get('EventBuses', []):
                 buses_data.append({
                     'Region': region,
@@ -61,6 +64,10 @@ def _scan_event_buses_region(region: str) -> list[dict[str, Any]]:
                     'Event Bus ARN': bus.get('Arn', 'N/A'),
                     'Has Policy': 'Yes' if bus.get('Policy') else 'No'
                 })
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception as e:
         utils.log_error(f"Error scanning event buses in {region}", e)
 
@@ -86,9 +93,16 @@ def _scan_event_rules_region(region: str) -> list[dict[str, Any]]:
     try:
         events_client = utils.get_boto3_client('events', region_name=region)
         buses = []
-        buses_paginator = events_client.get_paginator('list_event_buses')
-        for page in buses_paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = events_client.list_event_buses(**params)
             buses.extend(page.get('EventBuses', []))
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
         for bus in buses:
             bus_name = bus.get('Name', 'default')
@@ -140,9 +154,16 @@ def _scan_rule_targets_region(region: str) -> list[dict[str, Any]]:
     try:
         events_client = utils.get_boto3_client('events', region_name=region)
         buses = []
-        buses_paginator = events_client.get_paginator('list_event_buses')
-        for page in buses_paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = events_client.list_event_buses(**params)
             buses.extend(page.get('EventBuses', []))
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
         for bus in buses:
             bus_name = bus.get('Name', 'default')

--- a/scripts/glue_athena_export.py
+++ b/scripts/glue_athena_export.py
@@ -186,8 +186,13 @@ def _scan_athena_workgroups_region(region: str) -> list[dict[str, Any]]:
     regional_workgroups = []
     try:
         athena_client = utils.get_boto3_client('athena', region_name=region)
-        paginator = athena_client.get_paginator('list_work_groups')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = athena_client.list_work_groups(**params)
             for wg_summary in page.get('WorkGroups', []):
                 workgroup_name = wg_summary.get('Name', 'N/A')
                 try:
@@ -202,6 +207,9 @@ def _scan_athena_workgroups_region(region: str) -> list[dict[str, Any]]:
                     regional_workgroups.append({'Region': region, 'Workgroup Name': workgroup_name, 'State': wg.get('State', 'N/A'), 'Description': wg.get('Description', 'N/A'), 'Output Location': result_config.get('OutputLocation', 'N/A'), 'Encryption': encryption_option, 'KMS Key': encryption_config.get('KmsKey', 'N/A') if encryption_option != 'None' else 'N/A', 'Bytes Scanned Cutoff': configuration.get('BytesScannedCutoffPerQuery', 'N/A'), 'Enforce Config': 'Yes' if configuration.get('EnforceWorkGroupConfiguration', False) else 'No', 'CloudWatch Metrics': 'Yes' if configuration.get('PublishCloudWatchMetricsEnabled', False) else 'No', 'Requester Pays': 'Yes' if configuration.get('RequesterPaysEnabled', False) else 'No', 'Engine Version': engine_version.get('SelectedEngineVersion', 'N/A') if engine_version else 'N/A', 'Created': creation_time.strftime('%Y-%m-%d %H:%M:%S') if creation_time else 'N/A'})
                 except Exception as e:
                     utils.log_warning(f"Could not get details for workgroup {workgroup_name}: {str(e)}")
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception as e:
         utils.log_error(f"Error collecting Athena workgroups in {region}", e)
     return regional_workgroups

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -72,9 +72,17 @@ def collect_image_pipelines(regions: list[str]) -> list[dict[str, Any]]:
 
             # Get image pipelines (paginated)
             pipeline_arns = []
-            paginator = imagebuilder.get_paginator('list_image_pipelines')
-            for page in paginator.paginate():
+            next_token = None
+            while True:
+                params = {}
+                params['maxResults'] = 100
+                if next_token:
+                    params['nextToken'] = next_token
+                page = imagebuilder.list_image_pipelines(**params)
                 pipeline_arns.extend([p['arn'] for p in page.get('imagePipelineList', [])])
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
             print(f"  Found {len(pipeline_arns)} pipelines")
 
@@ -174,10 +182,18 @@ def collect_image_recipes(regions: list[str]) -> list[dict[str, Any]]:
             imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
 
             # Get image recipes
-            paginator = imagebuilder.get_paginator('list_image_recipes')
             recipe_arns = []
-            for page in paginator.paginate():
+            next_token = None
+            while True:
+                params = {}
+                params['maxResults'] = 100
+                if next_token:
+                    params['nextToken'] = next_token
+                page = imagebuilder.list_image_recipes(**params)
                 recipe_arns.extend([r['arn'] for r in page.get('imageRecipeSummaryList', [])])
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
             for recipe_arn in recipe_arns:
                 try:
@@ -260,10 +276,18 @@ def collect_components(regions: list[str]) -> list[dict[str, Any]]:
             imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
 
             # Get components (owned by account)
-            paginator = imagebuilder.get_paginator('list_components')
             component_arns = []
-            for page in paginator.paginate(owner='Self'):
+            next_token = None
+            while True:
+                params = {'owner': 'Self'}
+                params['maxResults'] = 100
+                if next_token:
+                    params['nextToken'] = next_token
+                page = imagebuilder.list_components(**params)
                 component_arns.extend([c['arn'] for c in page.get('componentVersionList', [])])
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
             for component_arn in component_arns:
                 try:
@@ -339,10 +363,18 @@ def collect_infrastructure_configurations(regions: list[str]) -> list[dict[str, 
             imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
 
             # Get infrastructure configurations
-            paginator = imagebuilder.get_paginator('list_infrastructure_configurations')
             config_arns = []
-            for page in paginator.paginate():
+            next_token = None
+            while True:
+                params = {}
+                params['maxResults'] = 100
+                if next_token:
+                    params['nextToken'] = next_token
+                page = imagebuilder.list_infrastructure_configurations(**params)
                 config_arns.extend([c['arn'] for c in page.get('infrastructureConfigurationSummaryList', [])])
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
             for config_arn in config_arns:
                 try:

--- a/scripts/lakeformation_export.py
+++ b/scripts/lakeformation_export.py
@@ -35,8 +35,13 @@ def _scan_lakeformation_resources_region(region: str) -> list[dict[str, Any]]:
     regional_resources = []
     try:
         lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-        paginator = lf_client.get_paginator('list_resources')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = lf_client.list_resources(**params)
             resources = page.get('ResourceInfoList', [])
 
             for resource in resources:
@@ -69,6 +74,9 @@ def _scan_lakeformation_resources_region(region: str) -> list[dict[str, Any]]:
                     'Role ARN': role_arn,
                     'Last Modified': last_modified_str,
                 })
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception as e:
         utils.log_error(f"Error collecting Lake Formation resources in {region}", e)
     return regional_resources
@@ -79,8 +87,13 @@ def _scan_lakeformation_permissions_region(region: str) -> list[dict[str, Any]]:
     regional_permissions = []
     try:
         lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-        paginator = lf_client.get_paginator('list_permissions')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = lf_client.list_permissions(**params)
             permissions = page.get('PrincipalResourcePermissions', [])
 
             for perm in permissions:
@@ -162,6 +175,9 @@ def _scan_lakeformation_permissions_region(region: str) -> list[dict[str, Any]]:
                     'Permissions': permissions_str,
                     'Grant Permissions': grant_permissions_str,
                 })
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception as e:
         utils.log_error(f"Error collecting Lake Formation permissions in {region}", e)
     return regional_permissions

--- a/scripts/license_manager_export.py
+++ b/scripts/license_manager_export.py
@@ -120,8 +120,13 @@ def collect_grants(region: str) -> list[dict[str, Any]]:
     grants = []
 
     try:
-        paginator = lm.get_paginator('list_received_grants')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = lm.list_received_grants(**params)
             for grant in page.get('Grants', []):
                 grants.append({
                     'Region': region,
@@ -135,12 +140,20 @@ def collect_grants(region: str) -> list[dict[str, Any]]:
                     'Version': grant.get('Version', 'N/A'),
                     'StatusReason': grant.get('StatusReason', 'N/A'),
                 })
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception:
         pass
 
     try:
-        paginator = lm.get_paginator('list_distributed_grants')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = lm.list_distributed_grants(**params)
             for grant in page.get('Grants', []):
                 grants.append({
                     'Region': region,
@@ -154,6 +167,9 @@ def collect_grants(region: str) -> list[dict[str, Any]]:
                     'Version': grant.get('Version', 'N/A'),
                     'StatusReason': grant.get('StatusReason', 'N/A'),
                 })
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception:
         pass
 
@@ -167,8 +183,13 @@ def collect_licenses(region: str) -> list[dict[str, Any]]:
     licenses = []
 
     try:
-        paginator = lm.get_paginator('list_licenses')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = lm.list_licenses(**params)
             for license_obj in page.get('Licenses', []):
                 # Extract entitlements
                 entitlements = []
@@ -190,6 +211,9 @@ def collect_licenses(region: str) -> list[dict[str, Any]]:
                     'ConsumptionConfiguration': str(license_obj.get('ConsumptionConfiguration', {})),
                     'Version': license_obj.get('Version', 'N/A'),
                 })
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception:
         pass
 

--- a/scripts/marketplace_export.py
+++ b/scripts/marketplace_export.py
@@ -37,10 +37,14 @@ def collect_agreements() -> list[dict[str, Any]]:
 
     try:
         # Search for all agreements (active and expired)
-        paginator = mp_client.get_paginator('search_agreements')
-
         # Search without filters to get all agreements
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['maxResults'] = 100
+            if next_token:
+                params['nextToken'] = next_token
+            page = mp_client.search_agreements(**params)
             agreements = page.get('agreementViewSummaries', [])
 
             for agreement_summary in agreements:
@@ -93,6 +97,10 @@ def collect_agreements() -> list[dict[str, Any]]:
                     utils.log_warning(f"Could not get details for agreement {agreement_id}: {str(e)}")
                     continue
 
+            next_token = page.get('nextToken')
+            if not next_token:
+                break
+
     except Exception as e:
         utils.log_warning(f"Error searching agreements: {str(e)}")
 
@@ -116,8 +124,13 @@ def collect_agreement_terms(agreements: list[dict[str, Any]]) -> list[dict[str, 
 
         try:
             # Get agreement terms
-            paginator = mp_client.get_paginator('get_agreement_terms')
-            for page in paginator.paginate(agreementId=agreement_id):
+            next_token = None
+            while True:
+                params = {'agreementId': agreement_id}
+                params['maxResults'] = 100
+                if next_token:
+                    params['nextToken'] = next_token
+                page = mp_client.get_agreement_terms(**params)
                 accepted_terms = page.get('acceptedTerms', [])
 
                 for term in accepted_terms:
@@ -163,6 +176,10 @@ def collect_agreement_terms(agreements: list[dict[str, Any]]) -> list[dict[str, 
                         'Support Details': support_info,
                         'Renewal Details': renewal_info
                     })
+
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
         except Exception as e:
             utils.log_warning(f"Could not get terms for agreement {agreement_id}: {str(e)}")

--- a/scripts/savings_plans_export.py
+++ b/scripts/savings_plans_export.py
@@ -69,10 +69,14 @@ def collect_savings_plans(states: list[str]) -> list[dict[str, Any]]:
         print(f"\nProcessing state: {state}")
 
         try:
-            paginator = sp_client.get_paginator('describe_savings_plans')
-            page_iterator = paginator.paginate(states=[state])
+            # describe_savings_plans has no boto3 paginator; page manually via nextToken.
+            next_token = None
+            while True:
+                params: dict[str, Any] = {'states': [state], 'maxResults': 100}
+                if next_token:
+                    params['nextToken'] = next_token
 
-            for page in page_iterator:
+                page = sp_client.describe_savings_plans(**params)
                 savings_plans = page.get('savingsPlans', [])
 
                 for plan in savings_plans:
@@ -149,6 +153,10 @@ def collect_savings_plans(states: list[str]) -> list[dict[str, Any]]:
                         'Tags': tags_str,
                         'Savings Plan ARN': plan_arn
                     })
+
+                next_token = page.get('nextToken')
+                if not next_token:
+                    break
 
         except Exception as e:
             utils.log_error(f"Error collecting savings plans in state {state}", e)

--- a/scripts/ses_export.py
+++ b/scripts/ses_export.py
@@ -37,8 +37,12 @@ def _scan_email_identities_region(region: str) -> list[dict[str, Any]]:
     ses_client = utils.get_boto3_client('sesv2', region_name=region)
 
     try:
-        paginator = ses_client.get_paginator('list_email_identities')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = ses_client.list_email_identities(**params)
             identities = page.get('EmailIdentities', [])
 
             for identity_summary in identities:
@@ -102,6 +106,10 @@ def _scan_email_identities_region(region: str) -> list[dict[str, Any]]:
                     utils.log_warning(f"Could not get details for identity {identity_name} in {region}: {str(e)}")
                     continue
 
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
+
     except Exception as e:
         utils.log_warning(f"Error listing email identities in {region}: {str(e)}")
 
@@ -124,8 +132,12 @@ def _scan_configuration_sets_region(region: str) -> list[dict[str, Any]]:
     ses_client = utils.get_boto3_client('sesv2', region_name=region)
 
     try:
-        paginator = ses_client.get_paginator('list_configuration_sets')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = ses_client.list_configuration_sets(**params)
             config_sets = page.get('ConfigurationSets', [])
 
             for config_set_name in config_sets:
@@ -190,6 +202,10 @@ def _scan_configuration_sets_region(region: str) -> list[dict[str, Any]]:
                     utils.log_warning(f"Could not get details for configuration set {config_set_name} in {region}: {str(e)}")
                     continue
 
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
+
     except Exception as e:
         utils.log_warning(f"Error listing configuration sets in {region}: {str(e)}")
 
@@ -212,8 +228,12 @@ def _scan_email_templates_region(region: str) -> list[dict[str, Any]]:
     ses_client = utils.get_boto3_client('sesv2', region_name=region)
 
     try:
-        paginator = ses_client.get_paginator('list_email_templates')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = ses_client.list_email_templates(**params)
             templates = page.get('TemplatesMetadata', [])
 
             for template_metadata in templates:
@@ -251,6 +271,10 @@ def _scan_email_templates_region(region: str) -> list[dict[str, Any]]:
                 except Exception as e:
                     utils.log_warning(f"Could not get details for template {template_name} in {region}: {str(e)}")
                     continue
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
     except Exception as e:
         utils.log_warning(f"Error listing email templates in {region}: {str(e)}")

--- a/scripts/ses_pinpoint_export.py
+++ b/scripts/ses_pinpoint_export.py
@@ -48,8 +48,12 @@ def collect_ses_identities(region: str) -> list[dict[str, Any]]:
     identities = []
 
     try:
-        paginator = sesv2.get_paginator('list_email_identities')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = sesv2.list_email_identities(**params)
             for identity in page.get('EmailIdentities', []):
                 identity_name = identity.get('IdentityName', 'N/A')
 
@@ -89,6 +93,10 @@ def collect_ses_identities(region: str) -> list[dict[str, Any]]:
                         'MailFromStatus': 'N/A',
                         'FeedbackForwardingEnabled': 'N/A',
                     })
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception as e:
         utils.log_warning(f"Error collecting SES identities in region {region}: {e}")
 
@@ -102,8 +110,12 @@ def collect_ses_config_sets(region: str) -> list[dict[str, Any]]:
     config_sets = []
 
     try:
-        paginator = sesv2.get_paginator('list_configuration_sets')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = sesv2.list_configuration_sets(**params)
             for config_set_name in page.get('ConfigurationSets', []):
                 # Get detailed configuration set information
                 try:
@@ -138,6 +150,10 @@ def collect_ses_config_sets(region: str) -> list[dict[str, Any]]:
                         'LastFreshStart': 'N/A',
                         'SuppressionListReasons': 'N/A',
                     })
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception:
         pass
 
@@ -183,8 +199,12 @@ def collect_ses_templates(region: str) -> list[dict[str, Any]]:
     templates = []
 
     try:
-        paginator = sesv2.get_paginator('list_email_templates')
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            if next_token:
+                params['NextToken'] = next_token
+            page = sesv2.list_email_templates(**params)
             for template in page.get('TemplatesMetadata', []):
                 template_name = template.get('TemplateName', 'N/A')
 
@@ -193,6 +213,10 @@ def collect_ses_templates(region: str) -> list[dict[str, Any]]:
                     'TemplateName': template_name,
                     'CreatedTimestamp': template.get('CreatedTimestamp', 'N/A'),
                 })
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
     except Exception:
         pass
 

--- a/scripts/shield_export.py
+++ b/scripts/shield_export.py
@@ -291,9 +291,13 @@ def collect_protection_groups() -> list[dict[str, Any]]:
 
     try:
         # List protection groups
-        paginator = client.get_paginator('list_protection_groups')
-
-        for page in paginator.paginate():
+        next_token = None
+        while True:
+            params = {}
+            params['MaxResults'] = 50
+            if next_token:
+                params['NextToken'] = next_token
+            page = client.list_protection_groups(**params)
             groups = page.get('ProtectionGroups', [])
 
             for group in groups:
@@ -308,6 +312,10 @@ def collect_protection_groups() -> list[dict[str, Any]]:
                 }
 
                 groups_data.append(group_info)
+
+            next_token = page.get('NextToken')
+            if not next_token:
+                break
 
         if groups_data:
             utils.log_info(f"Found {len(groups_data)} protection group(s)")

--- a/scripts/waf_export.py
+++ b/scripts/waf_export.py
@@ -67,9 +67,13 @@ def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[d
     wafv2_client = utils.get_boto3_client('wafv2', region_name=region)
 
     # List web ACLs
-    paginator = wafv2_client.get_paginator('list_web_acls')
-
-    for page in paginator.paginate(Scope=scope):
+    next_marker = None
+    while True:
+        params = {'Scope': scope}
+        params['Limit'] = 100
+        if next_marker:
+            params['NextMarker'] = next_marker
+        page = wafv2_client.list_web_acls(**params)
         web_acls = page.get('WebACLs', [])
 
         for acl_summary in web_acls:
@@ -138,6 +142,10 @@ def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[d
             except Exception as e:
                 utils.log_warning(f"Could not get details for web ACL {acl_name}: {e}")
 
+        next_marker = page.get('NextMarker')
+        if not next_marker:
+            break
+
     utils.log_info(f"Found {len(web_acls_data)} web ACLs ({scope}) in {region}")
     return web_acls_data
 
@@ -198,9 +206,13 @@ def collect_waf_rules_from_region(region: str, scope: str = 'REGIONAL') -> list[
     wafv2_client = utils.get_boto3_client('wafv2', region_name=region)
 
     # List web ACLs first
-    acl_paginator = wafv2_client.get_paginator('list_web_acls')
-
-    for acl_page in acl_paginator.paginate(Scope=scope):
+    next_marker = None
+    while True:
+        params = {'Scope': scope}
+        params['Limit'] = 100
+        if next_marker:
+            params['NextMarker'] = next_marker
+        acl_page = wafv2_client.list_web_acls(**params)
         web_acls = acl_page.get('WebACLs', [])
 
         for acl_summary in web_acls:
@@ -295,6 +307,10 @@ def collect_waf_rules_from_region(region: str, scope: str = 'REGIONAL') -> list[
             except Exception as e:
                 utils.log_warning(f"Could not get rules for web ACL {acl_name}: {e}")
 
+        next_marker = acl_page.get('NextMarker')
+        if not next_marker:
+            break
+
     utils.log_info(f"Found {len(rules_data)} rules ({scope}) in {region}")
     return rules_data
 
@@ -355,9 +371,13 @@ def collect_ip_sets_from_region(region: str, scope: str = 'REGIONAL') -> list[di
     wafv2_client = utils.get_boto3_client('wafv2', region_name=region)
 
     # List IP sets
-    paginator = wafv2_client.get_paginator('list_ip_sets')
-
-    for page in paginator.paginate(Scope=scope):
+    next_marker = None
+    while True:
+        params = {'Scope': scope}
+        params['Limit'] = 100
+        if next_marker:
+            params['NextMarker'] = next_marker
+        page = wafv2_client.list_ip_sets(**params)
         ip_sets = page.get('IPSets', [])
 
         for ip_set_summary in ip_sets:
@@ -399,6 +419,10 @@ def collect_ip_sets_from_region(region: str, scope: str = 'REGIONAL') -> list[di
 
             except Exception as e:
                 utils.log_warning(f"Could not get IP set {ip_set_name}: {e}")
+
+        next_marker = page.get('NextMarker')
+        if not next_marker:
+            break
 
     utils.log_info(f"Found {len(ip_sets_data)} IP sets ({scope}) in {region}")
     return ip_sets_data
@@ -459,9 +483,13 @@ def collect_rule_groups_from_region(region: str, scope: str = 'REGIONAL') -> lis
     rule_groups_data = []
     wafv2_client = utils.get_boto3_client('wafv2', region_name=region)
 
-    paginator = wafv2_client.get_paginator('list_rule_groups')
-
-    for page in paginator.paginate(Scope=scope):
+    next_marker = None
+    while True:
+        params = {'Scope': scope}
+        params['Limit'] = 100
+        if next_marker:
+            params['NextMarker'] = next_marker
+        page = wafv2_client.list_rule_groups(**params)
         rule_groups = page.get('RuleGroups', [])
 
         for rg_summary in rule_groups:
@@ -501,6 +529,10 @@ def collect_rule_groups_from_region(region: str, scope: str = 'REGIONAL') -> lis
 
             except Exception as e:
                 utils.log_warning(f"Could not get rule group {rg_name}: {e}")
+
+        next_marker = page.get('NextMarker')
+        if not next_marker:
+            break
 
     utils.log_info(f"Found {len(rule_groups_data)} rule groups ({scope}) in {region}")
     return rule_groups_data


### PR DESCRIPTION
Fixes #223.

## Problem

Exporters called `client.get_paginator('op')` on AWS operations boto3 has no paginator for. Each raised `OperationNotPageableError`, got swallowed by the broad per-collector `except`, and returned **0 results** — silent data loss. Reported via the Savings Plans export showing "No Savings Plans found."

## Fix

Replaced ~40 non-pageable paginator calls across 18 exporters with manual token loops using each API's native contract:

| Convention | Exporters |
|---|---|
| `NextToken` / `MaxResults` | apprunner, cloudtrail, detective, glue_athena, lakeformation, license_manager, shield, savings_plans |
| `nextToken` / `maxResults` | compute_optimizer, image_builder, marketplace |
| `NextToken`, no max | ses, ses_pinpoint, eventbridge |
| `NextMarker` / `Limit` (Scope preserved) | waf |
| single call (no token) | elasticbeanstalk `describe_applications`, bedrock `list_foundation_models` |

**Special cases**
- `bedrock list_guardrails` — absent at the pinned botocore floor (1.34.46); added an op-availability probe that skips cleanly + a manual loop for SDKs that expose it.
- `acm_privateca` — ACM-PCA has **no `list_certificates` API**; the issued-cert scanner could never return data. Removed it; the collector now logs the limitation and returns empty. Real inventory needs async `CreateCertificateAuthorityAuditReport` (S3/write) — flagged for a product decision.

## Verification
- Authoritative botocore `can_paginate` re-sweep: **0** remaining non-pageable `get_paginator` calls.
- `ruff check .` clean (3.9 floor preserved — no PEP-604, no 3.10+ syntax).
- Full suite: **698 passed, 2 skipped** (unchanged from baseline).

## Method
Mechanical fixes fanned out to 5 grouped subagents with exact per-op contracts (token field, list key, max param); the two design-level cases (bedrock guardrails, acm-pca) handled directly. Central re-sweep + ruff + pytest as the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)