### PR TITLE
Fix silent RDS data loss when region collection fails

### DIFF
--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -25,6 +25,7 @@ import datetime
 import json
 import re
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -312,16 +313,172 @@ def calculate_rds_storage_cost(storage_size, storage_type, storage_pricing):
         utils.log_warning(f"Error calculating storage cost: {e}")
         return 'N/A'
 
-@utils.aws_error_handler("Retrieving RDS instances", default_return=[])
+def _build_instance_data(instance, region, rds_client, pricing_data, storage_pricing, cost_note):
+    """
+    Build the export row for a single RDS instance.
+
+    Extracted so the per-instance processing can be wrapped in try/except by the
+    caller: a malformed instance (e.g. an engine variant such as RDS Custom that
+    omits an expected field) is logged and skipped rather than discarding the
+    whole region's results. Every required field is read with ``.get()`` and a
+    safe default for the same reason.
+
+    Args:
+        instance (dict): A single DBInstances entry from describe_db_instances.
+        region (str): AWS region name.
+        rds_client: Boto3 RDS client (for cluster-role and SG/VPC lookups).
+        pricing_data (dict): RDS instance pricing data.
+        storage_pricing (dict): EBS/storage pricing data.
+        cost_note (str): Partition-aware cost estimate note.
+
+    Returns:
+        dict: The assembled instance row.
+    """
+    instance_id = instance.get('DBInstanceIdentifier', 'Unknown')
+
+    # Extract security group IDs from VPC security groups
+    sg_ids = [sg['VpcSecurityGroupId'] for sg in instance.get('VpcSecurityGroups', [])]
+    sg_info = get_security_group_info(rds_client, sg_ids)
+
+    # Get VPC information from DB subnet group
+    vpc_id = instance.get('DBSubnetGroup', {}).get('VpcId', 'N/A')
+    vpc_info = get_vpc_info(rds_client, vpc_id) if vpc_id != 'N/A' else 'N/A'
+
+    # Get subnet IDs from DB subnet group
+    subnet_ids = get_subnet_ids(instance.get('DBSubnetGroup', {}))
+
+    # Get port information from endpoint
+    port = instance.get('Endpoint', {}).get('Port', 'N/A') if 'Endpoint' in instance else 'N/A'
+
+    # Get endpoint address - RDS connection endpoint
+    endpoint_address = instance.get('Endpoint', {}).get('Address', 'N/A') if 'Endpoint' in instance else 'N/A'
+
+    # Get master username - the primary database user
+    master_username = instance.get('MasterUsername', 'N/A')
+
+    # Determine if instance is part of a cluster and its role
+    db_cluster_id = instance.get('DBClusterIdentifier', 'N/A')
+    role = 'Standalone'
+    if db_cluster_id != 'N/A':
+        try:
+            # Get cluster info to determine if this instance is primary or replica
+            cluster_info = rds_client.describe_db_clusters(
+                DBClusterIdentifier=db_cluster_id
+            )
+            if cluster_info and 'DBClusters' in cluster_info and cluster_info['DBClusters']:
+                cluster = cluster_info['DBClusters'][0]
+                # Check if this instance is the primary (writer) in the cluster
+                if 'DBClusterMembers' in cluster:
+                    for member in cluster['DBClusterMembers']:
+                        if member.get('DBInstanceIdentifier') == instance_id:
+                            role = 'Primary' if member.get('IsClusterWriter', False) else 'Replica'
+        except Exception as e:
+            # If we can't determine cluster role, leave as default
+            utils.log_warning(f"Could not determine cluster role for {instance_id}: {e}")
+
+    # Check for RDS Extended Support status
+    extended_support = 'No'
+    try:
+        if 'StatusInfos' in instance:
+            for status_info in instance['StatusInfos']:
+                if status_info.get('Status') == 'extended-support':
+                    extended_support = 'Yes'
+    except Exception:
+        pass
+
+    # Format certificate expiry date
+    cert_expiry = 'N/A'
+    try:
+        if 'CertificateDetails' in instance and 'ValidTill' in instance['CertificateDetails']:
+            valid_till = instance['CertificateDetails']['ValidTill']
+            if isinstance(valid_till, datetime.datetime):
+                cert_expiry = valid_till.replace(tzinfo=None).strftime('%Y-%m-%d %H:%M:%S')
+    except Exception:
+        pass
+
+    # Format creation time
+    created_time = 'N/A'
+    try:
+        if 'InstanceCreateTime' in instance:
+            create_time = instance['InstanceCreateTime']
+            if isinstance(create_time, datetime.datetime):
+                created_time = create_time.replace(tzinfo=None).strftime('%Y-%m-%d %H:%M:%S')
+    except Exception:
+        pass
+
+    # Required fields read defensively: engine variants (Aurora, RDS Custom) can
+    # omit fields another engine always sets. A missing field yields 'N/A', not a
+    # KeyError that would sink the entire region (see the 07.15.2026 audit).
+    instance_class = instance.get('DBInstanceClass', 'N/A')
+    engine = instance.get('Engine', 'N/A')
+    engine_version = instance.get('EngineVersion', 'N/A')
+    allocated_storage = instance.get('AllocatedStorage', 'N/A')
+    storage_type = instance.get('StorageType', 'N/A')
+
+    # Calculate monthly cost
+    monthly_cost = calculate_rds_monthly_cost(instance_class, engine, pricing_data)
+
+    # Calculate storage cost
+    storage_cost = calculate_rds_storage_cost(allocated_storage, storage_type, storage_pricing)
+
+    # Calculate total monthly cost
+    total_monthly_cost = 'N/A'
+    if monthly_cost != 'N/A' and storage_cost != 'N/A':
+        total_monthly_cost = round(float(monthly_cost) + float(storage_cost), 2)
+    elif monthly_cost != 'N/A':
+        total_monthly_cost = float(monthly_cost)
+    elif storage_cost != 'N/A':
+        total_monthly_cost = float(storage_cost)
+
+    return {
+        'DB Identifier': instance_id,
+        'DB Cluster Identifier': db_cluster_id,
+        'Role': role,
+        'Engine': engine,
+        'Engine Version': engine_version,
+        'RDS Extended Support': extended_support,
+        'Region': region,
+        'Size': instance_class,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Monthly Storage Cost': storage_cost,
+        'Total Monthly Cost': total_monthly_cost,
+        'Cost Note': cost_note,
+        'Storage Type': storage_type,
+        'Storage (GB)': allocated_storage,
+        'Provisioned IOPS': instance.get('Iops', 'N/A'),
+        'Port': port,
+        'Endpoint': endpoint_address,  # RDS connection endpoint
+        'Master Username': master_username,  # Primary database user
+        'VPC': vpc_info,
+        'Subnet IDs': subnet_ids,
+        'Security Groups': sg_info,
+        'DB Subnet Group Name': instance.get('DBSubnetGroup', {}).get('DBSubnetGroupName', 'N/A'),
+        'DB Certificate Expiry': cert_expiry,
+        'Created Time': created_time,
+        'Encryption': 'Yes' if instance.get('StorageEncrypted', False) else 'No',
+        'Owner ID': utils.get_account_name_formatted(instance.get('OwnerId', 'N/A'))
+    }
+
+
 def get_rds_instances(region):
     """
     Get all RDS instances in a specific AWS region with detailed information.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return an
+    empty list that ``main()`` cannot distinguish from a genuinely empty region,
+    producing silent data loss (no file written). Region-level failures are
+    allowed to raise so the caller can record the region as *failed* rather than
+    *empty*. Per-instance errors are contained internally (logged and skipped).
 
     Args:
         region (str): AWS region name
 
     Returns:
         list: List of dictionaries containing RDS instance information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it as
+            a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -355,7 +512,9 @@ def get_rds_instances(region):
     if total_instances > 0:
         utils.log_info(f"Found {total_instances} RDS instances in {region} to process")
 
-    # Process each instance
+    # Process each instance. One malformed instance must not sink the region, so
+    # each is built inside try/except; failures are logged and skipped.
+    skipped = 0
     for processed, instance in enumerate(all_instances, start=1):
         instance_id = instance.get('DBInstanceIdentifier', 'Unknown')
         progress = (processed / total_instances) * 100 if total_instances > 0 else 0
@@ -363,130 +522,25 @@ def get_rds_instances(region):
         utils.log_info(f"[{progress:.1f}%] Processing RDS instance {processed}/{total_instances}: {instance_id}")
         if processed % 10 == 0:
             print(f"  [{region}] {processed}/{total_instances} RDS instances processed...", flush=True)
-        # Extract security group IDs from VPC security groups
-        sg_ids = [sg['VpcSecurityGroupId'] for sg in instance.get('VpcSecurityGroups', [])]
-        sg_info = get_security_group_info(rds_client, sg_ids)
 
-        # Get VPC information from DB subnet group
-        vpc_id = instance.get('DBSubnetGroup', {}).get('VpcId', 'N/A')
-        vpc_info = get_vpc_info(rds_client, vpc_id) if vpc_id != 'N/A' else 'N/A'
-
-        # Get subnet IDs from DB subnet group
-        subnet_ids = get_subnet_ids(instance.get('DBSubnetGroup', {}))
-
-        # Get port information from endpoint
-        port = instance.get('Endpoint', {}).get('Port', 'N/A') if 'Endpoint' in instance else 'N/A'
-
-        # Get endpoint address - RDS connection endpoint
-        endpoint_address = instance.get('Endpoint', {}).get('Address', 'N/A') if 'Endpoint' in instance else 'N/A'
-
-        # Get master username - the primary database user
-        master_username = instance.get('MasterUsername', 'N/A')
-
-        # Determine if instance is part of a cluster and its role
-        db_cluster_id = instance.get('DBClusterIdentifier', 'N/A')
-        role = 'Standalone'
-        if db_cluster_id != 'N/A':
-            try:
-                # Get cluster info to determine if this instance is primary or replica
-                cluster_info = rds_client.describe_db_clusters(
-                    DBClusterIdentifier=db_cluster_id
-                )
-                if cluster_info and 'DBClusters' in cluster_info and cluster_info['DBClusters']:
-                    cluster = cluster_info['DBClusters'][0]
-                    # Check if this instance is the primary (writer) in the cluster
-                    if 'DBClusterMembers' in cluster:
-                        for member in cluster['DBClusterMembers']:
-                            if member.get('DBInstanceIdentifier') == instance['DBInstanceIdentifier']:
-                                role = 'Primary' if member.get('IsClusterWriter', False) else 'Replica'
-            except Exception as e:
-                # If we can't determine cluster role, leave as default
-                utils.log_warning(f"Could not determine cluster role for {instance['DBInstanceIdentifier']}: {e}")
-
-        # Check for RDS Extended Support status
-        extended_support = 'No'
         try:
-            if 'StatusInfos' in instance:
-                for status_info in instance['StatusInfos']:
-                    if status_info.get('Status') == 'extended-support':
-                        extended_support = 'Yes'
-        except Exception:
-            pass
-
-        # Format certificate expiry date
-        cert_expiry = 'N/A'
-        try:
-            if 'CertificateDetails' in instance and 'ValidTill' in instance['CertificateDetails']:
-                valid_till = instance['CertificateDetails']['ValidTill']
-                if isinstance(valid_till, datetime.datetime):
-                    cert_expiry = valid_till.replace(tzinfo=None).strftime('%Y-%m-%d %H:%M:%S')
-        except Exception:
-            pass
-
-        # Format creation time
-        created_time = 'N/A'
-        try:
-            if 'InstanceCreateTime' in instance:
-                create_time = instance['InstanceCreateTime']
-                if isinstance(create_time, datetime.datetime):
-                    created_time = create_time.replace(tzinfo=None).strftime('%Y-%m-%d %H:%M:%S')
-        except Exception:
-            pass
-
-        # Create comprehensive instance data dictionary
-        # Calculate monthly cost
-        monthly_cost = calculate_rds_monthly_cost(
-            instance['DBInstanceClass'],
-            instance['Engine'],
-            pricing_data
-        )
-
-        # Calculate storage cost
-        storage_cost = calculate_rds_storage_cost(
-            instance['AllocatedStorage'],
-            instance['StorageType'],
-            storage_pricing
-        )
-
-        # Calculate total monthly cost
-        total_monthly_cost = 'N/A'
-        if monthly_cost != 'N/A' and storage_cost != 'N/A':
-            total_monthly_cost = round(float(monthly_cost) + float(storage_cost), 2)
-        elif monthly_cost != 'N/A':
-            total_monthly_cost = float(monthly_cost)
-        elif storage_cost != 'N/A':
-            total_monthly_cost = float(storage_cost)
-
-        instance_data = {
-            'DB Identifier': instance['DBInstanceIdentifier'],
-            'DB Cluster Identifier': db_cluster_id,
-            'Role': role,
-            'Engine': instance['Engine'],
-            'Engine Version': instance['EngineVersion'],
-            'RDS Extended Support': extended_support,
-            'Region': region,
-            'Size': instance['DBInstanceClass'],
-            'Monthly Cost (On-Demand)': monthly_cost,
-            'Monthly Storage Cost': storage_cost,
-            'Total Monthly Cost': total_monthly_cost,
-            'Cost Note': cost_note,
-            'Storage Type': instance['StorageType'],
-            'Storage (GB)': instance['AllocatedStorage'],
-            'Provisioned IOPS': instance.get('Iops', 'N/A'),
-            'Port': port,
-            'Endpoint': endpoint_address,  # RDS connection endpoint
-            'Master Username': master_username,  # Primary database user
-            'VPC': vpc_info,
-            'Subnet IDs': subnet_ids,
-            'Security Groups': sg_info,
-            'DB Subnet Group Name': instance.get('DBSubnetGroup', {}).get('DBSubnetGroupName', 'N/A'),
-            'DB Certificate Expiry': cert_expiry,
-            'Created Time': created_time,
-            'Encryption': 'Yes' if instance.get('StorageEncrypted', False) else 'No',
-            'Owner ID': utils.get_account_name_formatted(instance.get('OwnerId', 'N/A'))
-        }
+            instance_data = _build_instance_data(
+                instance, region, rds_client, pricing_data, storage_pricing, cost_note
+            )
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping RDS instance '{instance_id}' in {region} due to a processing error", e
+            )
+            continue
 
         rds_instances.append(instance_data)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_instances} RDS instance(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining instances were still collected."
+        )
 
     return rds_instances
 
@@ -554,6 +608,47 @@ def export_to_excel(data, account_name, region_filter=None):
             utils.log_error("CSV export also failed", csv_error)
             return None
 
+def write_failure_marker(account_name, failed_regions):
+    """
+    Write a ``*-rds-instances-FAILED-<date>.txt`` marker into the output
+    directory recording which regions failed to collect.
+
+    This is the visible signal a downstream consumer needs to tell a *failed*
+    RDS pull apart from a genuinely empty account. Without it, a region that
+    errors is indistinguishable from a region with no databases.
+
+    Args:
+        account_name (str): AWS account name (for the filename).
+        failed_regions (list): List of (region, error_message) tuples.
+
+    Returns:
+        str or None: Path to the marker file, or None if it could not be written.
+    """
+    try:
+        today = datetime.datetime.now().strftime("%m.%d.%Y")
+        marker_name = f"{account_name}-rds-instances-FAILED-{today}.txt"
+        marker_path = utils.get_output_filepath(marker_name)
+        lines = [
+            "RDS EXPORT FAILED FOR ONE OR MORE REGIONS",
+            f"Account: {account_name}",
+            f"Timestamp: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+            "The regions below raised an error during collection. Their RDS data is "
+            "MISSING or INCOMPLETE in any exported spreadsheet. Do NOT treat a missing "
+            "RDS file/rows for these regions as 'no databases' — re-run the export.",
+            "",
+        ]
+        for region, error in failed_regions:
+            lines.append(f"  - {region}: {error}")
+        marker_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        utils.log_error(f"Wrote RDS failure marker: {marker_path}")
+        return str(marker_path)
+    except Exception as e:
+        # Never let marker-writing itself mask the underlying failure.
+        utils.log_error("Could not write RDS failure marker", e)
+        return None
+
+
 def main():
     """
     Main function to coordinate the AWS RDS instance export process.
@@ -580,10 +675,25 @@ def main():
 
     utils.log_info(f"Collecting RDS instance data across {len(regions)} AWS region(s)...")
 
+    # Track regions whose collection raised. A failed region must never be
+    # collapsed into "empty" — that is the silent-data-loss bug (07.15.2026
+    # audit). The concurrent scanner runs scan_region_rds across threads, so the
+    # shared list is guarded by a lock.
+    failed_regions = []
+    failed_lock = threading.Lock()
+
     # Define region scan function for concurrent execution (Phase 4B)
     def scan_region_rds(region):
         utils.log_info(f"Searching for RDS instances in AWS region: {region}")
-        region_instances = get_rds_instances(region)
+        try:
+            region_instances = get_rds_instances(region)
+        except Exception as e:
+            # Record the failure so main() can surface it; return no rows for
+            # this region (partial data from other regions is still exported).
+            with failed_lock:
+                failed_regions.append((region, str(e)))
+            utils.log_error(f"RDS collection FAILED for region {region}", e)
+            return []
         utils.log_info(f"Found {len(region_instances)} RDS instances in {region}")
         return region_instances
 
@@ -598,7 +708,7 @@ def main():
     for instances in region_results:
         all_rds_instances.extend(instances)
 
-    # Export results to Excel file
+    # Export whatever succeeded, then decide on exit status based on failures.
     utils.log_success(f"Found {len(all_rds_instances)} RDS instances in total across all AWS regions.")
 
     if all_rds_instances:
@@ -610,8 +720,25 @@ def main():
         else:
             utils.log_error("Failed to export data. Please check the logs.")
             sys.exit(1)
-    else:
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No RDS instances found in any AWS region. No file exported.")
+
+    # If ANY region failed, make it loud: write a marker and exit non-zero, even
+    # if some data was exported. A partial export that looks complete is exactly
+    # the failure mode this guards against.
+    if failed_regions:
+        region_names = ", ".join(r for r, _ in failed_regions)
+        utils.log_error(
+            f"RDS collection failed for {len(failed_regions)} of {len(regions)} region(s): "
+            f"{region_names}. Exported data is INCOMPLETE."
+        )
+        write_failure_marker(account_name, failed_regions)
+        print(
+            "\nERROR: RDS export completed with failures — data is incomplete. "
+            "See the *-rds-instances-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 if __name__ == "__main__":
     try:

--- a/tests/test_exporters/test_rds_export.py
+++ b/tests/test_exporters/test_rds_export.py
@@ -10,10 +10,12 @@ import sys
 from pathlib import Path
 
 import boto3
+import botocore
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import rds_export  # noqa: E402
 from rds_export import get_rds_instances  # noqa: E402
 
 REGION = "us-east-1"
@@ -93,3 +95,80 @@ class TestGetRdsInstances:
         """Region with no RDS instances returns an empty list."""
         result = get_rds_instances(REGION)
         assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit: RDS data silently lost because a
+    collection error was swallowed to an empty list, indistinguishable from a
+    genuinely empty region. See .collab/audit/07.15.2026-rds-silent-collection-failure.md
+    """
+
+    @mock_aws
+    def test_malformed_instance_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One instance that fails to process must not discard the whole region's
+        results — the healthy instances are still collected.
+        """
+        rds = boto3.client("rds", region_name=REGION)
+        for name in ("good-db", "bad-db"):
+            rds.create_db_instance(
+                DBInstanceIdentifier=name,
+                DBInstanceClass="db.t3.micro",
+                Engine="postgres",
+                MasterUsername="admin",
+                MasterUserPassword="password123",
+                AllocatedStorage=20,
+            )
+
+        original = rds_export._build_instance_data
+
+        def raise_for_bad(instance, *args, **kwargs):
+            if instance.get("DBInstanceIdentifier") == "bad-db":
+                raise KeyError("SomeEngineSpecificField")
+            return original(instance, *args, **kwargs)
+
+        monkeypatch.setattr(rds_export, "_build_instance_data", raise_for_bad)
+
+        result = get_rds_instances(REGION)
+
+        ids = {row["DB Identifier"] for row in result}
+        assert "good-db" in ids, "healthy instance was lost when a sibling failed"
+        assert "bad-db" not in ids, "malformed instance should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeDBInstances",
+            )
+
+        monkeypatch.setattr(rds_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_rds_instances(REGION)
+
+    def test_write_failure_marker_records_failed_regions(self, monkeypatch, tmp_path):
+        """The failure marker names each failed region and warns against treating
+        the export as complete."""
+
+        monkeypatch.setattr(
+            rds_export.utils, "get_output_filepath", lambda name: tmp_path / name
+        )
+
+        marker = rds_export.write_failure_marker(
+            "ACME-PROD",
+            [("us-east-1", "Throttling: Rate exceeded"), ("us-gov-west-1", "KeyError")],
+        )
+
+        assert marker is not None
+        content = (tmp_path / Path(marker).name).read_text()
+        assert "us-east-1" in content
+        assert "us-gov-west-1" in content
+        assert "FAILED" in content


### PR DESCRIPTION
Closes #231.

## Problem

`scripts/rds_export.py` produced **silent, invisible data loss**. Any error during a region's RDS collection was swallowed to `[]`, which `main()` could not tell apart from a genuinely empty region — so the account produced **no file** and exited **0**. In the 07.15.2026 FCC audit, **4 of 15 RDS-bearing accounts silently produced no RDS file** (incl. two production SQL Server fleets). Report: `.collab/audit/07.15.2026-rds-silent-collection-failure.md`.

## Changes

1. **Per-instance robustness** — extracted `_build_instance_data()`; every required field (`DBInstanceClass`, `Engine`, `EngineVersion`, `AllocatedStorage`, `StorageType`, `DBInstanceIdentifier`) now reads with `.get(..., 'N/A')`; each instance is built inside `try/except → log + continue`. One malformed instance (Aurora / RDS Custom) is skipped, not fatal — recovers ~130/131 of the observed loss.
2. **Failed ≠ empty** — removed the `@aws_error_handler(..., default_return=[])` swallow so region failures propagate. `main()` records failed regions thread-safely (the scanner is concurrent), exports whatever succeeded, writes a `{ACCOUNT}-rds-instances-FAILED-{date}.txt` marker, and **exits non-zero**. Genuinely empty accounts stay a plain warning with no marker.

Throttling (report rec #5) is already handled at the client layer (`get_boto3_client` → `max_attempts:10, mode:adaptive`); it was just invisible before. An exhausted retry now surfaces as a FAILED region.

## Tests

New `TestSilentCollectionFailureRegression`:
- malformed instance skipped, healthy siblings survive
- region API `ClientError` raises (not swallowed to `[]`)
- failure marker names each failed region

`pytest`: rds 7/7; full suite **701 passed, 2 skipped, 0 failed**. `ruff` clean.

## Scope / follow-up

Only `rds_export.py` is touched; the shared `aws_error_handler` decorator is unchanged. A separate issue/PR will sweep all `scripts/` exporters for the same swallow → empty → no-file pattern and evaluate blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)