### PR TITLE
Replace os.system screen-clear with ANSI escape in configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -24,7 +24,6 @@ Usage:
 """
 
 import json
-import os
 import re
 import subprocess
 import sys
@@ -111,6 +110,14 @@ def get_aws_identity() -> Optional[dict]:
 # ============================================================================
 # VISUAL HELPERS
 # ============================================================================
+
+def clear_screen():
+    """
+    Clear the terminal screen using ANSI escape codes (avoids os.system shell call).
+    Works on Windows 10+, Linux, and macOS terminals.
+    """
+    print('\033[2J\033[H', end='', flush=True)
+
 
 def print_box(title: str, width: int = 70):
     """Print a box with title."""
@@ -395,7 +402,7 @@ def print_dashboard(config: dict, config_path: Path):
         config (dict): Configuration dictionary
         config_path (Path): Path to config file
     """
-    os.system('cls' if os.name == 'nt' else 'clear')
+    clear_screen()
     identity = get_aws_identity()
 
     # Header
@@ -543,7 +550,7 @@ def config_wizard(config: dict):
     Re-entrant — safe to run on an already-configured system.
     """
     def _clr():
-        return os.system('cls' if os.name == 'nt' else 'clear')
+        return clear_screen()
 
     _clr()
     print_section("CONFIG WIZARD")
@@ -690,7 +697,7 @@ def manage_account_mappings(config: dict):
     global _config_modified
 
     while True:
-        os.system('cls' if os.name == 'nt' else 'clear')
+        clear_screen()
         print_section("MANAGE ACCOUNT MAPPINGS")
 
         mappings = config.get('account_mappings', {})


### PR DESCRIPTION
## Summary

- Replaces the `os.system('cls' if os.name == 'nt' else 'clear')` screen-clear in `configure.py` (3 call sites) with an ANSI-based `clear_screen()` helper mirroring the one already in `stratusscan.py`.
- Removes the now-unused `import os`.

## Why

`os.system` is flagged by static analysis (Veracode SAST) as CWE-78 (OS command injection) regardless of whether the argument is a hardcoded literal. This is the one genuine (non-false-positive) SAST finding in the app code ahead of the upcoming Veracode scan. `stratusscan.py:clear_screen()` already fixed the identical pattern and even documented it ("avoids os.system shell call") — `configure.py` was simply never brought in line. Also removes a needless shell dependency for a cosmetic screen clear.

## Linked Issue(s)

Closes #225

## Validation

How was this verified?

- [x] Unit tests
- [ ] Integration/end-to-end tests
- [x] Manual verification
- [x] CI checks passed

Evidence (commands, screenshots, logs, links):

```text
$ grep -n 'os.system' configure.py
116:    Clear the terminal screen using ANSI escape codes (avoids os.system shell call).   # docstring only

$ ruff check configure.py
All checks passed!

$ python3 -c "import configure; configure.clear_screen()"
imports OK; clear_screen() callable OK   # emits \033[2J\033[H

$ python3 -m pytest -k config
26 passed, 681 deselected
```

## Risk Assessment

- Functional regression: low  (behavior-preserving; ANSI clear already proven in stratusscan.py on Win10+/Linux/macOS)
- Security impact: low  (removes a shell-out; net reduction in attack surface)
- Deployment risk: low

## Reviewer Checklist

- [ ] Scope matches linked issue intent
- [ ] Acceptance criteria satisfied
- [ ] Test evidence adequate for risk level
- [ ] No sensitive data or secrets introduced
