### PR TITLE
Silent collection failure: shared plumbing + Tier-1 exporters

### DIFF
--- a/scripts/ebs_snapshots_export.py
+++ b/scripts/ebs_snapshots_export.py
@@ -98,16 +98,100 @@ def format_tags(tags):
     else:
         return 'N/A'
 
-@utils.aws_error_handler("Collecting EBS snapshots", default_return=[])
+def _build_snapshot_row(snapshot, region):
+    """
+    Build the export row for a single EBS snapshot.
+
+    Extracted so the per-snapshot processing can be wrapped in try/except by the
+    caller: a malformed snapshot entry is logged and skipped rather than
+    discarding the whole region's results. Every required field is read with
+    ``.get()`` and a safe default for the same reason.
+
+    Args:
+        snapshot (dict): A single snapshot entry from describe_snapshots.
+        region (str): AWS region name.
+
+    Returns:
+        dict: The assembled snapshot row.
+    """
+    # Get snapshot name from tags
+    snapshot_name = get_snapshot_name(snapshot)
+
+    # Extract standard snapshot attributes. Required fields read defensively:
+    # a missing field yields 'N/A'/'Unknown', not a KeyError that would sink
+    # the entire region (see the 07.15.2026 audit / 07.16.2026 blast-radius sweep).
+    snapshot_id = snapshot.get('SnapshotId', 'Unknown')
+    volume_id = snapshot.get('VolumeId', 'N/A')
+    description = snapshot.get('Description', 'N/A')
+    volume_size = snapshot.get('VolumeSize', 0)  # Size in GB
+
+    # Handle start time (convert to string without timezone)
+    start_time = snapshot.get('StartTime', '')
+    start_time_str = start_time.strftime('%Y-%m-%d %H:%M:%S') if start_time else 'N/A'
+
+    # Get encryption status
+    encryption = 'Yes' if snapshot.get('Encrypted', False) else 'No'
+
+    # Get storage tier (Standard or Archive)
+    storage_tier = snapshot.get('StorageTier', 'Standard')
+
+    # Get state and progress
+    state = snapshot.get('State', 'N/A')
+    progress = snapshot.get('Progress', 'N/A')
+
+    # Get owner ID with account name mapping
+    owner_id = snapshot.get('OwnerId', 'N/A')
+    owner_formatted = utils.get_account_name_formatted(owner_id)
+
+    # Get KMS key ID if encrypted
+    kms_key_id = snapshot.get('KmsKeyId', 'N/A') if snapshot.get('Encrypted', False) else 'N/A'
+
+    # Format tags
+    snapshot_tags = format_tags(snapshot.get('Tags', []))
+
+    # Additional data processing for specific attributes
+    # Full snapshot size is not directly available via standard API
+    full_snapshot_size_gb = 'N/A'
+
+    return {
+        'Name': snapshot_name,
+        'Snapshot ID': snapshot_id,
+        'Volume ID': volume_id,
+        'Description': description,
+        'Volume Size (GB)': volume_size,
+        'Full Snapshot Size': full_snapshot_size_gb,
+        'Storage Tier': storage_tier,
+        'State': state,
+        'Progress': progress,
+        'Started': start_time_str,
+        'Encryption': encryption,
+        'KMS Key ID': kms_key_id,
+        'Owner ID': owner_formatted,
+        'Region': region,
+        'Tags': snapshot_tags
+    }
+
+
 def get_snapshots(region):
     """
     Get all EBS snapshots owned by the account in a specific AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that ``main()`` cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so the caller can record the region as
+    *failed* rather than *empty*. Per-snapshot errors are contained
+    internally (logged and skipped).
 
     Args:
         region (str): AWS region name
 
     Returns:
         list: List of dictionaries with snapshot information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -123,69 +207,34 @@ def get_snapshots(region):
     paginator = ec2_client.get_paginator('describe_snapshots')
     page_iterator = paginator.paginate(OwnerIds=['self'])
 
+    skipped = 0
+    total_processed = 0
     for page in page_iterator:
-        for snapshot in page['Snapshots']:
-            # Get snapshot name from tags
-            snapshot_name = get_snapshot_name(snapshot)
+        for snapshot in page.get('Snapshots', []):
+            total_processed += 1
+            snapshot_id = snapshot.get('SnapshotId', 'Unknown')
+            try:
+                snapshot_row = _build_snapshot_row(snapshot, region)
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping EBS snapshot '{snapshot_id}' in {region} due to a processing error", e
+                )
+                continue
 
-            # Extract standard snapshot attributes
-            snapshot_id = snapshot['SnapshotId']
-            volume_id = snapshot.get('VolumeId', 'N/A')
-            description = snapshot.get('Description', 'N/A')
-            volume_size = snapshot.get('VolumeSize', 0)  # Size in GB
-
-            # Handle start time (convert to string without timezone)
-            start_time = snapshot.get('StartTime', '')
-            start_time_str = start_time.strftime('%Y-%m-%d %H:%M:%S') if start_time else 'N/A'
-
-            # Get encryption status
-            encryption = 'Yes' if snapshot.get('Encrypted', False) else 'No'
-
-            # Get storage tier (Standard or Archive)
-            storage_tier = snapshot.get('StorageTier', 'Standard')
-
-            # Get state and progress
-            state = snapshot.get('State', 'N/A')
-            progress = snapshot.get('Progress', 'N/A')
-
-            # Get owner ID with account name mapping
-            owner_id = snapshot.get('OwnerId', 'N/A')
-            owner_formatted = utils.get_account_name_formatted(owner_id)
-
-            # Get KMS key ID if encrypted
-            kms_key_id = snapshot.get('KmsKeyId', 'N/A') if snapshot.get('Encrypted', False) else 'N/A'
-
-            # Format tags
-            snapshot_tags = format_tags(snapshot.get('Tags', []))
-
-            # Additional data processing for specific attributes
-            # Full snapshot size is not directly available via standard API
-            full_snapshot_size_gb = 'N/A'
-
-            # Add to results
-            snapshots_data.append({
-                'Name': snapshot_name,
-                'Snapshot ID': snapshot_id,
-                'Volume ID': volume_id,
-                'Description': description,
-                'Volume Size (GB)': volume_size,
-                'Full Snapshot Size': full_snapshot_size_gb,
-                'Storage Tier': storage_tier,
-                'State': state,
-                'Progress': progress,
-                'Started': start_time_str,
-                'Encryption': encryption,
-                'KMS Key ID': kms_key_id,
-                'Owner ID': owner_formatted,
-                'Region': region,
-                'Tags': snapshot_tags
-            })
+            snapshots_data.append(snapshot_row)
         # Inter-page delay to avoid throttling on large accounts
         time.sleep(0.1)
         # Heartbeat every 500 records so terminal stays alive
         collected = len(snapshots_data)
         if collected > 0 and collected % 500 == 0:
             print(f"  [{collected:,} snapshots collected — still running...]")
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_processed} EBS snapshot(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining snapshots were still collected."
+        )
 
     return snapshots_data
 
@@ -221,12 +270,15 @@ def main():
             utils.log_info(f"Found {len(region_snapshots)} snapshots in {region}")
             return region_snapshots
 
-        # Use concurrent region scanning
-        region_results = utils.scan_regions_concurrent(
+        # Use concurrent region scanning. collect_failures=True returns the
+        # regions that raised so a failed collection is distinguishable from a
+        # genuinely empty account (see Issue #233 blast-radius sweep).
+        region_results, failed_regions = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_snapshots,
             max_workers=2,
-            show_progress=True
+            show_progress=True,
+            collect_failures=True
         )
 
         # Flatten results
@@ -238,41 +290,52 @@ def main():
         total_snapshots = len(all_snapshots)
         utils.log_success(f"Total EBS snapshots found across all AWS regions: {total_snapshots}")
 
-        if total_snapshots == 0:
+        if all_snapshots:
+            # Create DataFrame from snapshot data
+            utils.log_info("Preparing data for export to Excel format...")
+            df = pd.DataFrame(all_snapshots)
+
+            # Prepare and sanitize DataFrame (tags may contain secrets)
+            df = utils.sanitize_for_export(
+                utils.prepare_dataframe_for_export(df)
+            )
+
+            # Generate filename with region info
+            region_suffix = regions[0] if len(regions) == 1 else 'all'
+
+            # Use utils module to generate filename
+            filename = utils.create_export_filename(
+                account_name,
+                "ebs-snapshots",
+                region_suffix if region_suffix else None,
+                datetime.datetime.now().strftime("%m.%d.%Y")
+            )
+
+            # Save the data using the utility function
+            output_path = utils.save_dataframe_to_excel(df, filename)
+
+            if output_path:
+                utils.log_success("AWS EBS snapshots data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+                utils.log_info(f"Total snapshots exported: {total_snapshots}")
+                print("\nScript execution completed.")
+            else:
+                utils.log_error("Error exporting data. Please check the logs.")
+                sys.exit(1)
+        elif not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
             utils.log_warning("No snapshots found. Nothing to export.")
-            sys.exit(0)
 
-        # Create DataFrame from snapshot data
-        utils.log_info("Preparing data for export to Excel format...")
-        df = pd.DataFrame(all_snapshots)
-
-        # Prepare and sanitize DataFrame (tags may contain secrets)
-        df = utils.sanitize_for_export(
-            utils.prepare_dataframe_for_export(df)
-        )
-
-        # Generate filename with region info
-        region_suffix = regions[0] if len(regions) == 1 else 'all'
-
-        # Use utils module to generate filename
-        filename = utils.create_export_filename(
-            account_name,
-            "ebs-snapshots",
-            region_suffix if region_suffix else None,
-            datetime.datetime.now().strftime("%m.%d.%Y")
-        )
-
-        # Save the data using the utility function
-        output_path = utils.save_dataframe_to_excel(df, filename)
-
-        if output_path:
-            utils.log_success("AWS EBS snapshots data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-            utils.log_info(f"Total snapshots exported: {total_snapshots}")
-            print("\nScript execution completed.")
-        else:
-            utils.log_error("Error exporting data. Please check the logs.")
+        # If ANY region failed, make it loud: write a marker and exit non-zero,
+        # even if some data was exported. A partial export that looks complete
+        # is exactly the failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, "ebs-snapshots", failed_regions)
+            print(
+                "\nERROR: EBS snapshots export completed with failures — data is incomplete. "
+                "See the *-ebs-snapshots-FAILED-*.txt marker in the output directory."
+            )
             sys.exit(1)
 
     except KeyboardInterrupt:

--- a/scripts/ebs_volumes_export.py
+++ b/scripts/ebs_volumes_export.py
@@ -177,16 +177,113 @@ def calculate_ebs_monthly_cost(volume_type, size_gb, state, pricing_data):
     total_cost = price_per_gb * size_gb
     return round(total_cost, 2)
 
-@utils.aws_error_handler("Collecting EBS volumes", default_return=[])
+def _build_volume_data(volume, region, pricing_data):
+    """
+    Build the export row for a single EBS volume.
+
+    Extracted so the per-volume processing can be wrapped in try/except by the
+    caller: a malformed volume must be logged and skipped rather than
+    discarding the whole region's results. Every required field is read with
+    ``.get()`` and a safe default for the same reason.
+
+    Args:
+        volume (dict): A single Volumes entry from describe_volumes.
+        region (str): AWS region name.
+        pricing_data (dict): EBS pricing data.
+
+    Returns:
+        dict: The assembled volume row.
+    """
+    volume_id = volume.get('VolumeId', 'Unknown')
+
+    # Initialize variables for volume data
+    volume_name = get_volume_name(volume)
+    instance_id = "Not attached"
+    device_name = "N/A"
+    attachment_state = "N/A"
+
+    # Get attachment information if the volume is attached
+    attachments = volume.get('Attachments', [])
+    if attachments:
+        attachment = attachments[0]
+        instance_id = attachment.get('InstanceId', 'Unknown')
+        device_name = attachment.get('Device', 'N/A')
+        attachment_state = attachment.get('State', 'N/A')
+
+    # Get KMS key information for encrypted volumes
+    kms_key_id = volume.get('KmsKeyId', 'N/A') if volume.get('Encrypted', False) else 'N/A'
+
+    # Get IOPS information
+    iops = volume.get('Iops', 'N/A')
+
+    # Get throughput information (for gp3 volumes)
+    throughput = volume.get('Throughput', 'N/A')
+
+    # Get multi-attach enabled status
+    multi_attach = 'Yes' if volume.get('MultiAttachEnabled', False) else 'No'
+
+    # Format tags
+    volume_tags = format_tags(volume.get('Tags', []))
+
+    # Get owner information
+    owner_id = utils.get_account_name_formatted(volume.get('OwnerId', 'N/A'))
+
+    # Format creation time
+    create_time = volume['CreateTime'].strftime('%Y-%m-%d %H:%M:%S') if 'CreateTime' in volume else 'N/A'
+
+    # Required fields read defensively: a missing field yields 'N/A' (or a
+    # sane default), not a KeyError that would sink the entire region.
+    size_gb = volume.get('Size', 'N/A')
+    volume_type = volume.get('VolumeType', 'N/A')
+    state = volume.get('State', 'N/A')
+
+    # Calculate monthly cost
+    monthly_cost = calculate_ebs_monthly_cost(volume_type, size_gb, state, pricing_data)
+
+    return {
+        'Region': region,
+        'Volume ID': volume_id,
+        'Name': volume_name,
+        'Size (GB)': size_gb,
+        'Volume Type': volume_type,
+        'Monthly Cost': monthly_cost,
+        'State': state,
+        'Attached To': instance_id,
+        'Device Name': device_name,
+        'Attachment State': attachment_state,
+        'IOPS': iops,
+        'Throughput (MiB/s)': throughput,
+        'Encrypted': 'Yes' if volume.get('Encrypted', False) else 'No',
+        'KMS Key ID': kms_key_id,
+        'Multi-Attach': multi_attach,
+        'Create Time': create_time,
+        'Availability Zone': volume.get('AvailabilityZone', 'N/A'),
+        'Snapshot ID': volume.get('SnapshotId', 'N/A'),
+        'Owner ID': owner_id,
+        'Tags': volume_tags
+    }
+
+
 def get_ebs_volumes(region):
     """
     Get all EBS volumes in a specific AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that ``main()`` cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so the caller can record the region as
+    *failed* rather than *empty*. Per-volume errors are contained internally
+    (logged and skipped).
 
     Args:
         region (str): AWS region name
 
     Returns:
         list: List of volume dictionaries with relevant information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -204,73 +301,31 @@ def get_ebs_volumes(region):
 
     # Use pagination to handle large numbers of volumes
     paginator = ec2_client.get_paginator('describe_volumes')
+    all_volumes = []
     for page in paginator.paginate():
-        for volume in page['Volumes']:
-            # Initialize variables for volume data
-            volume_name = get_volume_name(volume)
-            instance_id = "Not attached"
-            device_name = "N/A"
-            attachment_state = "N/A"
+        all_volumes.extend(page['Volumes'])
 
-            # Get attachment information if the volume is attached
-            if volume['Attachments']:
-                attachment = volume['Attachments'][0]
-                instance_id = attachment['InstanceId']
-                device_name = attachment['Device']
-                attachment_state = attachment['State']
-
-            # Get KMS key information for encrypted volumes
-            kms_key_id = volume.get('KmsKeyId', 'N/A') if volume.get('Encrypted', False) else 'N/A'
-
-            # Get IOPS information
-            iops = volume.get('Iops', 'N/A')
-
-            # Get throughput information (for gp3 volumes)
-            throughput = volume.get('Throughput', 'N/A')
-
-            # Get multi-attach enabled status
-            multi_attach = 'Yes' if volume.get('MultiAttachEnabled', False) else 'No'
-
-            # Format tags
-            volume_tags = format_tags(volume.get('Tags', []))
-
-            # Get owner information
-            owner_id = utils.get_account_name_formatted(volume.get('OwnerId', 'N/A'))
-
-            # Format creation time
-            create_time = volume['CreateTime'].strftime('%Y-%m-%d %H:%M:%S') if 'CreateTime' in volume else 'N/A'
-
-            # Calculate monthly cost
-            monthly_cost = calculate_ebs_monthly_cost(
-                volume['VolumeType'],
-                volume['Size'],
-                volume['State'],
-                pricing_data
+    # Process each volume. One malformed volume must not sink the region, so
+    # each is built inside try/except; failures are logged and skipped.
+    skipped = 0
+    for volume in all_volumes:
+        volume_id = volume.get('VolumeId', 'Unknown')
+        try:
+            volume_data = _build_volume_data(volume, region, pricing_data)
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping EBS volume '{volume_id}' in {region} due to a processing error", e
             )
+            continue
 
-            # Add volume data to the list with comprehensive information
-            volumes_data.append({
-                'Region': region,
-                'Volume ID': volume['VolumeId'],
-                'Name': volume_name,
-                'Size (GB)': volume['Size'],
-                'Volume Type': volume['VolumeType'],
-                'Monthly Cost': monthly_cost,
-                'State': volume['State'],
-                'Attached To': instance_id,
-                'Device Name': device_name,
-                'Attachment State': attachment_state,
-                'IOPS': iops,
-                'Throughput (MiB/s)': throughput,
-                'Encrypted': 'Yes' if volume['Encrypted'] else 'No',
-                'KMS Key ID': kms_key_id,
-                'Multi-Attach': multi_attach,
-                'Create Time': create_time,
-                'Availability Zone': volume['AvailabilityZone'],
-                'Snapshot ID': volume.get('SnapshotId', 'N/A'),
-                'Owner ID': owner_id,
-                'Tags': volume_tags
-            })
+        volumes_data.append(volume_data)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(all_volumes)} EBS volume(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining volumes were still collected."
+        )
 
     return volumes_data
 
@@ -356,18 +411,24 @@ def main():
         # Collect EBS volume data from all regions (Phase 4B: concurrent)
         utils.log_info("Collecting EBS volume data from all regions...")
 
-        # Define region scan function
+        # Define region scan function for concurrent execution. It lets
+        # get_ebs_volumes raise on a region-level failure so the scanner
+        # records that region as FAILED — a failed region must never be
+        # collapsed into "empty," which is the silent-data-loss bug.
         def scan_region_ebs_volumes(region):
             utils.log_info(f"Collecting EBS volume data from {region}")
             region_volumes = get_ebs_volumes(region)
             utils.log_info(f"Found {len(region_volumes)} volumes in {region}")
             return region_volumes
 
-        # Use concurrent region scanning
-        region_results = utils.scan_regions_concurrent(
+        # Use concurrent region scanning. collect_failures=True returns the
+        # regions that raised so a failed collection is distinguishable from
+        # a genuinely empty account.
+        region_results, failed_regions = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_ebs_volumes,
-            show_progress=True
+            show_progress=True,
+            collect_failures=True,
         )
 
         # Flatten results
@@ -378,22 +439,34 @@ def main():
         # Print summary of collected data
         utils.log_success(f"Total EBS volumes found across all AWS regions: {len(all_volumes)}")
 
-        if not all_volumes:
+        # Export whatever succeeded, then decide on exit status based on failures.
+        if all_volumes:
+            # Export data to Excel file
+            utils.log_info("Exporting data to Excel format...")
+            excel_path = create_excel_file(account_name, all_volumes, region_input)
+
+            if excel_path:
+                utils.log_success("AWS EBS volume data exported successfully!")
+                utils.log_success(f"File location: {excel_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+                utils.log_info(f"Total volumes exported: {len(all_volumes)}")
+                print("\nScript execution completed.")
+            else:
+                utils.log_error("Error exporting data. Please check the logs.")
+                sys.exit(1)
+        elif not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
             utils.log_warning("No volumes found in any AWS region. Exiting...")
-            sys.exit(0)
 
-        # Export data to Excel file
-        utils.log_info("Exporting data to Excel format...")
-        excel_path = create_excel_file(account_name, all_volumes, region_input)
-
-        if excel_path:
-            utils.log_success("AWS EBS volume data exported successfully!")
-            utils.log_success(f"File location: {excel_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-            utils.log_info(f"Total volumes exported: {len(all_volumes)}")
-            print("\nScript execution completed.")
-        else:
-            utils.log_error("Error exporting data. Please check the logs.")
+        # If ANY region failed, make it loud: write a marker and exit non-zero,
+        # even if some data was exported. A partial export that looks complete
+        # is exactly the failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, "ebs-volumes", failed_regions)
+            print(
+                "\nERROR: EBS volumes export completed with failures — data is incomplete. "
+                "See the *-ebs-volumes-FAILED-*.txt marker in the output directory."
+            )
             sys.exit(1)
 
     except KeyboardInterrupt:

--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -423,14 +423,170 @@ def is_valid_aws_region(region_name):
     """Check if a region name is a valid AWS region"""
     return utils.is_aws_region(region_name)
 
-@utils.aws_error_handler("Retrieving EC2 instances", default_return=[])
+def _build_instance_row(instance, region, ec2_client, pricing_data, storage_pricing, cost_note,
+                         instance_types_map, volumes_map):
+    """
+    Build the export row for a single EC2 instance.
+
+    Extracted so the per-instance processing can be wrapped in try/except by the
+    caller: a malformed instance (e.g. one missing an expected field) is logged
+    and skipped rather than discarding the whole region's results. Every
+    required field is read with ``.get()`` and a safe default for the same
+    reason.
+
+    Args:
+        instance (dict): A single Instances entry from describe_instances.
+        region (str): AWS region name.
+        ec2_client: Boto3 EC2 client (for AMI/volume lookups).
+        pricing_data (dict): EC2 instance pricing data.
+        storage_pricing (dict): EBS/storage pricing data.
+        cost_note (str): Partition-aware cost estimate note.
+        instance_types_map (dict): Prefetched {instance_type: memory_mib}.
+        volumes_map (dict): Prefetched {volume_id: volume_dict}.
+
+    Returns:
+        dict: The assembled instance row.
+    """
+    # Get the root volume information
+    root_device = next((device for device in instance.get('BlockDeviceMappings', [])
+                      if device.get('DeviceName') == instance.get('RootDeviceName')), None)
+
+    # Get detailed OS information
+    os_info = get_os_info_from_ssm(instance.get('InstanceId', ''), region)
+
+    # Get AMI name information
+    ami_name = get_os_info_from_ami(
+        ec2_client,
+        instance.get('ImageId', ''),
+        instance.get('PlatformDetails', 'N/A'),
+        instance.get('Platform', '')
+    )
+
+    # Get RAM info from the prefetched instance types map
+    instance_type = instance.get('InstanceType', 'N/A')
+    ram_mib = instance_types_map.get(instance_type, 'N/A')
+
+    # For root device size and type, we need to ensure we're fetching it correctly
+    root_device_size = 'N/A'
+    root_volume_id = 'N/A'
+    root_volume_type = 'N/A'
+
+    if root_device:
+        root_volume_id = root_device.get('Ebs', {}).get('VolumeId', 'N/A')
+        # If we have the volume ID, use prefetched cache or fall back to API
+        if root_volume_id != 'N/A':
+            if root_volume_id in volumes_map:
+                root_device_size = volumes_map[root_volume_id].get('Size', 'N/A')
+                root_volume_type = volumes_map[root_volume_id].get('VolumeType', 'N/A')
+            else:
+                try:
+                    volumes = ec2_client.describe_volumes(VolumeIds=[root_volume_id])
+                    if volumes and 'Volumes' in volumes and len(volumes['Volumes']) > 0:
+                        root_device_size = volumes['Volumes'][0].get('Size', 'N/A')
+                        root_volume_type = volumes['Volumes'][0].get('VolumeType', 'N/A')
+                except Exception as e:
+                    utils.log_warning(f"Error getting volume info for {root_volume_id}: {e}")
+        else:
+            # Try to get size from the device mapping directly
+            root_device_size = root_device.get('Ebs', {}).get('VolumeSize', 'N/A')
+
+    # Get attached volumes (non-root), using prefetched volume cache
+    attached_vols, attached_vol_info = get_attached_volumes(ec2_client, instance, volumes_map)
+    attached_volumes_str = ', '.join(attached_vols) if attached_vols else 'N/A'
+
+    # Get instance state and stopped date if applicable
+    instance_state = instance.get('State', {}).get('Name', 'N/A')
+    stop_date = get_instance_stop_date(instance, instance_state)
+
+    # Format tags
+    instance_tags = format_tags(instance.get('Tags', []))
+
+    # Calculate monthly cost
+    monthly_cost = calculate_monthly_cost(
+        instance.get('InstanceType', 'N/A'),
+        instance.get('Platform', 'Linux/UNIX'),
+        instance_state,
+        pricing_data
+    )
+
+    # Calculate storage cost
+    storage_cost = calculate_storage_cost(
+        root_device_size,
+        root_volume_type,
+        attached_vol_info,
+        storage_pricing
+    )
+
+    # Calculate total monthly cost
+    total_monthly_cost = 'N/A'
+    if monthly_cost != 'N/A' and storage_cost != 'N/A':
+        total_monthly_cost = round(float(monthly_cost) + float(storage_cost), 2)
+    elif monthly_cost != 'N/A':
+        total_monthly_cost = float(monthly_cost)
+    elif storage_cost != 'N/A':
+        total_monthly_cost = float(storage_cost)
+
+    # Extract instance information
+    return {
+        'Computer Name': next((tag.get('Value', 'N/A') for tag in instance.get('Tags', [])
+                            if tag.get('Key') == 'Name'), 'N/A'),
+        'Instance ID': instance.get('InstanceId', 'N/A'),
+        'State': instance_state,
+        'Stopped Date': stop_date,
+        'Instance Type': instance.get('InstanceType', 'N/A'),
+        'Platform': instance.get('Platform', 'Linux/UNIX'),
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Monthly Storage Cost': storage_cost,
+        'Total Monthly Cost': total_monthly_cost,
+        'Cost Note': cost_note,
+        'Operating System': os_info,
+        'AMI Name': ami_name,
+        'Private IPv4': instance.get('PrivateIpAddress', 'N/A'),
+        'Public IPv4': instance.get('PublicIpAddress', 'N/A'),
+        'IPv6': next((
+            next((addr.get('Ipv6Address', 'N/A')
+                 for addr in interface.get('Ipv6Addresses', [])), 'N/A')
+            for interface in instance.get('NetworkInterfaces', [])
+        ), 'N/A'),
+        'VPC ID': instance.get('VpcId', 'N/A'),
+        'Subnet ID': instance.get('SubnetId', 'N/A'),
+        'Availability Zone': instance.get('Placement', {}).get('AvailabilityZone', 'N/A'),
+        'AMI ID': instance.get('ImageId', 'N/A'),
+        'Launch Time': instance.get('LaunchTime', 'N/A'),
+        'Key Pair': instance.get('KeyName', 'N/A'),
+        'Region': region,
+        'Owner ID': utils.get_account_name_formatted(instance.get('OwnerId', 'N/A')),
+        'vCPU': instance.get('CpuOptions', {}).get('CoreCount', 'N/A'),
+        'RAM (MiB)': ram_mib,
+        'Root Device Volume ID': root_volume_id,
+        'Root Device Size (GiB)': root_device_size,
+        'Attached Volumes': attached_volumes_str,
+        'Tags': instance_tags
+    }
+
+
 def get_instance_data(region, instance_filter=None):
     """
-    Retrieve EC2 instance data for a specific AWS region
+    Retrieve EC2 instance data for a specific AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that ``_run_export`` cannot distinguish from a genuinely
+    empty region, producing silent data loss (see the 07.15.2026 audit).
+    Region-level failures (client creation, pagination, throttling) are
+    allowed to raise so the caller can record the region as FAILED rather
+    than EMPTY. Per-instance errors are contained internally (logged and
+    skipped).
 
     Args:
         region (str): AWS region name
         instance_filter (str, optional): Filter by instance state ('running', 'stopped', or None for all)
+
+    Returns:
+        list: List of dictionaries containing EC2 instance information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -444,214 +600,116 @@ def get_instance_data(region, instance_filter=None):
     pricing_data = load_pricing_data(region)
     storage_pricing = load_storage_pricing_data()
 
-    try:
-        # Prepare filters if needed
-        filters = []
-        if instance_filter:
-            filters.append({
-                'Name': 'instance-state-name',
-                'Values': [instance_filter]
-            })
+    # Prepare filters if needed
+    filters = []
+    if instance_filter:
+        filters.append({
+            'Name': 'instance-state-name',
+            'Values': [instance_filter]
+        })
 
-        # Get instances in the region with optional filter using paginator
-        paginator = ec2.get_paginator('describe_instances')
-        pages = paginator.paginate(Filters=filters) if filters else paginator.paginate()
+    # Get instances in the region with optional filter using paginator
+    paginator = ec2.get_paginator('describe_instances')
+    pages = paginator.paginate(Filters=filters) if filters else paginator.paginate()
 
-        all_reservations = []
-        for page in pages:
-            all_reservations.extend(page['Reservations'])
-            time.sleep(0.1)
+    all_reservations = []
+    for page in pages:
+        all_reservations.extend(page.get('Reservations', []))
+        time.sleep(0.1)
 
-        # Count total instances first for progress tracking
-        total_instances = 0
-        for reservation in all_reservations:
-            total_instances += len(reservation['Instances'])
+    # Count total instances first for progress tracking
+    total_instances = 0
+    for reservation in all_reservations:
+        total_instances += len(reservation.get('Instances', []))
 
-        if total_instances > 0:
-            utils.log_info(f"Found {total_instances} instances in {region} to process")
+    if total_instances > 0:
+        utils.log_info(f"Found {total_instances} instances in {region} to process")
 
-        # Prefetch all volume details in bulk to avoid N+1 API calls
-        volumes_map = {}
-        if total_instances > 0:
-            all_volume_ids = [
-                device.get('Ebs', {}).get('VolumeId')
-                for reservation in all_reservations
-                for inst in reservation['Instances']
-                for device in inst.get('BlockDeviceMappings', [])
-                if device.get('Ebs', {}).get('VolumeId')
-            ]
-            for i in range(0, len(all_volume_ids), 500):
-                chunk = all_volume_ids[i:i + 500]
-                try:
-                    resp = ec2.describe_volumes(VolumeIds=chunk)
-                    for v in resp.get('Volumes', []):
-                        volumes_map[v['VolumeId']] = v
-                except Exception as e:
-                    utils.log_warning(f"Error prefetching volumes in {region}: {e}")
+    # Prefetch all volume details in bulk to avoid N+1 API calls
+    volumes_map = {}
+    if total_instances > 0:
+        all_volume_ids = [
+            device.get('Ebs', {}).get('VolumeId')
+            for reservation in all_reservations
+            for inst in reservation.get('Instances', [])
+            for device in inst.get('BlockDeviceMappings', [])
+            if device.get('Ebs', {}).get('VolumeId')
+        ]
+        for i in range(0, len(all_volume_ids), 500):
+            chunk = all_volume_ids[i:i + 500]
+            try:
+                resp = ec2.describe_volumes(VolumeIds=chunk)
+                for v in resp.get('Volumes', []):
+                    volumes_map[v['VolumeId']] = v
+            except Exception as e:
+                utils.log_warning(f"Error prefetching volumes in {region}: {e}")
 
-        # Build RAM map from pricing JSON (memory_gib -> MiB); fall back to
-        # describe_instance_types for any types absent from the JSON.
-        instance_types_map = {}
-        if total_instances > 0:
-            unique_types = list({
-                inst.get('InstanceType')
-                for reservation in all_reservations
-                for inst in reservation['Instances']
-                if inst.get('InstanceType')
-            })
-            unknown_types = []
-            for it in unique_types:
-                memory_gib = pricing_data.get(it, {}).get('memory_gib')
-                if memory_gib is not None:
-                    instance_types_map[it] = int(memory_gib * 1024)
-                else:
-                    unknown_types.append(it)
-            for i in range(0, len(unknown_types), 100):
-                chunk = unknown_types[i:i + 100]
-                try:
-                    resp = ec2.describe_instance_types(InstanceTypes=chunk)
-                    for it in resp.get('InstanceTypes', []):
-                        instance_types_map[it['InstanceType']] = it.get('MemoryInfo', {}).get('SizeInMiB', 'N/A')
-                except Exception as e:
-                    utils.log_warning(f"Error fetching instance types in {region}: {e}")
+    # Build RAM map from pricing JSON (memory_gib -> MiB); fall back to
+    # describe_instance_types for any types absent from the JSON.
+    instance_types_map = {}
+    if total_instances > 0:
+        unique_types = list({
+            inst.get('InstanceType')
+            for reservation in all_reservations
+            for inst in reservation.get('Instances', [])
+            if inst.get('InstanceType')
+        })
+        unknown_types = []
+        for it in unique_types:
+            memory_gib = pricing_data.get(it, {}).get('memory_gib')
+            if memory_gib is not None:
+                instance_types_map[it] = int(memory_gib * 1024)
+            else:
+                unknown_types.append(it)
+        for i in range(0, len(unknown_types), 100):
+            chunk = unknown_types[i:i + 100]
+            try:
+                resp = ec2.describe_instance_types(InstanceTypes=chunk)
+                for it in resp.get('InstanceTypes', []):
+                    instance_types_map[it['InstanceType']] = it.get('MemoryInfo', {}).get('SizeInMiB', 'N/A')
+            except Exception as e:
+                utils.log_warning(f"Error fetching instance types in {region}: {e}")
 
-        _partition = utils.detect_partition(region)
-        cost_note = (
-            "Estimate (us-gov-west-1 pricing)"
-            if _partition == 'aws-us-gov'
-            else "Estimate (us-east-1 pricing)"
+    _partition = utils.detect_partition(region)
+    cost_note = (
+        "Estimate (us-gov-west-1 pricing)"
+        if _partition == 'aws-us-gov'
+        else "Estimate (us-east-1 pricing)"
+    )
+
+    # Process each instance. One malformed instance must not sink the region,
+    # so each is built inside try/except; failures are logged and skipped.
+    processed = 0
+    skipped = 0
+    for reservation in all_reservations:
+        for instance in reservation.get('Instances', []):
+            processed += 1
+            instance_id = instance.get('InstanceId', 'Unknown')
+            progress = (processed / total_instances) * 100 if total_instances > 0 else 0
+
+            utils.log_info(f"[{progress:.1f}%] Processing instance {processed}/{total_instances}: {instance_id}")
+            if processed % 25 == 0:
+                print(f"  [{region}] {processed}/{total_instances} EC2 instances processed...", flush=True)
+
+            try:
+                instance_data = _build_instance_row(
+                    instance, region, ec2, pricing_data, storage_pricing, cost_note,
+                    instance_types_map, volumes_map
+                )
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping EC2 instance '{instance_id}' in {region} due to a processing error", e
+                )
+                continue
+
+            instances.append(instance_data)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_instances} EC2 instance(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining instances were still collected."
         )
-
-        processed = 0
-        for reservation in all_reservations:
-            for instance in reservation['Instances']:
-                processed += 1
-                instance_id = instance.get('InstanceId', 'Unknown')
-                progress = (processed / total_instances) * 100 if total_instances > 0 else 0
-
-                utils.log_info(f"[{progress:.1f}%] Processing instance {processed}/{total_instances}: {instance_id}")
-                if processed % 25 == 0:
-                    print(f"  [{region}] {processed}/{total_instances} EC2 instances processed...", flush=True)
-                # Get the root volume information
-                root_device = next((device for device in instance.get('BlockDeviceMappings', [])
-                                  if device['DeviceName'] == instance.get('RootDeviceName')), None)
-
-                # Get detailed OS information
-                os_info = get_os_info_from_ssm(instance.get('InstanceId', ''), region)
-
-                # Get AMI name information
-                ami_name = get_os_info_from_ami(
-                    ec2,
-                    instance.get('ImageId', ''),
-                    instance.get('PlatformDetails', 'N/A'),
-                    instance.get('Platform', '')
-                )
-
-                # Get RAM info from the prefetched instance types map
-                instance_type = instance.get('InstanceType', 'N/A')
-                ram_mib = instance_types_map.get(instance_type, 'N/A')
-
-                # For root device size and type, we need to ensure we're fetching it correctly
-                root_device_size = 'N/A'
-                root_volume_id = 'N/A'
-                root_volume_type = 'N/A'
-
-                if root_device:
-                    root_volume_id = root_device.get('Ebs', {}).get('VolumeId', 'N/A')
-                    # If we have the volume ID, use prefetched cache or fall back to API
-                    if root_volume_id != 'N/A':
-                        if root_volume_id in volumes_map:
-                            root_device_size = volumes_map[root_volume_id].get('Size', 'N/A')
-                            root_volume_type = volumes_map[root_volume_id].get('VolumeType', 'N/A')
-                        else:
-                            try:
-                                volumes = ec2.describe_volumes(VolumeIds=[root_volume_id])
-                                if volumes and 'Volumes' in volumes and len(volumes['Volumes']) > 0:
-                                    root_device_size = volumes['Volumes'][0].get('Size', 'N/A')
-                                    root_volume_type = volumes['Volumes'][0].get('VolumeType', 'N/A')
-                            except Exception as e:
-                                utils.log_warning(f"Error getting volume info for {root_volume_id}: {e}")
-                    else:
-                        # Try to get size from the device mapping directly
-                        root_device_size = root_device.get('Ebs', {}).get('VolumeSize', 'N/A')
-
-                # Get attached volumes (non-root), using prefetched volume cache
-                attached_vols, attached_vol_info = get_attached_volumes(ec2, instance, volumes_map)
-                attached_volumes_str = ', '.join(attached_vols) if attached_vols else 'N/A'
-
-                # Get instance state and stopped date if applicable
-                instance_state = instance.get('State', {}).get('Name', 'N/A')
-                stop_date = get_instance_stop_date(instance, instance_state)
-
-                # Format tags
-                instance_tags = format_tags(instance.get('Tags', []))
-
-                # Calculate monthly cost
-                monthly_cost = calculate_monthly_cost(
-                    instance.get('InstanceType', 'N/A'),
-                    instance.get('Platform', 'Linux/UNIX'),
-                    instance_state,
-                    pricing_data
-                )
-
-                # Calculate storage cost
-                storage_cost = calculate_storage_cost(
-                    root_device_size,
-                    root_volume_type,
-                    attached_vol_info,
-                    storage_pricing
-                )
-
-                # Calculate total monthly cost
-                total_monthly_cost = 'N/A'
-                if monthly_cost != 'N/A' and storage_cost != 'N/A':
-                    total_monthly_cost = round(float(monthly_cost) + float(storage_cost), 2)
-                elif monthly_cost != 'N/A':
-                    total_monthly_cost = float(monthly_cost)
-                elif storage_cost != 'N/A':
-                    total_monthly_cost = float(storage_cost)
-
-                # Extract instance information
-                instance_data = {
-                    'Computer Name': next((tag['Value'] for tag in instance.get('Tags', [])
-                                        if tag['Key'] == 'Name'), 'N/A'),
-                    'Instance ID': instance.get('InstanceId', 'N/A'),
-                    'State': instance_state,
-                    'Stopped Date': stop_date,
-                    'Instance Type': instance.get('InstanceType', 'N/A'),
-                    'Platform': instance.get('Platform', 'Linux/UNIX'),
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Monthly Storage Cost': storage_cost,
-                    'Total Monthly Cost': total_monthly_cost,
-                    'Cost Note': cost_note,
-                    'Operating System': os_info,
-                    'AMI Name': ami_name,
-                    'Private IPv4': instance.get('PrivateIpAddress', 'N/A'),
-                    'Public IPv4': instance.get('PublicIpAddress', 'N/A'),
-                    'IPv6': next((
-                        next((addr.get('Ipv6Address', 'N/A')
-                             for addr in interface.get('Ipv6Addresses', [])), 'N/A')
-                        for interface in instance.get('NetworkInterfaces', [])
-                    ), 'N/A'),
-                    'VPC ID': instance.get('VpcId', 'N/A'),
-                    'Subnet ID': instance.get('SubnetId', 'N/A'),
-                    'Availability Zone': instance.get('Placement', {}).get('AvailabilityZone', 'N/A'),
-                    'AMI ID': instance.get('ImageId', 'N/A'),
-                    'Launch Time': instance.get('LaunchTime', 'N/A'),
-                    'Key Pair': instance.get('KeyName', 'N/A'),
-                    'Region': region,
-                    'Owner ID': utils.get_account_name_formatted(instance.get('OwnerId', 'N/A')),
-                    'vCPU': instance.get('CpuOptions', {}).get('CoreCount', 'N/A'),
-                    'RAM (MiB)': ram_mib,
-                    'Root Device Volume ID': root_volume_id,
-                    'Root Device Size (GiB)': root_device_size,
-                    'Attached Volumes': attached_volumes_str,
-                    'Tags': instance_tags
-                }
-                instances.append(instance_data)
-
-    except Exception as e:
-        utils.log_error(f"Error getting instances in region {region}", e)
 
     return instances
 
@@ -693,10 +751,14 @@ def _run_export(account_id, account_name, regions, instance_filter, filter_desc)
         utils.log_info(f"Found {len(instances)} instances in {region}")
         return instances
 
-    region_results = utils.scan_regions_concurrent(
+    # collect_failures=True lets get_instance_data raise on a region-level
+    # failure so the scanner records that region as FAILED — a failed region
+    # must never be collapsed into "empty" (silent data loss, 07.15.2026 audit).
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_region,
         show_progress=True,
+        collect_failures=True,
     )
 
     all_instances = []
@@ -705,35 +767,48 @@ def _run_export(account_id, account_name, regions, instance_filter, filter_desc)
 
     total_instances = len(all_instances)
 
-    if not all_instances:
+    if not all_instances and not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No instances found in any AWS region. Exiting...")
         sys.exit(0)
 
-    utils.log_success(f"Total EC2 Instances found across all AWS regions: {total_instances}")
+    if all_instances:
+        utils.log_success(f"Total EC2 Instances found across all AWS regions: {total_instances}")
 
-    utils.log_info("Preparing data for export to Excel format...")
-    df = pd.DataFrame(all_instances)
-    df = utils.sanitize_for_export(utils.prepare_dataframe_for_export(df))
+        utils.log_info("Preparing data for export to Excel format...")
+        df = pd.DataFrame(all_instances)
+        df = utils.sanitize_for_export(utils.prepare_dataframe_for_export(df))
 
-    region_desc = regions[0] if len(regions) == 1 else 'all'
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    filename = utils.create_export_filename(
-        account_name,
-        "ec2",
-        f"{filter_desc}-{region_desc}",
-        current_date,
-    )
+        region_desc = regions[0] if len(regions) == 1 else 'all'
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        filename = utils.create_export_filename(
+            account_name,
+            "ec2",
+            f"{filter_desc}-{region_desc}",
+            current_date,
+        )
 
-    output_path = utils.save_dataframe_to_excel(df, filename)
+        output_path = utils.save_dataframe_to_excel(df, filename)
 
-    if output_path:
-        utils.log_success("AWS EC2 data exported successfully!")
-        utils.log_success(f"File location: {output_path}")
-        utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-        utils.log_info(f"Total instances exported: {total_instances}")
-        print("\nScript execution completed.")
-    else:
-        utils.log_error("Error exporting data. Please check the logs.")
+        if output_path:
+            utils.log_success("AWS EC2 data exported successfully!")
+            utils.log_success(f"File location: {output_path}")
+            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+            utils.log_info(f"Total instances exported: {total_instances}")
+            print("\nScript execution completed.")
+        else:
+            utils.log_error("Error exporting data. Please check the logs.")
+            sys.exit(1)
+
+    # If ANY region failed, make it loud: write a marker and exit non-zero,
+    # even if some data was exported. A partial export that looks complete is
+    # exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, "ec2", failed_regions)
+        print(
+            "\nERROR: EC2 export completed with failures — data is incomplete. "
+            "See the *-ec2-FAILED-*.txt marker in the output directory."
+        )
         sys.exit(1)
 
 

--- a/scripts/elb_export.py
+++ b/scripts/elb_export.py
@@ -89,16 +89,88 @@ def get_security_group_names(security_group_ids, region):
 
     return sg_mapping
 
-@utils.aws_error_handler("Collecting Classic Load Balancers", default_return=[])
+def _build_classic_lb_row(lb, region):
+    """
+    Build the export row for a single Classic Load Balancer.
+
+    Extracted so the per-LB processing can be wrapped in try/except by the
+    caller: a malformed load balancer must not sink the whole region's
+    results. Every field is read with ``.get()`` and a safe default.
+
+    Args:
+        lb (dict): A single LoadBalancerDescriptions entry.
+        region (str): AWS region name.
+
+    Returns:
+        dict: The assembled load balancer row.
+    """
+    # Get security group names for the security group IDs
+    sg_ids = lb.get('SecurityGroups', [])
+    sg_mapping = get_security_group_names(sg_ids, region)
+
+    # Format security groups as "sg-name (sg-id), ..."
+    security_groups = []
+    for sg_id in sg_ids:
+        sg_name = sg_mapping.get(sg_id, "Unknown")
+        security_groups.append(f"{sg_name} ({sg_id})")
+
+    # Format availability zones as "subnet-id (az), ..."
+    availability_zones = []
+    for az in lb.get('AvailabilityZones', []):
+        availability_zones.append(f"{az}")
+
+    # Add subnets if available (VPC Classic ELB)
+    for subnet_id in lb.get('Subnets', []):
+        # For VPC Classic ELBs, we need to get the AZ for each subnet
+        try:
+            ec2 = utils.get_boto3_client('ec2', region_name=region)
+            subnet_response = ec2.describe_subnets(SubnetIds=[subnet_id])
+            subnet_az = subnet_response.get('Subnets', [{}])[0].get('AvailabilityZone', 'Unknown')
+            availability_zones.append(f"{subnet_id} ({subnet_az})")
+        except Exception as e:
+            utils.log_warning(f"Could not get AZ for subnet {subnet_id}: {e}")
+            availability_zones.append(f"{subnet_id} (Unknown AZ)")
+
+    # Get creation time
+    created_time = lb.get('CreatedTime', datetime.datetime.now())
+
+    # Get owner information
+    owner_id = lb.get('OwnerId', 'N/A')
+    owner_name = utils.get_account_name_formatted(owner_id)
+
+    return {
+        'Region': region,
+        'Name': lb.get('LoadBalancerName', ''),
+        'DNS Name': lb.get('DNSName', ''),
+        'VPC ID': lb.get('VPCId', 'N/A'),
+        'Availability Zones': ', '.join(availability_zones),
+        'Type': 'Classic',
+        'Date Created': created_time.strftime('%Y-%m-%d'),
+        'Security Groups': ', '.join(security_groups) if security_groups else 'N/A',
+        'Owner': owner_name
+    }
+
+
 def get_classic_load_balancers(region):
     """
-    Get information about Classic Load Balancers in the specified AWS region
+    Get information about Classic Load Balancers in the specified AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that ``main()`` cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so the caller can record the region as
+    *failed* rather than *empty*. Per-LB errors are contained internally
+    (logged and skipped).
 
     Args:
         region (str): AWS region
 
     Returns:
         list: List of dictionaries containing Classic Load Balancer information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -116,66 +188,113 @@ def get_classic_load_balancers(region):
     for page in paginator.paginate():
         all_lbs.extend(page.get('LoadBalancerDescriptions', []))
 
+    # Process each LB. One malformed LB must not sink the region, so each is
+    # built inside try/except; failures are logged and skipped.
+    skipped = 0
     for lb in all_lbs:
-        # Get security group names for the security group IDs
-        sg_ids = lb.get('SecurityGroups', [])
-        sg_mapping = get_security_group_names(sg_ids, region)
+        lb_name = lb.get('LoadBalancerName', 'Unknown')
+        try:
+            elb_data.append(_build_classic_lb_row(lb, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping Classic Load Balancer '{lb_name}' in {region} due to a processing error", e
+            )
+            continue
 
-        # Format security groups as "sg-name (sg-id), ..."
-        security_groups = []
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(all_lbs)} Classic Load Balancer(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining load balancers were still collected."
+        )
+
+    return elb_data
+
+def _build_albnlb_row(lb, region):
+    """
+    Build the export row for a single ALB/NLB.
+
+    Extracted so the per-LB processing can be wrapped in try/except by the
+    caller: a malformed load balancer must not sink the whole region's
+    results. Every field is read with ``.get()`` and a safe default.
+
+    Args:
+        lb (dict): A single LoadBalancers entry from describe_load_balancers (elbv2).
+        region (str): AWS region name.
+
+    Returns:
+        dict: The assembled load balancer row.
+    """
+    # Get load balancer type
+    lb_type = lb.get('Type', 'Unknown')
+
+    # Get security group names for ALBs (NLBs don't have security groups)
+    sg_ids = lb.get('SecurityGroups', [])
+    security_groups = []
+
+    if sg_ids:
+        sg_mapping = get_security_group_names(sg_ids, region)
         for sg_id in sg_ids:
             sg_name = sg_mapping.get(sg_id, "Unknown")
             security_groups.append(f"{sg_name} ({sg_id})")
 
-        # Format availability zones as "subnet-id (az), ..."
-        availability_zones = []
-        for az in lb.get('AvailabilityZones', []):
-            availability_zones.append(f"{az}")
+    # Get subnet information
+    availability_zones = []
+    for az_info in lb.get('AvailabilityZones', []):
+        subnet_id = az_info.get('SubnetId', '')
+        zone_name = az_info.get('ZoneName', '')
+        availability_zones.append(f"{subnet_id} ({zone_name})")
 
-        # Add subnets if available (VPC Classic ELB)
-        for subnet_id in lb.get('Subnets', []):
-            # For VPC Classic ELBs, we need to get the AZ for each subnet
-            try:
-                ec2 = utils.get_boto3_client('ec2', region_name=region)
-                subnet_response = ec2.describe_subnets(SubnetIds=[subnet_id])
-                subnet_az = subnet_response['Subnets'][0]['AvailabilityZone']
-                availability_zones.append(f"{subnet_id} ({subnet_az})")
-            except Exception as e:
-                utils.log_warning(f"Could not get AZ for subnet {subnet_id}: {e}")
-                availability_zones.append(f"{subnet_id} (Unknown AZ)")
+    # Get creation time
+    created_time = lb.get('CreatedTime', datetime.datetime.now())
 
-        # Get creation time
-        created_time = lb.get('CreatedTime', datetime.datetime.now())
+    # Get owner information from the ARN
+    lb_arn = lb.get('LoadBalancerArn', '')
+    owner_name = 'N/A'
+    if lb_arn:
+        # Parse owner from ARN
+        try:
+            arn_parts = lb_arn.split(':')
+            if len(arn_parts) >= 5:
+                owner_id = arn_parts[4]
+                owner_name = utils.get_account_name_formatted(owner_id)
+        except Exception:
+            owner_name = 'N/A'
 
-        # Get owner information
-        owner_id = lb.get('OwnerId', 'N/A')
-        owner_name = utils.get_account_name_formatted(owner_id)
+    return {
+        'Region': region,
+        'Name': lb.get('LoadBalancerName', ''),
+        'DNS Name': lb.get('DNSName', ''),
+        'VPC ID': lb.get('VpcId', 'N/A'),
+        'Availability Zones': ', '.join(availability_zones),
+        'Type': lb_type,
+        'Date Created': created_time.strftime('%Y-%m-%d'),
+        'Security Groups': ', '.join(security_groups) if security_groups else 'N/A',
+        'Owner': owner_name
+    }
 
-        # Add load balancer data to the list
-        elb_data.append({
-            'Region': region,
-            'Name': lb.get('LoadBalancerName', ''),
-            'DNS Name': lb.get('DNSName', ''),
-            'VPC ID': lb.get('VPCId', 'N/A'),
-            'Availability Zones': ', '.join(availability_zones),
-            'Type': 'Classic',
-            'Date Created': created_time.strftime('%Y-%m-%d'),
-            'Security Groups': ', '.join(security_groups) if security_groups else 'N/A',
-            'Owner': owner_name
-        })
 
-    return elb_data
-
-@utils.aws_error_handler("Collecting Application and Network Load Balancers", default_return=[])
 def get_application_network_load_balancers(region):
     """
-    Get information about Application and Network Load Balancers in the specified AWS region
+    Get information about Application and Network Load Balancers in the
+    specified AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that ``main()`` cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so the caller can record the region as
+    *failed* rather than *empty*. Per-LB errors are contained internally
+    (logged and skipped).
 
     Args:
         region (str): AWS region
 
     Returns:
         list: List of dictionaries containing ALB/NLB information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     # Validate region is AWS
     if not utils.is_aws_region(region):
@@ -193,58 +312,25 @@ def get_application_network_load_balancers(region):
     for page in paginator.paginate():
         all_lbs.extend(page.get('LoadBalancers', []))
 
+    # Process each LB. One malformed LB must not sink the region, so each is
+    # built inside try/except; failures are logged and skipped.
+    skipped = 0
     for lb in all_lbs:
-        # Get load balancer type
-        lb_type = lb.get('Type', 'Unknown')
+        lb_name = lb.get('LoadBalancerName', 'Unknown')
+        try:
+            elb_data.append(_build_albnlb_row(lb, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping Application/Network Load Balancer '{lb_name}' in {region} due to a processing error", e
+            )
+            continue
 
-        # Get security group names for ALBs (NLBs don't have security groups)
-        sg_ids = lb.get('SecurityGroups', [])
-        security_groups = []
-
-        if sg_ids:
-            sg_mapping = get_security_group_names(sg_ids, region)
-            for sg_id in sg_ids:
-                sg_name = sg_mapping.get(sg_id, "Unknown")
-                security_groups.append(f"{sg_name} ({sg_id})")
-
-        # Get subnet information
-        availability_zones = []
-        for az_info in lb.get('AvailabilityZones', []):
-            subnet_id = az_info.get('SubnetId', '')
-            zone_name = az_info.get('ZoneName', '')
-            availability_zones.append(f"{subnet_id} ({zone_name})")
-
-        # Get creation time
-        created_time = lb.get('CreatedTime', datetime.datetime.now())
-
-        # Get owner information from the ARN
-        lb_arn = lb.get('LoadBalancerArn', '')
-        if lb_arn:
-            # Parse owner from ARN
-            try:
-                arn_parts = lb_arn.split(':')
-                if len(arn_parts) >= 5:
-                    owner_id = arn_parts[4]
-                    owner_name = utils.get_account_name_formatted(owner_id)
-                else:
-                    owner_name = 'N/A'
-            except Exception:
-                owner_name = 'N/A'
-        else:
-            owner_name = 'N/A'
-
-        # Add load balancer data to the list
-        elb_data.append({
-            'Region': region,
-            'Name': lb.get('LoadBalancerName', ''),
-            'DNS Name': lb.get('DNSName', ''),
-            'VPC ID': lb.get('VpcId', 'N/A'),
-            'Availability Zones': ', '.join(availability_zones),
-            'Type': lb_type,
-            'Date Created': created_time.strftime('%Y-%m-%d'),
-            'Security Groups': ', '.join(security_groups) if security_groups else 'N/A',
-            'Owner': owner_name
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(all_lbs)} Application/Network Load Balancer(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining load balancers were still collected."
+        )
 
     return elb_data
 
@@ -371,11 +457,15 @@ def main():
 
         return region_elbs
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning (with automatic fallback to sequential on
+    # errors). collect_failures=True returns the regions that raised so a
+    # failed collection is distinguishable from a genuinely empty account
+    # (silent-data-loss bug, 07.15.2026 audit).
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_region_elbs,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results and count totals
@@ -391,66 +481,77 @@ def main():
                 total_elbv2s += 1
         all_elb_data.extend(region_elbs)
 
-    # If no ELBs found, exit
-    if not all_elb_data:
+    # Export whatever succeeded, then decide on exit status based on failures.
+    if all_elb_data:
+        # Convert to DataFrame
+        df = pd.DataFrame(all_elb_data)
+        df = df.sort_values(by=['Region', 'Type', 'Name'])
+
+        # Collect target groups and listeners (Phase F: API coverage fix)
+        utils.log_info("Collecting target groups...")
+        tg_results = utils.scan_regions_concurrent(
+            regions=regions,
+            scan_function=get_target_groups,
+            show_progress=True
+        )
+        all_tg_data = [tg for result in tg_results for tg in result]
+        utils.log_success(f"Total target groups collected: {len(all_tg_data)}")
+
+        utils.log_info("Collecting listeners...")
+        listener_results = utils.scan_regions_concurrent(
+            regions=regions,
+            scan_function=get_listeners,
+            show_progress=True
+        )
+        all_listener_data = [listener for result in listener_results for listener in result]
+        utils.log_success(f"Total listeners collected: {len(all_listener_data)}")
+
+        # Generate filename with current date
+        current_date = datetime.datetime.now().strftime('%m.%d.%Y')
+        filename = utils.create_export_filename(
+            account_name,
+            "elb",
+            region_suffix,
+            current_date
+        )
+
+        # Build multi-sheet workbook
+        data_frames = {'Load Balancers': df}
+        if all_tg_data:
+            tg_df = pd.DataFrame(all_tg_data)
+            tg_df = tg_df.sort_values(by=['Region', 'Target Group Name'])
+            data_frames['Target Groups'] = tg_df
+        if all_listener_data:
+            listener_df = pd.DataFrame(all_listener_data)
+            listener_df = listener_df.sort_values(by=['Region', 'Load Balancer Name', 'Port'])
+            data_frames['Listeners'] = listener_df
+
+        output_path = utils.save_multiple_dataframes_to_excel(data_frames, filename)
+
+        if output_path:
+            utils.log_success("AWS ELB data exported successfully!")
+            utils.log_success(f"File location: {output_path}")
+            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+            utils.log_info(f"Total Classic ELBs: {total_classic_elbs}")
+            utils.log_info(f"Total ALB/NLB: {total_elbv2s}")
+            utils.log_info(f"Total Load Balancers: {len(all_elb_data)}")
+            print("\nScript execution completed.")
+        else:
+            utils.log_error("Failed to save the Excel file.")
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Elastic Load Balancers found in any AWS region.")
-        return
 
-    # Convert to DataFrame
-    df = pd.DataFrame(all_elb_data)
-    df = df.sort_values(by=['Region', 'Type', 'Name'])
-
-    # Collect target groups and listeners (Phase F: API coverage fix)
-    utils.log_info("Collecting target groups...")
-    tg_results = utils.scan_regions_concurrent(
-        regions=regions,
-        scan_function=get_target_groups,
-        show_progress=True
-    )
-    all_tg_data = [tg for result in tg_results for tg in result]
-    utils.log_success(f"Total target groups collected: {len(all_tg_data)}")
-
-    utils.log_info("Collecting listeners...")
-    listener_results = utils.scan_regions_concurrent(
-        regions=regions,
-        scan_function=get_listeners,
-        show_progress=True
-    )
-    all_listener_data = [listener for result in listener_results for listener in result]
-    utils.log_success(f"Total listeners collected: {len(all_listener_data)}")
-
-    # Generate filename with current date
-    current_date = datetime.datetime.now().strftime('%m.%d.%Y')
-    filename = utils.create_export_filename(
-        account_name,
-        "elb",
-        region_suffix,
-        current_date
-    )
-
-    # Build multi-sheet workbook
-    data_frames = {'Load Balancers': df}
-    if all_tg_data:
-        tg_df = pd.DataFrame(all_tg_data)
-        tg_df = tg_df.sort_values(by=['Region', 'Target Group Name'])
-        data_frames['Target Groups'] = tg_df
-    if all_listener_data:
-        listener_df = pd.DataFrame(all_listener_data)
-        listener_df = listener_df.sort_values(by=['Region', 'Load Balancer Name', 'Port'])
-        data_frames['Listeners'] = listener_df
-
-    output_path = utils.save_multiple_dataframes_to_excel(data_frames, filename)
-
-    if output_path:
-        utils.log_success("AWS ELB data exported successfully!")
-        utils.log_success(f"File location: {output_path}")
-        utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-        utils.log_info(f"Total Classic ELBs: {total_classic_elbs}")
-        utils.log_info(f"Total ALB/NLB: {total_elbv2s}")
-        utils.log_info(f"Total Load Balancers: {len(all_elb_data)}")
-        print("\nScript execution completed.")
-    else:
-        utils.log_error("Failed to save the Excel file.")
+    # If ANY region failed, make it loud: write a marker and exit non-zero,
+    # even if some data was exported. A partial export that looks complete is
+    # exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, "elb", failed_regions)
+        print(
+            "\nERROR: ELB export completed with failures — data is incomplete. "
+            "See the *-elb-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 if __name__ == "__main__":
     try:

--- a/scripts/iam_export.py
+++ b/scripts/iam_export.py
@@ -217,79 +217,116 @@ def get_access_key_info(iam_client, username):
     return access_key_ids, active_key_age, access_key_last_used
 
 
+def _build_user_row(iam_client, user):
+    """
+    Build the export row for a single IAM user.
+
+    Extracted so per-user processing can be wrapped in try/except by the
+    caller: a malformed user entry (e.g. a missing field) must not sink the
+    whole account-level collection. Required fields are read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        iam_client: The boto3 IAM client.
+        user (dict): A single Users entry from list_users.
+
+    Returns:
+        dict: The assembled user row.
+    """
+    username = user.get('UserName', 'Unknown')
+
+    create_date = user.get('CreateDate')
+    creation_date = create_date.strftime('%Y-%m-%d %H:%M:%S UTC') if create_date else "Unknown"
+    password_last_used = user.get('PasswordLastUsed')
+
+    if password_last_used:
+        console_last_signin = password_last_used.strftime('%Y-%m-%d %H:%M:%S UTC')
+    else:
+        console_last_signin = "Never"
+
+    groups = get_user_groups(iam_client, username)
+    mfa_status = get_user_mfa_devices(iam_client, username)
+    password_age, console_access = get_password_info(iam_client, username)
+    access_key_id, active_key_age, access_key_last_used = get_access_key_info(iam_client, username)
+    permission_policies = get_user_policies(iam_client, username)
+
+    return {
+        'User Name': username,
+        'Groups': groups,
+        'MFA': mfa_status,
+        'Password Age': f"{password_age} days" if isinstance(password_age, int) else password_age,
+        'Console Last Sign-in': console_last_signin,
+        'Access Key ID': access_key_id,
+        'Active Key Age': f"{active_key_age} days" if isinstance(active_key_age, int) else active_key_age,
+        'Access Key Last Used': access_key_last_used,
+        'Creation Date': creation_date,
+        'Console Access': console_access,
+        'Permission Policies': permission_policies
+    }
+
+
 def collect_iam_user_information():
     """
     Collect IAM user information from AWS.
 
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account, producing silent data loss (see the 07.15.2026
+    / 07.16.2026 silent-collection-failure audits). Account-scope failures
+    (client creation, pagination) are allowed to raise so the caller can
+    record this scope as *failed* rather than *empty*. Per-user errors are
+    contained internally (logged and skipped).
+
     Returns:
         list: List of dictionaries containing user information
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     utils.log_info("Collecting IAM user information from AWS environment...")
 
-    try:
-        home_region = utils.get_partition_default_region()
-        iam_client = utils.get_boto3_client('iam', region_name=home_region)
-    except Exception as e:
-        utils.log_error("Error creating IAM client", e)
-        return []
+    home_region = utils.get_partition_default_region()
+    iam_client = utils.get_boto3_client('iam', region_name=home_region)
 
     user_data = []
 
-    try:
-        paginator = iam_client.get_paginator('list_users')
+    paginator = iam_client.get_paginator('list_users')
 
-        total_users = 0
-        for page in paginator.paginate():
-            total_users += len(page['Users'])
+    total_users = 0
+    for page in paginator.paginate():
+        total_users += len(page['Users'])
 
-        utils.log_info(f"Found {total_users} IAM users to process")
+    utils.log_info(f"Found {total_users} IAM users to process")
 
-        paginator = iam_client.get_paginator('list_users')
-        processed = 0
+    paginator = iam_client.get_paginator('list_users')
+    processed = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            users = page['Users']
+    for page in paginator.paginate():
+        users = page['Users']
 
-            for user in users:
-                username = user['UserName']
-                processed += 1
-                progress = (processed / total_users) * 100 if total_users > 0 else 0
+        for user in users:
+            username = user.get('UserName', 'Unknown')
+            processed += 1
+            progress = (processed / total_users) * 100 if total_users > 0 else 0
 
-                utils.log_info(f"[{progress:.1f}%] Processing user {processed}/{total_users}: {username}")
+            utils.log_info(f"[{progress:.1f}%] Processing user {processed}/{total_users}: {username}")
 
-                creation_date = user['CreateDate'].strftime('%Y-%m-%d %H:%M:%S UTC') if user['CreateDate'] else "Unknown"
-                password_last_used = user.get('PasswordLastUsed')
+            try:
+                user_info = _build_user_row(iam_client, user)
+            except Exception as e:
+                skipped += 1
+                utils.log_error(f"Skipping IAM user '{username}' due to a processing error", e)
+                continue
 
-                if password_last_used:
-                    console_last_signin = password_last_used.strftime('%Y-%m-%d %H:%M:%S UTC')
-                else:
-                    console_last_signin = "Never"
+            user_data.append(user_info)
 
-                groups = get_user_groups(iam_client, username)
-                mfa_status = get_user_mfa_devices(iam_client, username)
-                password_age, console_access = get_password_info(iam_client, username)
-                access_key_id, active_key_age, access_key_last_used = get_access_key_info(iam_client, username)
-                permission_policies = get_user_policies(iam_client, username)
-
-                user_info = {
-                    'User Name': username,
-                    'Groups': groups,
-                    'MFA': mfa_status,
-                    'Password Age': f"{password_age} days" if isinstance(password_age, int) else password_age,
-                    'Console Last Sign-in': console_last_signin,
-                    'Access Key ID': access_key_id,
-                    'Active Key Age': f"{active_key_age} days" if isinstance(active_key_age, int) else active_key_age,
-                    'Access Key Last Used': access_key_last_used,
-                    'Creation Date': creation_date,
-                    'Console Access': console_access,
-                    'Permission Policies': permission_policies
-                }
-
-                user_data.append(user_info)
-
-    except Exception as e:
-        utils.log_error("Error collecting IAM user information", e)
-        return []
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_users} IAM user(s) were skipped due to processing "
+            "errors (see log above); the remaining users were still collected."
+        )
 
     utils.log_success(f"Successfully collected information for {len(user_data)} users")
     return user_data
@@ -505,13 +542,86 @@ def get_role_tags(iam_client, role_name):
     return ", ".join(tag_strings) if tag_strings else "None"
 
 
-@utils.aws_error_handler("Collecting IAM role information", default_return=[])
+def _build_role_row(iam_client, role):
+    """
+    Build the export row for a single IAM role.
+
+    Extracted so per-role processing can be wrapped in try/except by the
+    caller: a malformed role entry must not sink the whole account-level
+    collection. Required fields are read with ``.get()`` and a safe default
+    for the same reason.
+
+    Args:
+        iam_client: The boto3 IAM client.
+        role (dict): A single Roles entry from list_roles.
+
+    Returns:
+        dict: The assembled role row.
+    """
+    role_name = role.get('RoleName', 'Unknown')
+    create_date = role.get('CreateDate')
+    creation_date = create_date.strftime('%Y-%m-%d %H:%M:%S UTC') if create_date else "Unknown"
+    role_path = role.get('Path', '/')
+    description = role.get('Description', 'None')
+    max_session_duration = role.get('MaxSessionDuration', 3600) // 3600
+
+    trust_policy_doc = role.get('AssumeRolePolicyDocument', {})
+    trusted_entities, trust_summary, cross_account_info, service_usage = analyze_trust_policy(trust_policy_doc)
+
+    role_type = determine_role_type(role_name, role_path, trust_policy_doc)
+
+    try:
+        role_usage = iam_client.get_role(RoleName=role_name)
+        role_last_used = role_usage['Role'].get('RoleLastUsed', {})
+        last_used_date = role_last_used.get('LastUsedDate')
+
+        if last_used_date:
+            last_used_str = last_used_date.strftime('%Y-%m-%d %H:%M:%S UTC')
+            days_since_used = calculate_days_since_last_used(last_used_date)
+        else:
+            last_used_str = "Never"
+            days_since_used = "Never"
+
+    except Exception as e:
+        utils.log_warning(f"Could not get usage info for role {role_name}: {e}")
+        last_used_str = "Unknown"
+        days_since_used = "Unknown"
+
+    permission_policies = get_role_policies(iam_client, role_name)
+    tags = get_role_tags(iam_client, role_name)
+
+    return {
+        'Role Name': role_name,
+        'Role Type': role_type,
+        'Trusted Entities': trusted_entities,
+        'Trust Policy Summary': trust_summary,
+        'Permission Policies': permission_policies,
+        'Last Used': last_used_str,
+        'Days Since Last Used': days_since_used,
+        'Max Session Duration (Hours)': max_session_duration,
+        'Cross-Account Access': cross_account_info,
+        'Service Usage': service_usage,
+        'Creation Date': creation_date,
+        'Path': role_path,
+        'Description': description,
+        'Tags': tags
+    }
+
+
 def collect_iam_role_information():
     """
     Collect IAM role information from AWS.
 
+    Not wrapped in ``aws_error_handler``: see collect_iam_user_information for
+    rationale. Account-scope failures (client creation, pagination) raise so
+    the caller can record this scope as *failed* rather than *empty*.
+    Per-role errors are contained internally (logged and skipped).
+
     Returns:
         list: List of dictionaries containing role information
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope.
     """
     utils.log_info("Collecting IAM role information from AWS environment...")
 
@@ -529,65 +639,32 @@ def collect_iam_role_information():
 
     paginator = iam_client.get_paginator('list_roles')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate():
         roles = page['Roles']
 
         for role in roles:
-            role_name = role['RoleName']
+            role_name = role.get('RoleName', 'Unknown')
             processed += 1
             progress = (processed / total_roles) * 100 if total_roles > 0 else 0
 
             utils.log_info(f"[{progress:.1f}%] Processing role {processed}/{total_roles}: {role_name}")
 
-            creation_date = role['CreateDate'].strftime('%Y-%m-%d %H:%M:%S UTC') if role['CreateDate'] else "Unknown"
-            role_path = role.get('Path', '/')
-            description = role.get('Description', 'None')
-            max_session_duration = role.get('MaxSessionDuration', 3600) // 3600
-
-            trust_policy_doc = role.get('AssumeRolePolicyDocument', {})
-            trusted_entities, trust_summary, cross_account_info, service_usage = analyze_trust_policy(trust_policy_doc)
-
-            role_type = determine_role_type(role_name, role_path, trust_policy_doc)
-
             try:
-                role_usage = iam_client.get_role(RoleName=role_name)
-                role_last_used = role_usage['Role'].get('RoleLastUsed', {})
-                last_used_date = role_last_used.get('LastUsedDate')
-
-                if last_used_date:
-                    last_used_str = last_used_date.strftime('%Y-%m-%d %H:%M:%S UTC')
-                    days_since_used = calculate_days_since_last_used(last_used_date)
-                else:
-                    last_used_str = "Never"
-                    days_since_used = "Never"
-
+                role_info = _build_role_row(iam_client, role)
             except Exception as e:
-                utils.log_warning(f"Could not get usage info for role {role_name}: {e}")
-                last_used_str = "Unknown"
-                days_since_used = "Unknown"
-
-            permission_policies = get_role_policies(iam_client, role_name)
-            tags = get_role_tags(iam_client, role_name)
-
-            role_info = {
-                'Role Name': role_name,
-                'Role Type': role_type,
-                'Trusted Entities': trusted_entities,
-                'Trust Policy Summary': trust_summary,
-                'Permission Policies': permission_policies,
-                'Last Used': last_used_str,
-                'Days Since Last Used': days_since_used,
-                'Max Session Duration (Hours)': max_session_duration,
-                'Cross-Account Access': cross_account_info,
-                'Service Usage': service_usage,
-                'Creation Date': creation_date,
-                'Path': role_path,
-                'Description': description,
-                'Tags': tags
-            }
+                skipped += 1
+                utils.log_error(f"Skipping IAM role '{role_name}' due to a processing error", e)
+                continue
 
             role_data.append(role_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_roles} IAM role(s) were skipped due to processing "
+            "errors (see log above); the remaining roles were still collected."
+        )
 
     utils.log_success(f"Successfully collected information for {len(role_data)} roles")
     return role_data
@@ -758,10 +835,17 @@ def get_policy_entities(iam_client, policy_arn):
     )
 
 
-@utils.aws_error_handler("Collecting managed policies", default_return=[])
 def collect_managed_policies(iam_client, include_aws_managed=False):
     """
     Collect customer managed and optionally AWS managed policies.
+
+    Not wrapped in ``aws_error_handler``: see collect_iam_user_information for
+    rationale. Account-scope failures (pagination) raise so the caller can
+    record this scope as *failed* rather than *empty*. Per-policy processing
+    is delegated to ``process_managed_policy``, which already contains its
+    own try/except and returns ``None`` on a per-item failure (skipped
+    rather than sinking the whole scope); the call is additionally wrapped
+    here as a defensive guard.
 
     Args:
         iam_client: The boto3 IAM client
@@ -769,6 +853,9 @@ def collect_managed_policies(iam_client, include_aws_managed=False):
 
     Returns:
         list: List of policy information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope.
     """
     policies_data = []
 
@@ -786,6 +873,7 @@ def collect_managed_policies(iam_client, include_aws_managed=False):
     utils.log_info(f"Found {total_policies} managed policies to process")
 
     processed = 0
+    skipped = 0
 
     paginator = iam_client.get_paginator('list_policies')
     for page in paginator.paginate(Scope='Local'):
@@ -793,9 +881,14 @@ def collect_managed_policies(iam_client, include_aws_managed=False):
         for policy in policies:
             processed += 1
             progress = (processed / total_policies) * 100 if total_policies > 0 else 0
-            policy_name = policy['PolicyName']
+            policy_name = policy.get('PolicyName', 'Unknown')
             utils.log_info(f"[{progress:.1f}%] Processing policy {processed}/{total_policies}: {policy_name}")
-            policy_info = process_managed_policy(iam_client, policy, 'Customer Managed')
+            try:
+                policy_info = process_managed_policy(iam_client, policy, 'Customer Managed')
+            except Exception as e:
+                skipped += 1
+                utils.log_error(f"Skipping managed policy '{policy_name}' due to a processing error", e)
+                continue
             if policy_info:
                 policies_data.append(policy_info)
 
@@ -806,11 +899,22 @@ def collect_managed_policies(iam_client, include_aws_managed=False):
             for policy in policies:
                 processed += 1
                 progress = (processed / total_policies) * 100 if total_policies > 0 else 0
-                policy_name = policy['PolicyName']
+                policy_name = policy.get('PolicyName', 'Unknown')
                 utils.log_info(f"[{progress:.1f}%] Processing AWS policy {processed}/{total_policies}: {policy_name}")
-                policy_info = process_managed_policy(iam_client, policy, 'AWS Managed')
+                try:
+                    policy_info = process_managed_policy(iam_client, policy, 'AWS Managed')
+                except Exception as e:
+                    skipped += 1
+                    utils.log_error(f"Skipping AWS managed policy '{policy_name}' due to a processing error", e)
+                    continue
                 if policy_info:
                     policies_data.append(policy_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_policies} managed polic(ies) were skipped due to "
+            "processing errors (see log above); the remaining policies were still collected."
+        )
 
     return policies_data
 
@@ -891,16 +995,26 @@ def process_managed_policy(iam_client, policy, policy_type):
         return None
 
 
-@utils.aws_error_handler("Collecting inline policies", default_return=[])
 def collect_inline_policies(iam_client):
     """
     Collect inline policies from users, groups, and roles.
+
+    Not wrapped in ``aws_error_handler``: see collect_iam_user_information for
+    rationale. Account-scope failures (pagination) raise so the caller can
+    record this scope as *failed* rather than *empty*. Per-entity policy
+    listing failures are already contained by the try/except around each
+    ``list_*_policies`` call below (logged and the loop continues); entity
+    names are read with ``.get()`` so a malformed entity does not raise
+    before reaching that guard.
 
     Args:
         iam_client: The boto3 IAM client
 
     Returns:
         list: List of inline policy information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope.
     """
     inline_policies = []
 
@@ -928,7 +1042,7 @@ def collect_inline_policies(iam_client):
         for user in page['Users']:
             processed += 1
             progress = (processed / total_entities) * 100 if total_entities > 0 else 0
-            username = user['UserName']
+            username = user.get('UserName', 'Unknown')
             utils.log_info(f"[{progress:.1f}%] Checking user {processed}/{total_entities}: {username}")
 
             try:
@@ -945,7 +1059,7 @@ def collect_inline_policies(iam_client):
         for group in page['Groups']:
             processed += 1
             progress = (processed / total_entities) * 100 if total_entities > 0 else 0
-            groupname = group['GroupName']
+            groupname = group.get('GroupName', 'Unknown')
             utils.log_info(f"[{progress:.1f}%] Checking group {processed}/{total_entities}: {groupname}")
 
             try:
@@ -962,7 +1076,7 @@ def collect_inline_policies(iam_client):
         for role in page['Roles']:
             processed += 1
             progress = (processed / total_entities) * 100 if total_entities > 0 else 0
-            rolename = role['RoleName']
+            rolename = role.get('RoleName', 'Unknown')
             utils.log_info(f"[{progress:.1f}%] Checking role {processed}/{total_entities}: {rolename}")
 
             try:
@@ -1438,66 +1552,147 @@ def _export_comprehensive_to_excel(users_data, roles_data, policies_data, accoun
 # ---------------------------------------------------------------------------
 
 def _run_users_export(account_id, account_name):
-    """Collect IAM users and export to Excel."""
+    """Collect IAM users and export to Excel.
+
+    IAM is a global/account-scope service (not multi-region), so failures are
+    tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent``. A failed collection is exported as a
+    partial result (if any data was collected) and always surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit — it must never be
+    silently collapsed into "no data" (07.15.2026 / 07.16.2026 audits).
+    """
     utils.log_info("Starting IAM user information collection from AWS...")
-    user_data = collect_iam_user_information()
 
-    if not user_data:
+    failed_scopes = []
+    try:
+        user_data = collect_iam_user_information()
+    except Exception as e:
+        failed_scopes.append(("iam-users", str(e)))
+        user_data = []
+
+    if user_data:
+        _export_users_to_excel(user_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No IAM user data collected.")
-        return
 
-    _export_users_to_excel(user_data, account_id, account_name)
+    if failed_scopes:
+        utils.report_collection_failures(account_name, "iam-users", failed_scopes)
+        print(
+            "\nERROR: IAM export completed with failures — data is incomplete. "
+            "See the *-iam-users-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def _run_roles_export(account_id, account_name):
-    """Collect IAM roles and export to Excel."""
+    """Collect IAM roles and export to Excel. See _run_users_export for the
+    account-scope failure-handling rationale."""
     utils.log_info("Starting IAM role information collection from AWS...")
-    role_data = collect_iam_role_information()
 
-    if not role_data:
+    failed_scopes = []
+    try:
+        role_data = collect_iam_role_information()
+    except Exception as e:
+        failed_scopes.append(("iam-roles", str(e)))
+        role_data = []
+
+    if role_data:
+        _export_roles_to_excel(role_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No IAM role data collected.")
-        return
 
-    _export_roles_to_excel(role_data, account_id, account_name)
+    if failed_scopes:
+        utils.report_collection_failures(account_name, "iam-roles", failed_scopes)
+        print(
+            "\nERROR: IAM export completed with failures — data is incomplete. "
+            "See the *-iam-roles-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def _run_policies_export(account_id, account_name, include_aws_managed=False):
-    """Collect IAM policies and export to Excel."""
+    """Collect IAM policies and export to Excel. See _run_users_export for the
+    account-scope failure-handling rationale. Managed and inline policies are
+    tracked as separate scopes so a failure in one does not discard data
+    already collected from the other."""
     utils.log_info("Starting IAM policy information collection from AWS...")
 
     home_region = utils.get_partition_default_region()
     iam_client = utils.get_boto3_client('iam', region_name=home_region)
 
-    managed_policies = collect_managed_policies(iam_client, include_aws_managed)
-    inline_policies = collect_inline_policies(iam_client)
+    failed_scopes = []
 
-    if not managed_policies and not inline_policies:
+    try:
+        managed_policies = collect_managed_policies(iam_client, include_aws_managed)
+    except Exception as e:
+        failed_scopes.append(("iam-managed-policies", str(e)))
+        managed_policies = []
+
+    try:
+        inline_policies = collect_inline_policies(iam_client)
+    except Exception as e:
+        failed_scopes.append(("iam-inline-policies", str(e)))
+        inline_policies = []
+
+    if managed_policies or inline_policies:
+        _export_policies_to_excel(managed_policies, inline_policies, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No IAM policy data collected.")
-        return
 
-    _export_policies_to_excel(managed_policies, inline_policies, account_id, account_name)
+    if failed_scopes:
+        utils.report_collection_failures(account_name, "iam-policies", failed_scopes)
+        print(
+            "\nERROR: IAM export completed with failures — data is incomplete. "
+            "See the *-iam-policies-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def _run_comprehensive_export(account_id, account_name):
-    """Collect all IAM resources and export to a single comprehensive workbook."""
+    """Collect all IAM resources and export to a single comprehensive
+    workbook. See _run_users_export for the account-scope failure-handling
+    rationale. Users, roles, and managed policies are tracked as separate
+    scopes so a failure in one phase does not discard data already collected
+    from the others."""
     utils.log_info("Starting comprehensive IAM information collection from AWS...")
 
+    failed_scopes = []
+
     utils.log_info("Phase 1: Collecting IAM Users...")
-    users_data = collect_iam_user_information()
+    try:
+        users_data = collect_iam_user_information()
+    except Exception as e:
+        failed_scopes.append(("iam-users", str(e)))
+        users_data = []
 
     utils.log_info("Phase 2: Collecting IAM Roles...")
-    roles_data = collect_iam_role_information()
+    try:
+        roles_data = collect_iam_role_information()
+    except Exception as e:
+        failed_scopes.append(("iam-roles", str(e)))
+        roles_data = []
 
     utils.log_info("Phase 3: Collecting IAM Policies (Customer Managed)...")
-    home_region = utils.get_partition_default_region()
-    iam_client = utils.get_boto3_client('iam', region_name=home_region)
-    policies_data = collect_managed_policies(iam_client, include_aws_managed=False)
+    try:
+        home_region = utils.get_partition_default_region()
+        iam_client = utils.get_boto3_client('iam', region_name=home_region)
+        policies_data = collect_managed_policies(iam_client, include_aws_managed=False)
+    except Exception as e:
+        failed_scopes.append(("iam-managed-policies", str(e)))
+        policies_data = []
 
-    if not users_data and not roles_data and not policies_data:
+    if users_data or roles_data or policies_data:
+        _export_comprehensive_to_excel(users_data, roles_data, policies_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No IAM data collected.")
-        return
 
-    _export_comprehensive_to_excel(users_data, roles_data, policies_data, account_id, account_name)
+    if failed_scopes:
+        utils.report_collection_failures(account_name, "iam-comprehensive", failed_scopes)
+        print(
+            "\nERROR: IAM export completed with failures — data is incomplete. "
+            "See the *-iam-comprehensive-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -50,13 +50,26 @@ args = utils.parse_script_args("Export IAM Identity Center (SSO) configuration t
 # Instance discovery
 # ---------------------------------------------------------------------------
 
-@utils.aws_error_handler("Getting IAM Identity Center instance", default_return=(None, None))
 def get_identity_center_instance():
     """
     Get the IAM Identity Center instance ARN and Identity Store ID.
 
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    (None, None), which is indistinguishable from IAM Identity Center being
+    genuinely disabled in this account. The empty-instances case (a clean,
+    valid API response with zero instances) is a legitimate account state and
+    is handled explicitly below without raising. Any other failure
+    (throttling, access denied, malformed response, etc.) is allowed to
+    propagate so the caller can record it as a FAILED scope rather than
+    silently treating it as "not enabled."
+
     Returns:
-        tuple: (instance_arn, identity_store_id) or (None, None) if not configured
+        tuple: (instance_arn, identity_store_id), or (None, None) if IAM
+            Identity Center is not enabled/configured in this account.
+
+    Raises:
+        Exception: Any AWS API error other than a legitimately empty instance
+            list (never masked as "not enabled").
     """
     home_region = utils.get_partition_default_region()
     sso_admin_client = utils.get_boto3_client('sso-admin', region_name=home_region)
@@ -70,8 +83,13 @@ def get_identity_center_instance():
         return None, None
 
     instance = instances[0]
-    instance_arn = instance['InstanceArn']
-    identity_store_id = instance['IdentityStoreId']
+    instance_arn = instance.get('InstanceArn')
+    identity_store_id = instance.get('IdentityStoreId')
+
+    if not instance_arn or not identity_store_id:
+        raise ValueError(
+            f"IAM Identity Center instance response is missing InstanceArn/IdentityStoreId: {instance}"
+        )
 
     utils.log_success(f"Found IAM Identity Center instance: {instance_arn}")
     return instance_arn, identity_store_id
@@ -240,10 +258,55 @@ def get_user_application_assignments(sso_admin_client, instance_arn, user_id):
     return ', '.join(user_applications) if user_applications else 'None'
 
 
-@utils.aws_error_handler("Collecting Identity Center users", default_return=[])
+def _build_identity_center_user_row(identitystore_client, sso_admin_client, identity_store_id, instance_arn, user):
+    """
+    Build the export row for a single Identity Center user (combined export).
+
+    Extracted so per-user processing can be wrapped in try/except by the
+    caller: a malformed user record must not sink the whole account's
+    collection. UserId is read via .get() and validated explicitly — the
+    group/account/application lookups all require it, so a record missing it
+    is treated as malformed and raised for the caller's per-item guard to
+    catch and skip.
+
+    Raises:
+        ValueError: If the user record is missing UserId.
+    """
+    user_id = user.get('UserId')
+    if not user_id:
+        raise ValueError(f"Identity Center user record missing UserId: {user}")
+
+    group_memberships = get_user_group_memberships(identitystore_client, identity_store_id, user_id)
+    account_assignments = get_user_account_assignments(sso_admin_client, instance_arn, user_id)
+    application_assignments = get_user_application_assignments(sso_admin_client, instance_arn, user_id)
+
+    return {
+        'User ID': user_id,
+        'User Name': user.get('UserName', 'N/A'),
+        'Display Name': user.get('DisplayName', 'N/A'),
+        'Given Name': user.get('Name', {}).get('GivenName', 'N/A'),
+        'Family Name': user.get('Name', {}).get('FamilyName', 'N/A'),
+        'Email': get_user_email(user),
+        'Status': 'Active' if user.get('Active', True) else 'Inactive',
+        'External ID': get_user_external_id(user),
+        'Groups': group_memberships,
+        'AWS Accounts': account_assignments,
+        'Applications': application_assignments,
+        'Created Date': user.get('Meta', {}).get('Created', 'N/A'),
+        'Last Modified': user.get('Meta', {}).get('LastModified', 'N/A')
+    }
+
+
 def collect_identity_center_users(identity_store_id, instance_arn):
     """
     Collect IAM Identity Center users (combined export).
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    users, producing silent data loss. Account-scope API failures (listing,
+    pagination, throttling, access denied) are allowed to raise so the
+    caller can record this scope as FAILED. Per-user errors are contained
+    internally (logged and skipped) via _build_identity_center_user_row.
 
     Args:
         identity_store_id: The Identity Store ID
@@ -251,6 +314,9 @@ def collect_identity_center_users(identity_store_id, instance_arn):
 
     Returns:
         list: List of user information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not identity_store_id:
         return []
@@ -271,6 +337,7 @@ def collect_identity_center_users(identity_store_id, instance_arn):
 
     paginator = identitystore_client.get_paginator('list_users')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(IdentityStoreId=identity_store_id):
         users = page.get('Users', [])
@@ -282,27 +349,24 @@ def collect_identity_center_users(identity_store_id, instance_arn):
 
             utils.log_info(f"[{progress:.1f}%] Processing user {processed}/{total_users}: {user_name}")
 
-            group_memberships = get_user_group_memberships(identitystore_client, identity_store_id, user['UserId'])
-            account_assignments = get_user_account_assignments(sso_admin_client, instance_arn, user['UserId'])
-            application_assignments = get_user_application_assignments(sso_admin_client, instance_arn, user['UserId'])
-
-            user_info = {
-                'User ID': user.get('UserId', 'N/A'),
-                'User Name': user.get('UserName', 'N/A'),
-                'Display Name': user.get('DisplayName', 'N/A'),
-                'Given Name': user.get('Name', {}).get('GivenName', 'N/A'),
-                'Family Name': user.get('Name', {}).get('FamilyName', 'N/A'),
-                'Email': get_user_email(user),
-                'Status': 'Active' if user.get('Active', True) else 'Inactive',
-                'External ID': get_user_external_id(user),
-                'Groups': group_memberships,
-                'AWS Accounts': account_assignments,
-                'Applications': application_assignments,
-                'Created Date': user.get('Meta', {}).get('Created', 'N/A'),
-                'Last Modified': user.get('Meta', {}).get('LastModified', 'N/A')
-            }
+            try:
+                user_info = _build_identity_center_user_row(
+                    identitystore_client, sso_admin_client, identity_store_id, instance_arn, user
+                )
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Identity Center user '{user.get('UserId', user_name)}' due to a processing error", e
+                )
+                continue
 
             users_data.append(user_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_users} Identity Center user(s) were skipped due to processing errors "
+            "(see log above); the remaining users were still collected."
+        )
 
     return users_data
 
@@ -344,16 +408,52 @@ def get_group_member_count(identitystore_client, identity_store_id, group_id):
     return member_count
 
 
-@utils.aws_error_handler("Collecting Identity Center groups", default_return=[])
+def _build_identity_center_group_row(identitystore_client, identity_store_id, group):
+    """
+    Build the export row for a single Identity Center group (simple version).
+
+    Extracted so per-group processing can be wrapped in try/except by the
+    caller: a malformed group record must not sink the whole account's
+    collection.
+
+    Raises:
+        ValueError: If the group record is missing GroupId.
+    """
+    group_id = group.get('GroupId')
+    if not group_id:
+        raise ValueError(f"Identity Center group record missing GroupId: {group}")
+
+    member_count = get_group_member_count(identitystore_client, identity_store_id, group_id)
+
+    return {
+        'Group ID': group_id,
+        'Group Name': group.get('DisplayName', 'N/A'),
+        'Description': group.get('Description', 'N/A'),
+        'External ID': get_group_external_id(group),
+        'Member Count': member_count,
+        'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
+        'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A')
+    }
+
+
 def collect_identity_center_groups(identity_store_id):
     """
     Collect IAM Identity Center groups (simple version, for combined export option 1).
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    groups. Account-scope API failures are allowed to raise so the caller can
+    record this scope as FAILED. Per-group errors are contained internally
+    (logged and skipped) via _build_identity_center_group_row.
 
     Args:
         identity_store_id: The Identity Store ID
 
     Returns:
         list: List of group information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not identity_store_id:
         return []
@@ -373,6 +473,7 @@ def collect_identity_center_groups(identity_store_id):
 
     paginator = identitystore_client.get_paginator('list_groups')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(IdentityStoreId=identity_store_id):
         groups = page.get('Groups', [])
@@ -384,19 +485,22 @@ def collect_identity_center_groups(identity_store_id):
 
             utils.log_info(f"[{progress:.1f}%] Processing group {processed}/{total_groups}: {group_name}")
 
-            member_count = get_group_member_count(identitystore_client, identity_store_id, group['GroupId'])
-
-            group_info = {
-                'Group ID': group.get('GroupId', 'N/A'),
-                'Group Name': group.get('DisplayName', 'N/A'),
-                'Description': group.get('Description', 'N/A'),
-                'External ID': get_group_external_id(group),
-                'Member Count': member_count,
-                'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
-                'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A')
-            }
+            try:
+                group_info = _build_identity_center_group_row(identitystore_client, identity_store_id, group)
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Identity Center group '{group.get('GroupId', group_name)}' due to a processing error", e
+                )
+                continue
 
             groups_data.append(group_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_groups} Identity Center group(s) were skipped due to processing errors "
+            "(see log above); the remaining groups were still collected."
+        )
 
     return groups_data
 
@@ -465,17 +569,68 @@ def _get_group_members_detailed(identitystore_client, identity_store_id, group_i
     return members
 
 
-@utils.aws_error_handler("Collecting Identity Center groups (detailed)", default_return=[])
+def _build_identity_center_group_detailed_row(identitystore_client, identity_store_id, group):
+    """
+    Build the export row for a single Identity Center group (detailed version).
+
+    Extracted so per-group processing can be wrapped in try/except by the
+    caller: a malformed group record must not sink the whole account's
+    collection.
+
+    Raises:
+        ValueError: If the group record is missing GroupId.
+    """
+    group_id = group.get('GroupId')
+    if not group_id:
+        raise ValueError(f"Identity Center group record missing GroupId: {group}")
+
+    members = _get_group_members_detailed(identitystore_client, identity_store_id, group_id)
+
+    member_names = [m['name'] for m in members]
+    user_members = [m['name'] for m in members if m['type'] == 'User']
+    group_members = [m['name'] for m in members if m['type'] == 'Group']
+
+    external_ids = group.get('ExternalIds', [])
+    external_id = external_ids[0].get('Id', 'N/A') if external_ids else 'N/A'
+
+    return {
+        'Group ID': group_id,
+        'Group Name': group.get('DisplayName', 'N/A'),
+        'Description': group.get('Description', 'N/A'),
+        'External ID': external_id,
+        'Total Members': len(members),
+        'User Members': len(user_members),
+        'Group Members': len(group_members),
+        'Member Names': ', '.join(member_names) if member_names else 'None',
+        'User Member Names': ', '.join(user_members) if user_members else 'None',
+        'Group Member Names': ', '.join(group_members) if group_members else 'None',
+        'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
+        'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A'),
+        'Resource Version': group.get('Meta', {}).get('ResourceType', 'N/A')
+    }
+
+
 def collect_identity_center_groups_detailed(identity_store_id):
     """
     Collect IAM Identity Center groups with detailed member information.
     Used for Groups-only export (option 2).
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    groups. Account-scope API failures are allowed to raise so the caller can
+    record this scope as FAILED. Per-group errors are contained internally
+    (logged and skipped) via _build_identity_center_group_detailed_row. The
+    zero-groups case below is a legitimate, non-error account state and
+    returns [] without raising.
 
     Args:
         identity_store_id: The Identity Store ID
 
     Returns:
         list: List of group information dictionaries with member details
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not identity_store_id:
         return []
@@ -498,6 +653,7 @@ def collect_identity_center_groups_detailed(identity_store_id):
 
     paginator = identitystore_client.get_paginator('list_groups')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(IdentityStoreId=identity_store_id):
         groups = page.get('Groups', [])
@@ -509,32 +665,24 @@ def collect_identity_center_groups_detailed(identity_store_id):
 
             utils.log_info(f"[{progress:.1f}%] Processing group {processed}/{total_groups}: {group_name}")
 
-            members = _get_group_members_detailed(identitystore_client, identity_store_id, group['GroupId'])
-
-            member_names = [m['name'] for m in members]
-            user_members = [m['name'] for m in members if m['type'] == 'User']
-            group_members = [m['name'] for m in members if m['type'] == 'Group']
-
-            external_ids = group.get('ExternalIds', [])
-            external_id = external_ids[0].get('Id', 'N/A') if external_ids else 'N/A'
-
-            group_info = {
-                'Group ID': group.get('GroupId', 'N/A'),
-                'Group Name': group.get('DisplayName', 'N/A'),
-                'Description': group.get('Description', 'N/A'),
-                'External ID': external_id,
-                'Total Members': len(members),
-                'User Members': len(user_members),
-                'Group Members': len(group_members),
-                'Member Names': ', '.join(member_names) if member_names else 'None',
-                'User Member Names': ', '.join(user_members) if user_members else 'None',
-                'Group Member Names': ', '.join(group_members) if group_members else 'None',
-                'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
-                'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A'),
-                'Resource Version': group.get('Meta', {}).get('ResourceType', 'N/A')
-            }
+            try:
+                group_info = _build_identity_center_group_detailed_row(
+                    identitystore_client, identity_store_id, group
+                )
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Identity Center group '{group.get('GroupId', group_name)}' due to a processing error", e
+                )
+                continue
 
             groups_data.append(group_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_groups} Identity Center group(s) were skipped due to processing errors "
+            "(see log above); the remaining groups were still collected."
+        )
 
     return groups_data
 
@@ -596,16 +744,25 @@ def get_permission_set_tags(sso_admin_client, instance_arn, permission_set_arn):
     return ', '.join(tag_strings) if tag_strings else 'None'
 
 
-@utils.aws_error_handler("Collecting permission sets", default_return=[])
 def collect_permission_sets(instance_arn):
     """
     Collect IAM Identity Center permission sets.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    permission sets. Account-scope API failures (listing, pagination) are
+    allowed to raise so the caller can record this scope as FAILED. Per-item
+    errors (a single permission set failing to describe) are contained
+    internally (logged and skipped) below.
 
     Args:
         instance_arn: IAM Identity Center instance ARN
 
     Returns:
         list: List of permission set information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not instance_arn:
         return []
@@ -625,6 +782,7 @@ def collect_permission_sets(instance_arn):
 
     paginator = sso_admin_client.get_paginator('list_permission_sets')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(InstanceArn=instance_arn):
         permission_sets = page.get('PermissionSets', [])
@@ -641,7 +799,7 @@ def collect_permission_sets(instance_arn):
                     PermissionSetArn=permission_set_arn
                 )
 
-                permission_set = ps_response['PermissionSet']
+                permission_set = ps_response.get('PermissionSet', {})
 
                 managed_policies = get_permission_set_managed_policies(sso_admin_client, instance_arn, permission_set_arn)
                 inline_policy = get_permission_set_inline_policy(sso_admin_client, instance_arn, permission_set_arn)
@@ -663,7 +821,14 @@ def collect_permission_sets(instance_arn):
                 permission_sets_data.append(permission_set_info)
 
             except Exception as e:
-                utils.log_warning(f"Error processing permission set {permission_set_arn}: {e}")
+                skipped += 1
+                utils.log_error(f"Skipping permission set '{permission_set_arn}' due to a processing error", e)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_permission_sets} permission set(s) were skipped due to processing errors "
+            "(see log above); the remaining permission sets were still collected."
+        )
 
     return permission_sets_data
 
@@ -672,10 +837,94 @@ def collect_permission_sets(instance_arn):
 # Comprehensive collection functions (from iam_identity_center_comprehensive_export.py)
 # ---------------------------------------------------------------------------
 
-@utils.aws_error_handler("Collecting comprehensive Identity Center users", default_return=[])
+def _build_comprehensive_user_row(identitystore_client, sso_admin_client, identity_store_id, instance_arn, user):
+    """
+    Build the export row for a single Identity Center user (comprehensive export).
+
+    Extracted so per-user processing can be wrapped in try/except by the
+    caller: a malformed user record must not sink the whole account's
+    collection. UserId is read via .get() and validated explicitly — the
+    group/account/application lookups all require it.
+
+    Raises:
+        ValueError: If the user record is missing UserId.
+    """
+    user_id = user.get('UserId')
+    if not user_id:
+        raise ValueError(f"Identity Center user record missing UserId: {user}")
+
+    group_memberships = get_user_group_memberships(identitystore_client, identity_store_id, user_id)
+    account_assignments = get_user_account_assignments(sso_admin_client, instance_arn, user_id)
+    application_assignments = get_user_application_assignments(sso_admin_client, instance_arn, user_id)
+
+    addresses = user.get('Addresses', [])
+    phone_numbers = user.get('PhoneNumbers', [])
+
+    primary_address = 'N/A'
+    if addresses:
+        primary_addr = next((addr for addr in addresses if addr.get('Primary', False)), addresses[0])
+        if primary_addr:
+            addr_parts = []
+            if primary_addr.get('StreetAddress'):
+                addr_parts.append(primary_addr['StreetAddress'])
+            if primary_addr.get('Locality'):
+                addr_parts.append(primary_addr['Locality'])
+            if primary_addr.get('Region'):
+                addr_parts.append(primary_addr['Region'])
+            if primary_addr.get('PostalCode'):
+                addr_parts.append(primary_addr['PostalCode'])
+            primary_address = ', '.join(addr_parts)
+
+    primary_phone = 'N/A'
+    if phone_numbers:
+        primary_ph = next((phone for phone in phone_numbers if phone.get('Primary', False)), phone_numbers[0])
+        if primary_ph:
+            primary_phone = primary_ph.get('Value', 'N/A')
+
+    return {
+        'User ID': user_id,
+        'User Name': user.get('UserName', 'N/A'),
+        'Display Name': user.get('DisplayName', 'N/A'),
+        'Nick Name': user.get('NickName', 'N/A'),
+        'Profile URL': user.get('ProfileUrl', 'N/A'),
+        'Given Name': user.get('Name', {}).get('GivenName', 'N/A'),
+        'Middle Name': user.get('Name', {}).get('MiddleName', 'N/A'),
+        'Family Name': user.get('Name', {}).get('FamilyName', 'N/A'),
+        'Formatted Name': user.get('Name', {}).get('Formatted', 'N/A'),
+        'Honorific Prefix': user.get('Name', {}).get('HonorificPrefix', 'N/A'),
+        'Honorific Suffix': user.get('Name', {}).get('HonorificSuffix', 'N/A'),
+        'Email': get_user_email(user),
+        'Email Verified': 'Yes' if get_user_email_verified(user) else 'No',
+        'Primary Phone': primary_phone,
+        'Primary Address': primary_address[:200],
+        'User Type': user.get('UserType', 'N/A'),
+        'Title': user.get('Title', 'N/A'),
+        'Preferred Language': user.get('PreferredLanguage', 'N/A'),
+        'Locale': user.get('Locale', 'N/A'),
+        'Timezone': user.get('Timezone', 'N/A'),
+        'Status': 'Active' if user.get('Active', True) else 'Inactive',
+        'External ID': get_user_external_id(user),
+        'Groups': group_memberships,
+        'AWS Accounts': account_assignments,
+        'Applications': application_assignments,
+        'Group Count': len(group_memberships.split(', ')) if group_memberships != 'None' else 0,
+        'Account Assignment Count': len(account_assignments.split(', ')) if account_assignments not in ['None', 'Unknown'] else 0,
+        'Application Assignment Count': len(application_assignments.split(', ')) if application_assignments not in ['None', 'Unknown', 'Service Not Available'] else 0,
+        'Created Date': user.get('Meta', {}).get('Created', 'N/A'),
+        'Last Modified': user.get('Meta', {}).get('LastModified', 'N/A'),
+        'Resource Type': user.get('Meta', {}).get('ResourceType', 'N/A')
+    }
+
+
 def collect_comprehensive_users(identity_store_id, instance_arn):
     """
     Collect comprehensive IAM Identity Center user information.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    users. Account-scope API failures are allowed to raise so the caller can
+    record this scope as FAILED. Per-user errors are contained internally
+    (logged and skipped) via _build_comprehensive_user_row.
 
     Args:
         identity_store_id: The Identity Store ID
@@ -683,6 +932,9 @@ def collect_comprehensive_users(identity_store_id, instance_arn):
 
     Returns:
         list: List of comprehensive user information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not identity_store_id:
         return []
@@ -703,6 +955,7 @@ def collect_comprehensive_users(identity_store_id, instance_arn):
 
     paginator = identitystore_client.get_paginator('list_users')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(IdentityStoreId=identity_store_id):
         users = page.get('Users', [])
@@ -714,69 +967,24 @@ def collect_comprehensive_users(identity_store_id, instance_arn):
 
             utils.log_info(f"[{progress:.1f}%] Processing user {processed}/{total_users}: {user_name}")
 
-            group_memberships = get_user_group_memberships(identitystore_client, identity_store_id, user['UserId'])
-            account_assignments = get_user_account_assignments(sso_admin_client, instance_arn, user['UserId'])
-            application_assignments = get_user_application_assignments(sso_admin_client, instance_arn, user['UserId'])
-
-            addresses = user.get('Addresses', [])
-            phone_numbers = user.get('PhoneNumbers', [])
-
-            primary_address = 'N/A'
-            if addresses:
-                primary_addr = next((addr for addr in addresses if addr.get('Primary', False)), addresses[0])
-                if primary_addr:
-                    addr_parts = []
-                    if primary_addr.get('StreetAddress'):
-                        addr_parts.append(primary_addr['StreetAddress'])
-                    if primary_addr.get('Locality'):
-                        addr_parts.append(primary_addr['Locality'])
-                    if primary_addr.get('Region'):
-                        addr_parts.append(primary_addr['Region'])
-                    if primary_addr.get('PostalCode'):
-                        addr_parts.append(primary_addr['PostalCode'])
-                    primary_address = ', '.join(addr_parts)
-
-            primary_phone = 'N/A'
-            if phone_numbers:
-                primary_ph = next((phone for phone in phone_numbers if phone.get('Primary', False)), phone_numbers[0])
-                if primary_ph:
-                    primary_phone = primary_ph.get('Value', 'N/A')
-
-            user_info = {
-                'User ID': user.get('UserId', 'N/A'),
-                'User Name': user.get('UserName', 'N/A'),
-                'Display Name': user.get('DisplayName', 'N/A'),
-                'Nick Name': user.get('NickName', 'N/A'),
-                'Profile URL': user.get('ProfileUrl', 'N/A'),
-                'Given Name': user.get('Name', {}).get('GivenName', 'N/A'),
-                'Middle Name': user.get('Name', {}).get('MiddleName', 'N/A'),
-                'Family Name': user.get('Name', {}).get('FamilyName', 'N/A'),
-                'Formatted Name': user.get('Name', {}).get('Formatted', 'N/A'),
-                'Honorific Prefix': user.get('Name', {}).get('HonorificPrefix', 'N/A'),
-                'Honorific Suffix': user.get('Name', {}).get('HonorificSuffix', 'N/A'),
-                'Email': get_user_email(user),
-                'Email Verified': 'Yes' if get_user_email_verified(user) else 'No',
-                'Primary Phone': primary_phone,
-                'Primary Address': primary_address[:200],
-                'User Type': user.get('UserType', 'N/A'),
-                'Title': user.get('Title', 'N/A'),
-                'Preferred Language': user.get('PreferredLanguage', 'N/A'),
-                'Locale': user.get('Locale', 'N/A'),
-                'Timezone': user.get('Timezone', 'N/A'),
-                'Status': 'Active' if user.get('Active', True) else 'Inactive',
-                'External ID': get_user_external_id(user),
-                'Groups': group_memberships,
-                'AWS Accounts': account_assignments,
-                'Applications': application_assignments,
-                'Group Count': len(group_memberships.split(', ')) if group_memberships != 'None' else 0,
-                'Account Assignment Count': len(account_assignments.split(', ')) if account_assignments not in ['None', 'Unknown'] else 0,
-                'Application Assignment Count': len(application_assignments.split(', ')) if application_assignments not in ['None', 'Unknown', 'Service Not Available'] else 0,
-                'Created Date': user.get('Meta', {}).get('Created', 'N/A'),
-                'Last Modified': user.get('Meta', {}).get('LastModified', 'N/A'),
-                'Resource Type': user.get('Meta', {}).get('ResourceType', 'N/A')
-            }
+            try:
+                user_info = _build_comprehensive_user_row(
+                    identitystore_client, sso_admin_client, identity_store_id, instance_arn, user
+                )
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Identity Center user '{user.get('UserId', user_name)}' due to a processing error", e
+                )
+                continue
 
             users_data.append(user_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_users} Identity Center user(s) were skipped due to processing errors "
+            "(see log above); the remaining users were still collected."
+        )
 
     return users_data
 
@@ -855,10 +1063,49 @@ def get_group_account_assignments(sso_admin_client, instance_arn, group_id):
     return ', '.join(assignments) if assignments else 'None'
 
 
-@utils.aws_error_handler("Collecting comprehensive Identity Center groups", default_return=[])
+def _build_comprehensive_group_row(identitystore_client, sso_admin_client, identity_store_id, instance_arn, group):
+    """
+    Build the export row for a single Identity Center group (comprehensive export).
+
+    Extracted so per-group processing can be wrapped in try/except by the
+    caller: a malformed group record must not sink the whole account's
+    collection.
+
+    Raises:
+        ValueError: If the group record is missing GroupId.
+    """
+    group_id = group.get('GroupId')
+    if not group_id:
+        raise ValueError(f"Identity Center group record missing GroupId: {group}")
+
+    member_count = get_group_member_count(identitystore_client, identity_store_id, group_id)
+    member_details = get_group_member_details(identitystore_client, identity_store_id, group_id)
+    account_assignments = get_group_account_assignments(sso_admin_client, instance_arn, group_id)
+
+    return {
+        'Group ID': group_id,
+        'Group Name': group.get('DisplayName', 'N/A'),
+        'Description': group.get('Description', 'N/A'),
+        'External ID': get_group_external_id(group),
+        'Member Count': member_count,
+        'Member Details': member_details[:500],
+        'Account Assignments': account_assignments,
+        'Assignment Count': len(account_assignments.split(', ')) if account_assignments not in ['None', 'Unknown'] else 0,
+        'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
+        'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A'),
+        'Resource Type': group.get('Meta', {}).get('ResourceType', 'N/A')
+    }
+
+
 def collect_comprehensive_groups(identity_store_id, instance_arn):
     """
     Collect comprehensive IAM Identity Center group information.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    groups. Account-scope API failures are allowed to raise so the caller can
+    record this scope as FAILED. Per-group errors are contained internally
+    (logged and skipped) via _build_comprehensive_group_row.
 
     Args:
         identity_store_id: The Identity Store ID
@@ -866,6 +1113,9 @@ def collect_comprehensive_groups(identity_store_id, instance_arn):
 
     Returns:
         list: List of comprehensive group information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not identity_store_id:
         return []
@@ -886,6 +1136,7 @@ def collect_comprehensive_groups(identity_store_id, instance_arn):
 
     paginator = identitystore_client.get_paginator('list_groups')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(IdentityStoreId=identity_store_id):
         groups = page.get('Groups', [])
@@ -897,25 +1148,24 @@ def collect_comprehensive_groups(identity_store_id, instance_arn):
 
             utils.log_info(f"[{progress:.1f}%] Processing group {processed}/{total_groups}: {group_name}")
 
-            member_count = get_group_member_count(identitystore_client, identity_store_id, group['GroupId'])
-            member_details = get_group_member_details(identitystore_client, identity_store_id, group['GroupId'])
-            account_assignments = get_group_account_assignments(sso_admin_client, instance_arn, group['GroupId'])
-
-            group_info = {
-                'Group ID': group.get('GroupId', 'N/A'),
-                'Group Name': group.get('DisplayName', 'N/A'),
-                'Description': group.get('Description', 'N/A'),
-                'External ID': get_group_external_id(group),
-                'Member Count': member_count,
-                'Member Details': member_details[:500],
-                'Account Assignments': account_assignments,
-                'Assignment Count': len(account_assignments.split(', ')) if account_assignments not in ['None', 'Unknown'] else 0,
-                'Created Date': group.get('Meta', {}).get('Created', 'N/A'),
-                'Last Modified': group.get('Meta', {}).get('LastModified', 'N/A'),
-                'Resource Type': group.get('Meta', {}).get('ResourceType', 'N/A')
-            }
+            try:
+                group_info = _build_comprehensive_group_row(
+                    identitystore_client, sso_admin_client, identity_store_id, instance_arn, group
+                )
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Identity Center group '{group.get('GroupId', group_name)}' due to a processing error", e
+                )
+                continue
 
             groups_data.append(group_info)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_groups} Identity Center group(s) were skipped due to processing errors "
+            "(see log above); the remaining groups were still collected."
+        )
 
     return groups_data
 
@@ -1126,16 +1376,25 @@ def get_average_session_duration(permission_sets_data):
         return 'N/A'
 
 
-@utils.aws_error_handler("Collecting comprehensive permission sets", default_return=[])
 def collect_comprehensive_permission_sets(instance_arn):
     """
     Collect comprehensive IAM Identity Center permission set information.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from an account genuinely having zero
+    permission sets. Account-scope API failures (listing, pagination) are
+    allowed to raise so the caller can record this scope as FAILED. Per-item
+    errors (a single permission set failing to describe) are contained
+    internally (logged and skipped) below.
 
     Args:
         instance_arn: IAM Identity Center instance ARN
 
     Returns:
         list: List of comprehensive permission set information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for this scope.
     """
     if not instance_arn:
         return []
@@ -1155,6 +1414,7 @@ def collect_comprehensive_permission_sets(instance_arn):
 
     paginator = sso_admin_client.get_paginator('list_permission_sets')
     processed = 0
+    skipped = 0
 
     for page in paginator.paginate(InstanceArn=instance_arn):
         permission_sets = page.get('PermissionSets', [])
@@ -1171,7 +1431,7 @@ def collect_comprehensive_permission_sets(instance_arn):
                     PermissionSetArn=permission_set_arn
                 )
 
-                permission_set = ps_response['PermissionSet']
+                permission_set = ps_response.get('PermissionSet', {})
 
                 managed_policies = get_permission_set_managed_policies_detailed(sso_admin_client, instance_arn, permission_set_arn)
                 inline_policy = get_permission_set_inline_policy_detailed(sso_admin_client, instance_arn, permission_set_arn)
@@ -1208,7 +1468,14 @@ def collect_comprehensive_permission_sets(instance_arn):
                 permission_sets_data.append(permission_set_info)
 
             except Exception as e:
-                utils.log_warning(f"Error processing permission set {permission_set_arn}: {e}")
+                skipped += 1
+                utils.log_error(f"Skipping permission set '{permission_set_arn}' due to a processing error", e)
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_permission_sets} permission set(s) were skipped due to processing errors "
+            "(see log above); the remaining permission sets were still collected."
+        )
 
     return permission_sets_data
 
@@ -1629,101 +1896,193 @@ def _export_comprehensive_to_excel(users_data, groups_data, permission_sets_data
 # Run functions
 # ---------------------------------------------------------------------------
 
+def _report_and_exit_if_failed(account_name, resource_type, failed_scopes):
+    """
+    If any account-scope collector failed, write a failure marker and exit(1).
+
+    Shared by all _run_*_export functions so a failed collection is never
+    silently indistinguishable from a genuinely empty (or not-enabled)
+    account. Does nothing if failed_scopes is empty.
+    """
+    if not failed_scopes:
+        return
+    utils.report_collection_failures(account_name, resource_type, failed_scopes)
+    print(
+        "\nERROR: IAM Identity Center export completed with failures — data is incomplete. "
+        f"See the *-{resource_type}-FAILED-*.txt marker in the output directory."
+    )
+    sys.exit(1)
+
+
 def _run_users_export(account_id, account_name):
     """Collect Identity Center users; export users-only workbook."""
-    instance_arn, identity_store_id = get_identity_center_instance()
-    if not identity_store_id:
-        utils.log_error("Could not find IAM Identity Center instance. Exiting.")
-        return
+    failed_scopes = []
+    resource_type = "iam-identity-center-users"
 
-    utils.log_info("Collecting Identity Center users...")
-    users_data = collect_identity_center_users(identity_store_id, instance_arn)
+    try:
+        instance_arn, identity_store_id = get_identity_center_instance()
+    except Exception as e:
+        failed_scopes.append(("Identity Center Instance Discovery", str(e)))
+        instance_arn, identity_store_id = None, None
 
-    if not users_data:
+    users_data = []
+    if identity_store_id:
+        utils.log_info("Collecting Identity Center users...")
+        try:
+            users_data = collect_identity_center_users(identity_store_id, instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Users", str(e)))
+    elif not failed_scopes:
+        utils.log_warning("IAM Identity Center is not enabled/configured in this account. Nothing to export.")
+
+    if users_data:
+        _export_users_to_excel(users_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No Identity Center users collected.")
-        return
 
-    _export_users_to_excel(users_data, account_id, account_name)
+    _report_and_exit_if_failed(account_name, resource_type, failed_scopes)
 
 
 def _run_combined_export(account_id, account_name):
     """Collect Identity Center users, groups, and permission sets; export combined workbook."""
-    instance_arn, identity_store_id = get_identity_center_instance()
-    if not instance_arn:
-        utils.log_error("Could not find IAM Identity Center instance. Exiting.")
-        return
+    failed_scopes = []
+    resource_type = "iam-identity-center"
 
-    utils.log_info("Collecting Identity Center users...")
-    users_data = collect_identity_center_users(identity_store_id, instance_arn)
+    try:
+        instance_arn, identity_store_id = get_identity_center_instance()
+    except Exception as e:
+        failed_scopes.append(("Identity Center Instance Discovery", str(e)))
+        instance_arn, identity_store_id = None, None
 
-    utils.log_info("Collecting Identity Center groups...")
-    groups_data = collect_identity_center_groups(identity_store_id)
+    users_data, groups_data, permission_sets_data = [], [], []
 
-    utils.log_info("Collecting permission sets...")
-    permission_sets_data = collect_permission_sets(instance_arn)
+    if instance_arn:
+        utils.log_info("Collecting Identity Center users...")
+        try:
+            users_data = collect_identity_center_users(identity_store_id, instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Users", str(e)))
 
-    if not users_data and not groups_data and not permission_sets_data:
+        utils.log_info("Collecting Identity Center groups...")
+        try:
+            groups_data = collect_identity_center_groups(identity_store_id)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Groups", str(e)))
+
+        utils.log_info("Collecting permission sets...")
+        try:
+            permission_sets_data = collect_permission_sets(instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Permission Sets", str(e)))
+    elif not failed_scopes:
+        utils.log_warning("IAM Identity Center is not enabled/configured in this account. Nothing to export.")
+
+    if users_data or groups_data or permission_sets_data:
+        _export_combined_to_excel(users_data, groups_data, permission_sets_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No Identity Center data collected.")
-        return
 
-    _export_combined_to_excel(users_data, groups_data, permission_sets_data, account_id, account_name)
+    _report_and_exit_if_failed(account_name, resource_type, failed_scopes)
 
 
 def _run_groups_export(account_id, account_name):
     """Collect Identity Center groups with detailed member info; export groups workbook."""
-    instance_arn, identity_store_id = get_identity_center_instance()
-    if not identity_store_id:
-        utils.log_error("Could not find IAM Identity Center instance. Exiting.")
-        return
+    failed_scopes = []
+    resource_type = "iam-identity-center-groups"
 
-    utils.log_info("Collecting Identity Center groups (detailed)...")
-    groups_data = collect_identity_center_groups_detailed(identity_store_id)
+    try:
+        _instance_arn, identity_store_id = get_identity_center_instance()
+    except Exception as e:
+        failed_scopes.append(("Identity Center Instance Discovery", str(e)))
+        identity_store_id = None
 
-    if not groups_data:
+    groups_data = []
+    if identity_store_id:
+        utils.log_info("Collecting Identity Center groups (detailed)...")
+        try:
+            groups_data = collect_identity_center_groups_detailed(identity_store_id)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Groups", str(e)))
+    elif not failed_scopes:
+        utils.log_warning("IAM Identity Center is not enabled/configured in this account. Nothing to export.")
+
+    if groups_data:
+        _export_groups_to_excel(groups_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No Identity Center groups collected.")
-        return
 
-    _export_groups_to_excel(groups_data, account_id, account_name)
+    _report_and_exit_if_failed(account_name, resource_type, failed_scopes)
 
 
 def _run_permission_sets_export(account_id, account_name):
     """Collect Identity Center permission sets; export permission sets workbook."""
-    instance_arn, identity_store_id = get_identity_center_instance()
-    if not instance_arn:
-        utils.log_error("Could not find IAM Identity Center instance. Exiting.")
-        return
+    failed_scopes = []
+    resource_type = "iam-identity-center-permission-sets"
 
-    utils.log_info("Collecting permission sets...")
-    permission_sets_data = collect_permission_sets(instance_arn)
+    try:
+        instance_arn, identity_store_id = get_identity_center_instance()
+    except Exception as e:
+        failed_scopes.append(("Identity Center Instance Discovery", str(e)))
+        instance_arn = None
 
-    if not permission_sets_data:
+    permission_sets_data = []
+    if instance_arn:
+        utils.log_info("Collecting permission sets...")
+        try:
+            permission_sets_data = collect_permission_sets(instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Permission Sets", str(e)))
+    elif not failed_scopes:
+        utils.log_warning("IAM Identity Center is not enabled/configured in this account. Nothing to export.")
+
+    if permission_sets_data:
+        _export_permission_sets_to_excel(permission_sets_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No permission sets collected.")
-        return
 
-    _export_permission_sets_to_excel(permission_sets_data, account_id, account_name)
+    _report_and_exit_if_failed(account_name, resource_type, failed_scopes)
 
 
 def _run_comprehensive_export(account_id, account_name):
     """Collect all Identity Center resources; export comprehensive workbook."""
-    instance_arn, identity_store_id = get_identity_center_instance()
-    if not instance_arn:
-        utils.log_error("Could not find IAM Identity Center instance. Exiting.")
-        return
+    failed_scopes = []
+    resource_type = "iam-identity-center-comprehensive"
 
-    utils.log_info("Collecting comprehensive Identity Center users...")
-    users_data = collect_comprehensive_users(identity_store_id, instance_arn)
+    try:
+        instance_arn, identity_store_id = get_identity_center_instance()
+    except Exception as e:
+        failed_scopes.append(("Identity Center Instance Discovery", str(e)))
+        instance_arn, identity_store_id = None, None
 
-    utils.log_info("Collecting comprehensive Identity Center groups...")
-    groups_data = collect_comprehensive_groups(identity_store_id, instance_arn)
+    users_data, groups_data, permission_sets_data = [], [], []
 
-    utils.log_info("Collecting comprehensive permission sets...")
-    permission_sets_data = collect_comprehensive_permission_sets(instance_arn)
+    if instance_arn:
+        utils.log_info("Collecting comprehensive Identity Center users...")
+        try:
+            users_data = collect_comprehensive_users(identity_store_id, instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Users", str(e)))
 
-    if not users_data and not groups_data and not permission_sets_data:
+        utils.log_info("Collecting comprehensive Identity Center groups...")
+        try:
+            groups_data = collect_comprehensive_groups(identity_store_id, instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Groups", str(e)))
+
+        utils.log_info("Collecting comprehensive permission sets...")
+        try:
+            permission_sets_data = collect_comprehensive_permission_sets(instance_arn)
+        except Exception as e:
+            failed_scopes.append(("Identity Center Permission Sets", str(e)))
+    elif not failed_scopes:
+        utils.log_warning("IAM Identity Center is not enabled/configured in this account. Nothing to export.")
+
+    if users_data or groups_data or permission_sets_data:
+        _export_comprehensive_to_excel(users_data, groups_data, permission_sets_data, account_id, account_name)
+    elif not failed_scopes:
         utils.log_warning("No Identity Center data collected.")
-        return
 
-    _export_comprehensive_to_excel(users_data, groups_data, permission_sets_data, account_id, account_name)
+    _report_and_exit_if_failed(account_name, resource_type, failed_scopes)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/kms_export.py
+++ b/scripts/kms_export.py
@@ -45,336 +45,442 @@ except ImportError:
 args = utils.parse_script_args("Export KMS keys and aliases to Excel")
 
 
+def _build_key_row(kms_client, key: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single KMS key.
+
+    Extracted so per-key processing can be wrapped in try/except by the
+    caller: a malformed or unusual key (e.g. a key type/manager combination
+    that omits a field another key type always sets) is logged and skipped
+    rather than discarding the whole region's results. Every field is read
+    with ``.get()`` and a safe default for the same reason.
+
+    Args:
+        kms_client: Boto3 KMS client for the region.
+        key: A single entry from list_keys' ``Keys``.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled key row.
+    """
+    key_id = key.get('KeyId', 'N/A')
+    key_arn = key.get('KeyArn', 'N/A')
+
+    metadata = kms_client.describe_key(KeyId=key_id)
+    key_metadata = metadata.get('KeyMetadata', {})
+
+    key_manager = key_metadata.get('KeyManager', 'N/A')
+    key_state = key_metadata.get('KeyState', 'N/A')
+    description = key_metadata.get('Description', 'N/A')
+    creation_date = key_metadata.get('CreationDate', '')
+    if creation_date:
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+    else:
+        creation_date = 'N/A'
+
+    enabled = key_metadata.get('Enabled', False)
+
+    key_spec = key_metadata.get('KeySpec', 'N/A')
+    key_usage = key_metadata.get('KeyUsage', 'N/A')
+
+    encryption_algorithms = key_metadata.get('EncryptionAlgorithms', [])
+    encryption_algorithms_str = ', '.join(encryption_algorithms) if encryption_algorithms else 'N/A'
+
+    multi_region = key_metadata.get('MultiRegion', False)
+    multi_region_config = 'N/A'
+    if multi_region:
+        multi_region_config = key_metadata.get('MultiRegionConfiguration', {}).get('MultiRegionKeyType', 'N/A')
+
+    origin = key_metadata.get('Origin', 'N/A')
+    custom_key_store_id = key_metadata.get('CustomKeyStoreId', 'N/A')
+    cloud_hsm_cluster_id = key_metadata.get('CloudHsmClusterId', 'N/A')
+
+    deletion_date = key_metadata.get('DeletionDate', '')
+    if deletion_date:
+        deletion_date = deletion_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(deletion_date, datetime.datetime) else str(deletion_date)
+    else:
+        deletion_date = 'N/A'
+
+    # Check rotation status (only for customer managed keys)
+    rotation_enabled = 'N/A'
+    if key_manager == 'CUSTOMER' and key_state == 'Enabled':
+        try:
+            rotation_status = kms_client.get_key_rotation_status(KeyId=key_id)
+            rotation_enabled = rotation_status.get('KeyRotationEnabled', False)
+        except Exception:
+            rotation_enabled = 'N/A'
+
+    return {
+        'Region': region,
+        'Key ID': key_id,
+        'Key State': key_state,
+        'Enabled': enabled,
+        'Description': description,
+        'Key Manager': key_manager,
+        'Key Spec': key_spec,
+        'Key Usage': key_usage,
+        'Encryption Algorithms': encryption_algorithms_str,
+        'Multi-Region': multi_region,
+        'Multi-Region Type': multi_region_config,
+        'Origin': origin,
+        'Rotation Enabled': rotation_enabled,
+        'Custom Key Store ID': custom_key_store_id,
+        'CloudHSM Cluster ID': cloud_hsm_cluster_id,
+        'Creation Date': creation_date,
+        'Deletion Date': deletion_date,
+        'Key ARN': key_arn
+    }
+
+
 def scan_kms_keys_in_region(region: str, account_id: str) -> list[dict[str, Any]]:
     """
     Scan KMS keys in a single region.
 
+    Not wrapped in a swallow-all try/except: a region-level API error (e.g.
+    throttling on list_keys) must propagate so the caller can record the
+    region as FAILED rather than collapsing it into an empty/successful
+    result -- silent data loss (see 07.16.2026 blast-radius audit). Per-key
+    errors are contained internally (logged and skipped) so one malformed
+    key does not sink the whole region's collection.
+
     Args:
         region: AWS region to scan
-        account_id: AWS account ID for filtering
+        account_id: AWS account ID (unused for filtering; kept for interface
+            compatibility with collect_kms_keys)
 
     Returns:
         list: List of dictionaries with KMS key information from this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
+    kms_client = utils.get_boto3_client('kms', region_name=region)
+
+    paginator = kms_client.get_paginator('list_keys')
+    all_keys: list[dict[str, Any]] = []
+    for page in paginator.paginate():
+        all_keys.extend(page.get('Keys', []))
+
+    total_keys = len(all_keys)
+    if total_keys:
+        utils.log_info(f"Found {total_keys} KMS keys in {region} to process")
+
     regional_keys = []
+    skipped = 0
+    for key in all_keys:
+        key_id = key.get('KeyId', 'Unknown')
+        try:
+            regional_keys.append(_build_key_row(kms_client, key, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping KMS key '{key_id}' in {region} due to a processing error", e)
+            continue
 
-    try:
-        kms_client = utils.get_boto3_client('kms', region_name=region)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_keys} KMS key(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining keys were still collected."
+        )
 
-        # Get KMS keys
-        paginator = kms_client.get_paginator('list_keys')
-        key_count = 0
-
-        for page in paginator.paginate():
-            keys = page.get('Keys', [])
-            key_count += len(keys)
-
-            for key in keys:
-                key_id = key.get('KeyId', '')
-                key_arn = key.get('KeyArn', '')
-
-                # Skip AWS managed keys if desired, but include for visibility
-                try:
-                    # Get key metadata
-                    metadata = kms_client.describe_key(KeyId=key_id)
-                    key_metadata = metadata.get('KeyMetadata', {})
-
-                    key_manager = key_metadata.get('KeyManager', '')
-
-                    # Get basic info
-                    key_state = key_metadata.get('KeyState', '')
-                    description = key_metadata.get('Description', '')
-                    creation_date = key_metadata.get('CreationDate', '')
-                    if creation_date:
-                        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
-
-                    # Enabled status
-                    enabled = key_metadata.get('Enabled', False)
-
-                    # Key spec and usage
-                    key_spec = key_metadata.get('KeySpec', 'N/A')
-                    key_usage = key_metadata.get('KeyUsage', 'N/A')
-
-                    # Encryption algorithms
-                    encryption_algorithms = key_metadata.get('EncryptionAlgorithms', [])
-                    encryption_algorithms_str = ', '.join(encryption_algorithms) if encryption_algorithms else 'N/A'
-
-                    # Multi-region key
-                    multi_region = key_metadata.get('MultiRegion', False)
-                    multi_region_config = 'N/A'
-                    if multi_region:
-                        multi_region_config = key_metadata.get('MultiRegionConfiguration', {}).get('MultiRegionKeyType', 'N/A')
-
-                    # Origin
-                    origin = key_metadata.get('Origin', 'N/A')
-
-                    # Custom key store ID
-                    custom_key_store_id = key_metadata.get('CustomKeyStoreId', 'N/A')
-
-                    # Cloud HSM cluster ID
-                    cloud_hsm_cluster_id = key_metadata.get('CloudHsmClusterId', 'N/A')
-
-                    # Deletion date
-                    deletion_date = key_metadata.get('DeletionDate', '')
-                    if deletion_date:
-                        deletion_date = deletion_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(deletion_date, datetime.datetime) else str(deletion_date)
-                    else:
-                        deletion_date = 'N/A'
-
-                    # Check rotation status (only for customer managed keys)
-                    rotation_enabled = 'N/A'
-                    if key_manager == 'CUSTOMER' and key_state == 'Enabled':
-                        try:
-                            rotation_status = kms_client.get_key_rotation_status(KeyId=key_id)
-                            rotation_enabled = rotation_status.get('KeyRotationEnabled', False)
-                        except Exception:
-                            rotation_enabled = 'N/A'
-
-                    regional_keys.append({
-                        'Region': region,
-                        'Key ID': key_id,
-                        'Key State': key_state,
-                        'Enabled': enabled,
-                        'Description': description,
-                        'Key Manager': key_manager,
-                        'Key Spec': key_spec,
-                        'Key Usage': key_usage,
-                        'Encryption Algorithms': encryption_algorithms_str,
-                        'Multi-Region': multi_region,
-                        'Multi-Region Type': multi_region_config,
-                        'Origin': origin,
-                        'Rotation Enabled': rotation_enabled,
-                        'Custom Key Store ID': custom_key_store_id,
-                        'CloudHSM Cluster ID': cloud_hsm_cluster_id,
-                        'Creation Date': creation_date,
-                        'Deletion Date': deletion_date,
-                        'Key ARN': key_arn
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get metadata for key {key_id} in {region}: {e}")
-
-        utils.log_info(f"Found {key_count} KMS keys in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for KMS keys", e)
-
+    utils.log_info(f"Found {len(regional_keys)} KMS keys in {region}")
     return regional_keys
 
 
-@utils.aws_error_handler("Collecting KMS keys", default_return=[])
-def collect_kms_keys(regions: list[str], account_id: str) -> list[dict[str, Any]]:
+def collect_kms_keys(
+    regions: list[str], account_id: str
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
     """
     Collect KMS key information from AWS regions using concurrent scanning.
+
+    Not wrapped in ``aws_error_handler``: swallowing here would return an
+    empty list indistinguishable from a genuinely empty account. Instead the
+    per-region collector is allowed to raise and ``failed_regions`` is
+    returned so the caller can surface a failed collection instead of
+    masking it as "no keys".
 
     Args:
         regions: List of AWS regions to scan
         account_id: AWS account ID for filtering
 
     Returns:
-        list: List of dictionaries with KMS key information
+        tuple: (list of KMS key dicts, list of (region, error_message) failures)
     """
     print("\n=== COLLECTING KMS KEYS ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning with account_id parameter
-    all_keys = []
-    for region_data in utils.scan_regions_concurrent(
+    def _scan(region: str) -> list[dict[str, Any]]:
+        return scan_kms_keys_in_region(region, account_id)
+
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=scan_kms_keys_in_region,
-        account_id=account_id
-    ):
+        scan_function=_scan,
+        collect_failures=True,
+    )
+
+    all_keys: list[dict[str, Any]] = []
+    for region_data in region_results:
         all_keys.extend(region_data)
 
     utils.log_success(f"Total KMS keys collected: {len(all_keys)}")
-    return all_keys
+    return all_keys, failed_regions
+
+
+def _build_alias_row(alias: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single KMS alias.
+
+    Extracted so per-alias processing can be wrapped in try/except by the
+    caller. Every field is read with ``.get()`` and a safe default.
+
+    Args:
+        alias: A single entry from list_aliases' ``Aliases``.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled alias row.
+    """
+    alias_name = alias.get('AliasName', 'N/A')
+    alias_arn = alias.get('AliasArn', 'N/A')
+    target_key_id = alias.get('TargetKeyId', 'N/A')
+
+    creation_date = alias.get('CreationDate', '')
+    if creation_date:
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+    else:
+        creation_date = 'N/A'
+
+    last_updated_date = alias.get('LastUpdatedDate', '')
+    if last_updated_date:
+        last_updated_date = last_updated_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_updated_date, datetime.datetime) else str(last_updated_date)
+    else:
+        last_updated_date = 'N/A'
+
+    return {
+        'Region': region,
+        'Alias Name': alias_name,
+        'Target Key ID': target_key_id,
+        'Creation Date': creation_date,
+        'Last Updated Date': last_updated_date,
+        'Alias ARN': alias_arn
+    }
 
 
 def scan_kms_aliases_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan KMS aliases in a single region.
 
+    Not wrapped in a swallow-all try/except; a region-level API error must
+    propagate so the caller can record the region as FAILED (see
+    scan_kms_keys_in_region for the full rationale). Per-alias errors are
+    contained internally (logged and skipped).
+
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with alias information from this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
+    kms_client = utils.get_boto3_client('kms', region_name=region)
+
+    paginator = kms_client.get_paginator('list_aliases')
+    all_aliases: list[dict[str, Any]] = []
+    for page in paginator.paginate():
+        all_aliases.extend(page.get('Aliases', []))
+
     regional_aliases = []
+    skipped = 0
+    for alias in all_aliases:
+        alias_name = alias.get('AliasName', 'Unknown')
+        try:
+            regional_aliases.append(_build_alias_row(alias, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping KMS alias '{alias_name}' in {region} due to a processing error", e)
+            continue
 
-    try:
-        kms_client = utils.get_boto3_client('kms', region_name=region)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(all_aliases)} KMS alias(es) in {region} were skipped due to "
+            "processing errors (see log above); the remaining aliases were still collected."
+        )
 
-        # Get aliases
-        paginator = kms_client.get_paginator('list_aliases')
-
-        for page in paginator.paginate():
-            aliases = page.get('Aliases', [])
-
-            for alias in aliases:
-                alias_name = alias.get('AliasName', '')
-                alias_arn = alias.get('AliasArn', '')
-                target_key_id = alias.get('TargetKeyId', 'N/A')
-
-                # Creation date
-                creation_date = alias.get('CreationDate', '')
-                if creation_date:
-                    creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
-
-                # Last updated date
-                last_updated_date = alias.get('LastUpdatedDate', '')
-                if last_updated_date:
-                    last_updated_date = last_updated_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_updated_date, datetime.datetime) else str(last_updated_date)
-
-                regional_aliases.append({
-                    'Region': region,
-                    'Alias Name': alias_name,
-                    'Target Key ID': target_key_id,
-                    'Creation Date': creation_date,
-                    'Last Updated Date': last_updated_date if last_updated_date else 'N/A',
-                    'Alias ARN': alias_arn
-                })
-
-        utils.log_info(f"Found {len(regional_aliases)} KMS aliases in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting aliases in region {region}", e)
-
+    utils.log_info(f"Found {len(regional_aliases)} KMS aliases in {region}")
     return regional_aliases
 
 
-@utils.aws_error_handler("Collecting KMS aliases", default_return=[])
-def collect_kms_aliases(regions: list[str]) -> list[dict[str, Any]]:
+def collect_kms_aliases(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
     """
     Collect KMS key alias information from AWS regions using concurrent scanning.
+
+    Not wrapped in ``aws_error_handler``; see collect_kms_keys for rationale.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with alias information
+        tuple: (list of alias dicts, list of (region, error_message) failures)
     """
     print("\n=== COLLECTING KMS ALIASES ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_aliases = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_kms_aliases_in_region,
-    ):
+        collect_failures=True,
+    )
+
+    all_aliases: list[dict[str, Any]] = []
+    for region_data in region_results:
         all_aliases.extend(region_data)
 
     utils.log_success(f"Total KMS aliases collected: {len(all_aliases)}")
-    return all_aliases
+    return all_aliases, failed_regions
+
+
+def _build_grant_row(grant: dict[str, Any], key_id: str, region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single KMS grant.
+
+    Extracted so per-grant processing can be wrapped in try/except by the
+    caller. Every field is read with ``.get()`` and a safe default.
+
+    Args:
+        grant: A single entry from list_grants' ``Grants``.
+        key_id: The KMS key ID the grant belongs to.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled grant row.
+    """
+    grant_id = grant.get('GrantId', 'N/A')
+    grant_name = grant.get('Name', 'N/A')
+    grantee_principal = grant.get('GranteePrincipal', 'N/A')
+
+    operations = grant.get('Operations', [])
+    operations_str = ', '.join(operations) if operations else 'N/A'
+
+    creation_date = grant.get('CreationDate', '')
+    if creation_date:
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+    else:
+        creation_date = 'N/A'
+
+    retiring_principal = grant.get('RetiringPrincipal', 'N/A')
+    grant_tokens = grant.get('GrantTokens', [])
+    grant_token_count = len(grant_tokens)
+
+    return {
+        'Region': region,
+        'Key ID': key_id,
+        'Grant ID': grant_id,
+        'Grant Name': grant_name,
+        'Grantee Principal': grantee_principal,
+        'Operations': operations_str,
+        'Retiring Principal': retiring_principal,
+        'Grant Token Count': grant_token_count,
+        'Creation Date': creation_date
+    }
 
 
 def scan_kms_grants_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan KMS grants in a single region.
 
+    The initial key listing is a region-level operation and is NOT wrapped in
+    a swallow-all try/except: it must propagate so the caller can record the
+    region as FAILED (see scan_kms_keys_in_region for the full rationale).
+
+    Grant lookups are performed per-key. A single key whose grants cannot be
+    listed (e.g. pending deletion, access denied for that specific key) is
+    logged and skipped -- that is genuine per-item enrichment scoped to one
+    key and must not sink the whole region's grant collection.
+
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with grant information from this region
+
+    Raises:
+        Exception: Any AWS/pagination error while listing keys for the region.
     """
+    kms_client = utils.get_boto3_client('kms', region_name=region)
+
+    key_paginator = kms_client.get_paginator('list_keys')
+    all_keys: list[dict[str, Any]] = []
+    for key_page in key_paginator.paginate():
+        all_keys.extend(key_page.get('Keys', []))
+
     regional_grants = []
+    skipped_keys = 0
+    for key in all_keys:
+        key_id = key.get('KeyId', 'Unknown')
+        try:
+            grant_paginator = kms_client.get_paginator('list_grants')
+            for grant_page in grant_paginator.paginate(KeyId=key_id):
+                for grant in grant_page.get('Grants', []):
+                    regional_grants.append(_build_grant_row(grant, key_id, region))
+        except Exception as e:
+            skipped_keys += 1
+            utils.log_warning(f"Could not list grants for KMS key '{key_id}' in {region} (skipping): {e}")
+            continue
 
-    try:
-        kms_client = utils.get_boto3_client('kms', region_name=region)
+    if skipped_keys:
+        utils.log_warning(
+            f"Grants could not be listed for {skipped_keys} of {len(all_keys)} KMS key(s) in "
+            f"{region}; grants for the remaining keys were still collected."
+        )
 
-        # Get all keys first
-        key_paginator = kms_client.get_paginator('list_keys')
-
-        for key_page in key_paginator.paginate():
-            keys = key_page.get('Keys', [])
-
-            for key in keys:
-                key_id = key.get('KeyId', '')
-
-                try:
-                    # Get grants for this key
-                    grant_paginator = kms_client.get_paginator('list_grants')
-
-                    for grant_page in grant_paginator.paginate(KeyId=key_id):
-                        grants = grant_page.get('Grants', [])
-
-                        for grant in grants:
-                            grant_id = grant.get('GrantId', '')
-                            grant_name = grant.get('Name', 'N/A')
-                            grantee_principal = grant.get('GranteePrincipal', '')
-
-                            # Operations
-                            operations = grant.get('Operations', [])
-                            operations_str = ', '.join(operations) if operations else 'N/A'
-
-                            # Constraints
-                            # Creation date
-                            creation_date = grant.get('CreationDate', '')
-                            if creation_date:
-                                creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
-
-                            # Retiring principal
-                            retiring_principal = grant.get('RetiringPrincipal', 'N/A')
-
-                            # Grant tokens
-                            grant_tokens = grant.get('GrantTokens', [])
-                            grant_token_count = len(grant_tokens)
-
-                            regional_grants.append({
-                                'Region': region,
-                                'Key ID': key_id,
-                                'Grant ID': grant_id,
-                                'Grant Name': grant_name,
-                                'Grantee Principal': grantee_principal,
-                                'Operations': operations_str,
-                                'Retiring Principal': retiring_principal,
-                                'Grant Token Count': grant_token_count,
-                                'Creation Date': creation_date
-                            })
-
-                except Exception:
-                    # Some keys may not have grants, which is normal
-                    pass
-
-        utils.log_info(f"Found {len(regional_grants)} KMS grants in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting grants in region {region}", e)
-
+    utils.log_info(f"Found {len(regional_grants)} KMS grants in {region}")
     return regional_grants
 
 
-@utils.aws_error_handler("Collecting KMS grants", default_return=[])
-def collect_kms_grants(regions: list[str]) -> list[dict[str, Any]]:
+def collect_kms_grants(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
     """
     Collect KMS grant information from AWS regions using concurrent scanning.
+
+    Not wrapped in ``aws_error_handler``; see collect_kms_keys for rationale.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with grant information
+        tuple: (list of grant dicts, list of (region, error_message) failures)
     """
     print("\n=== COLLECTING KMS GRANTS ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_grants = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_kms_grants_in_region,
-    ):
+        collect_failures=True,
+    )
+
+    all_grants: list[dict[str, Any]] = []
+    for region_data in region_results:
         all_grants.extend(region_data)
 
     utils.log_success(f"Total KMS grants collected: {len(all_grants)}")
-    return all_grants
+    return all_grants, failed_regions
 
 
 def export_kms_data(account_id: str, account_name: str):
     """
     Export KMS information to an Excel file.
+
+    All three collectors (keys, aliases, grants) now report failed regions
+    instead of silently swallowing them. A partial export (some sheets/rows
+    present) is still written when possible, but any failed scope is
+    recorded via a failure marker and the script exits non-zero -- a partial
+    result that looks complete is exactly the silent-data-loss failure mode
+    this guards against (see 07.16.2026 blast-radius audit).
 
     Args:
         account_id: The AWS account ID
@@ -390,59 +496,82 @@ def export_kms_data(account_id: str, account_name: str):
 
     # Dictionary to hold all DataFrames for export
     data_frames = {}
+    all_failed_regions: list[tuple[str, str]] = []
 
     # STEP 1: Collect KMS keys
-    keys = collect_kms_keys(regions, account_id)
+    keys, failed = collect_kms_keys(regions, account_id)
+    all_failed_regions.extend((f"{failed_region} (keys)", err) for failed_region, err in failed)
     if keys:
         data_frames['KMS Keys'] = pd.DataFrame(keys)
 
     # STEP 2: Collect aliases
-    aliases = collect_kms_aliases(regions)
+    aliases, failed = collect_kms_aliases(regions)
+    all_failed_regions.extend((f"{failed_region} (aliases)", err) for failed_region, err in failed)
     if aliases:
         data_frames['Key Aliases'] = pd.DataFrame(aliases)
 
     # STEP 3: Collect grants
-    grants = collect_kms_grants(regions)
+    grants, failed = collect_kms_grants(regions)
+    all_failed_regions.extend((f"{failed_region} (grants)", err) for failed_region, err in failed)
     if grants:
         data_frames['Key Grants'] = pd.DataFrame(grants)
 
     # Check if we have any data
     if not data_frames:
-        utils.log_warning("No KMS data was collected. Nothing to export.")
-        print("\nNo KMS keys found in the selected region(s).")
-        return
-
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'kms',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("KMS data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
+        if not all_failed_regions:
+            # Genuinely empty account: every region/sub-resource succeeded
+            # and returned nothing. No file is exported.
+            utils.log_warning("No KMS data was collected. Nothing to export.")
+            print("\nNo KMS keys found in the selected region(s).")
         else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+            utils.log_error(
+                "No KMS data was collected and one or more regions failed to collect."
+            )
+    else:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'kms',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting. Partial export
+        # (some sheets missing/incomplete due to failed_regions above) is
+        # written deliberately -- whatever succeeded is still useful data.
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("KMS data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+
+    # If ANY region/sub-resource failed, make it loud: write a marker and
+    # exit non-zero, even if some data was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if all_failed_regions:
+        utils.report_collection_failures(account_name, "kms", all_failed_regions)
+        print(
+            "\nERROR: KMS export completed with failures — data is incomplete. "
+            "See the *-kms-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/lambda_export.py
+++ b/scripts/lambda_export.py
@@ -51,16 +51,132 @@ except ImportError:
 args = utils.parse_script_args("Export Lambda functions to Excel")
 
 
-@utils.aws_error_handler("Collecting Lambda functions for region", default_return=[])
+def _build_function_row(func: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single Lambda function.
+
+    Extracted so the per-function processing can be wrapped in try/except by
+    the caller: a malformed function entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        func: A single Functions entry from list_functions.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled function row.
+    """
+    function_name = func.get('FunctionName', 'Unknown')
+
+    # Basic information
+    function_arn = func.get('FunctionArn', 'N/A')
+    runtime = func.get('Runtime', 'N/A')
+    handler = func.get('Handler', 'N/A')
+    code_size = func.get('CodeSize', 0)
+    description = func.get('Description', 'N/A')
+    timeout = func.get('Timeout', 0)
+    memory_size = func.get('MemorySize', 0)
+    last_modified = func.get('LastModified', 'N/A')
+    version = func.get('Version', '$LATEST')
+
+    # Role
+    role = func.get('Role', 'N/A')
+
+    # VPC configuration
+    vpc_config = func.get('VpcConfig', {}) or {}
+    vpc_id = vpc_config.get('VpcId', 'N/A')
+    subnet_ids = vpc_config.get('SubnetIds', [])
+    security_group_ids = vpc_config.get('SecurityGroupIds', [])
+    subnet_count = len(subnet_ids)
+    sg_count = len(security_group_ids)
+
+    # Environment variables (count only for security)
+    env_vars = (func.get('Environment', {}) or {}).get('Variables', {}) or {}
+    env_var_count = len(env_vars)
+
+    # Layers
+    layers = func.get('Layers', []) or []
+    layer_count = len(layers)
+    layer_arns = [layer.get('Arn', '') for layer in layers]
+    layers_str = ', '.join(layer_arns) if layer_arns else 'N/A'
+
+    # Dead letter config
+    dead_letter_config = func.get('DeadLetterConfig', {}) or {}
+    dlq_arn = dead_letter_config.get('TargetArn', 'N/A')
+
+    # Tracing config
+    tracing_config = func.get('TracingConfig', {}) or {}
+    tracing_mode = tracing_config.get('Mode', 'PassThrough')
+
+    # Architecture
+    architectures = func.get('Architectures', ['x86_64']) or ['x86_64']
+    architecture = ', '.join(architectures)
+
+    # Package type
+    package_type = func.get('PackageType', 'Zip')
+
+    # Ephemeral storage
+    ephemeral_storage = func.get('EphemeralStorage', {}) or {}
+    ephemeral_storage_size = ephemeral_storage.get('Size', 512)
+
+    # Code repository
+    code_sha256 = func.get('CodeSha256', 'N/A')
+
+    # State and state reason
+    state = func.get('State', 'N/A')
+    state_reason = func.get('StateReason', 'N/A')
+
+    return {
+        'Region': region,
+        'Function Name': function_name,
+        'Runtime': runtime,
+        'Handler': handler,
+        'State': state,
+        'Memory (MB)': memory_size,
+        'Timeout (s)': timeout,
+        'Code Size (bytes)': code_size,
+        'Package Type': package_type,
+        'Architecture': architecture,
+        'Ephemeral Storage (MB)': ephemeral_storage_size,
+        'VPC ID': vpc_id,
+        'Subnet Count': subnet_count,
+        'Security Group Count': sg_count,
+        'Environment Variables': env_var_count,
+        'Layer Count': layer_count,
+        'Layers': layers_str,
+        'DLQ ARN': dlq_arn,
+        'Tracing Mode': tracing_mode,
+        'Role ARN': role,
+        'Version': version,
+        'Last Modified': last_modified,
+        'Code SHA256': code_sha256,
+        'State Reason': state_reason,
+        'Description': description,
+        'Function ARN': function_arn
+    }
+
+
 def collect_lambda_functions_for_region(region: str) -> list[dict[str, Any]]:
     """
     Collect Lambda function information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that the caller cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so ``scan_regions_concurrent`` can record
+    the region as FAILED rather than empty. Per-function errors are
+    contained internally (logged and skipped) via ``_build_function_row``.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with Lambda function information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     functions = []
 
@@ -75,122 +191,61 @@ def collect_lambda_functions_for_region(region: str) -> list[dict[str, Any]]:
     # Get Lambda functions
     paginator = lambda_client.get_paginator('list_functions')
     function_count = 0
+    skipped = 0
 
     for page in paginator.paginate():
         page_functions = page.get('Functions', [])
         function_count += len(page_functions)
 
+        # Process each function. One malformed function must not sink the
+        # region, so each is built inside try/except; failures are logged
+        # and skipped.
         for func in page_functions:
-            function_name = func.get('FunctionName', '')
+            function_name = func.get('FunctionName', 'Unknown')
             print(f"  Processing function: {function_name}")
 
-            # Basic information
-            function_arn = func.get('FunctionArn', '')
-            runtime = func.get('Runtime', 'N/A')
-            handler = func.get('Handler', 'N/A')
-            code_size = func.get('CodeSize', 0)
-            description = func.get('Description', 'N/A')
-            timeout = func.get('Timeout', 0)
-            memory_size = func.get('MemorySize', 0)
-            last_modified = func.get('LastModified', 'N/A')
-            version = func.get('Version', '$LATEST')
+            try:
+                functions.append(_build_function_row(func, region))
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping Lambda function '{function_name}' in {region} due to a processing error", e
+                )
+                continue
 
-            # Role
-            role = func.get('Role', 'N/A')
-
-            # VPC configuration
-            vpc_config = func.get('VpcConfig', {})
-            vpc_id = vpc_config.get('VpcId', 'N/A')
-            subnet_ids = vpc_config.get('SubnetIds', [])
-            security_group_ids = vpc_config.get('SecurityGroupIds', [])
-            subnet_count = len(subnet_ids)
-            sg_count = len(security_group_ids)
-
-            # Environment variables (count only for security)
-            env_vars = func.get('Environment', {}).get('Variables', {})
-            env_var_count = len(env_vars)
-
-            # Layers
-            layers = func.get('Layers', [])
-            layer_count = len(layers)
-            layer_arns = [layer.get('Arn', '') for layer in layers]
-            layers_str = ', '.join(layer_arns) if layer_arns else 'N/A'
-
-            # Dead letter config
-            dead_letter_config = func.get('DeadLetterConfig', {})
-            dlq_arn = dead_letter_config.get('TargetArn', 'N/A')
-
-            # Tracing config
-            tracing_config = func.get('TracingConfig', {})
-            tracing_mode = tracing_config.get('Mode', 'PassThrough')
-
-            # Architecture
-            architectures = func.get('Architectures', ['x86_64'])
-            architecture = ', '.join(architectures)
-
-            # Package type
-            package_type = func.get('PackageType', 'Zip')
-
-            # Ephemeral storage
-            ephemeral_storage = func.get('EphemeralStorage', {})
-            ephemeral_storage_size = ephemeral_storage.get('Size', 512)
-
-            # Code repository
-            code_sha256 = func.get('CodeSha256', 'N/A')
-
-            # State and state reason
-            state = func.get('State', 'N/A')
-            state_reason = func.get('StateReason', 'N/A')
-
-            functions.append({
-                'Region': region,
-                'Function Name': function_name,
-                'Runtime': runtime,
-                'Handler': handler,
-                'State': state,
-                'Memory (MB)': memory_size,
-                'Timeout (s)': timeout,
-                'Code Size (bytes)': code_size,
-                'Package Type': package_type,
-                'Architecture': architecture,
-                'Ephemeral Storage (MB)': ephemeral_storage_size,
-                'VPC ID': vpc_id,
-                'Subnet Count': subnet_count,
-                'Security Group Count': sg_count,
-                'Environment Variables': env_var_count,
-                'Layer Count': layer_count,
-                'Layers': layers_str,
-                'DLQ ARN': dlq_arn,
-                'Tracing Mode': tracing_mode,
-                'Role ARN': role,
-                'Version': version,
-                'Last Modified': last_modified,
-                'Code SHA256': code_sha256,
-                'State Reason': state_reason,
-                'Description': description,
-                'Function ARN': function_arn
-            })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {function_count} Lambda function(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining functions were still collected."
+        )
 
     print(f"  Found {function_count} Lambda functions")
     return functions
 
-def collect_lambda_functions(regions: list[str]) -> list[dict[str, Any]]:
+def collect_lambda_functions(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
     """
     Collect Lambda function information from AWS regions (Phase 4B: concurrent).
+
+    Uses ``collect_failures=True``: ``collect_lambda_functions_for_region``
+    raises on a region-level failure so that failure is recorded and
+    surfaced by the caller, never silently collapsed into "no functions"
+    (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with Lambda function information
+        tuple: (functions, failed_regions) where failed_regions is a list of
+            (region, error_message) tuples for regions whose scan raised.
     """
     print("\n=== COLLECTING LAMBDA FUNCTIONS ===")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_lambda_functions_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -199,7 +254,7 @@ def collect_lambda_functions(regions: list[str]) -> list[dict[str, Any]]:
         all_functions.extend(funcs)
 
     utils.log_success(f"Total Lambda functions collected: {len(all_functions)}")
-    return all_functions
+    return all_functions, failed_regions
 
 
 @utils.aws_error_handler("Collecting event source mappings for region", default_return=[])
@@ -420,64 +475,80 @@ def export_lambda_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Lambda functions
-    functions = collect_lambda_functions(regions)
+    # STEP 1: Collect Lambda functions (scope collection — region failures
+    # must propagate as failed_regions, never collapse into "empty").
+    functions, failed_regions = collect_lambda_functions(regions)
     if functions:
         data_frames['Lambda Functions'] = pd.DataFrame(functions)
 
-    # STEP 2: Collect event source mappings
+    # STEP 2: Collect event source mappings (enrichment — degrades
+    # gracefully; a region-level failure here does not fail the whole export).
     mappings = collect_event_source_mappings(regions)
     if mappings:
         data_frames['Event Source Mappings'] = pd.DataFrame(mappings)
 
-    # STEP 3: Collect concurrency configurations
+    # STEP 3: Collect concurrency configurations (enrichment — degrades
+    # gracefully; a region-level failure here does not fail the whole export).
     concurrency_configs = collect_concurrency_configs(regions)
     if concurrency_configs:
         data_frames['Concurrency Configurations'] = pd.DataFrame(concurrency_configs)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see .collab/audit/07.16.2026-...).
+    if data_frames:
+        # STEP 4: Prepare and sanitize all DataFrames for export
+        for sheet_name in data_frames:
+            # Apply sanitization to functions sheet (may contain env vars in description)
+            if sheet_name == 'Lambda Functions':
+                data_frames[sheet_name] = utils.sanitize_for_export(
+                    utils.prepare_dataframe_for_export(data_frames[sheet_name])
+                )
+            else:
+                data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'lambda',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Lambda data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Lambda function data was collected. Nothing to export.")
         print("\nNo Lambda functions found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare and sanitize all DataFrames for export
-    for sheet_name in data_frames:
-        # Apply sanitization to functions sheet (may contain env vars in description)
-        if sheet_name == 'Lambda Functions':
-            data_frames[sheet_name] = utils.sanitize_for_export(
-                utils.prepare_dataframe_for_export(data_frames[sheet_name])
-            )
-        else:
-            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'lambda',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Lambda data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the Lambda Functions scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data (from this
+    # scope or the enrichment sheets) was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'lambda', failed_regions)
+        print(
+            "\nERROR: Lambda export completed with failures — data is incomplete. "
+            "See the *-lambda-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -25,7 +25,6 @@ import datetime
 import json
 import re
 import sys
-import threading
 import time
 from pathlib import Path
 
@@ -608,47 +607,6 @@ def export_to_excel(data, account_name, region_filter=None):
             utils.log_error("CSV export also failed", csv_error)
             return None
 
-def write_failure_marker(account_name, failed_regions):
-    """
-    Write a ``*-rds-instances-FAILED-<date>.txt`` marker into the output
-    directory recording which regions failed to collect.
-
-    This is the visible signal a downstream consumer needs to tell a *failed*
-    RDS pull apart from a genuinely empty account. Without it, a region that
-    errors is indistinguishable from a region with no databases.
-
-    Args:
-        account_name (str): AWS account name (for the filename).
-        failed_regions (list): List of (region, error_message) tuples.
-
-    Returns:
-        str or None: Path to the marker file, or None if it could not be written.
-    """
-    try:
-        today = datetime.datetime.now().strftime("%m.%d.%Y")
-        marker_name = f"{account_name}-rds-instances-FAILED-{today}.txt"
-        marker_path = utils.get_output_filepath(marker_name)
-        lines = [
-            "RDS EXPORT FAILED FOR ONE OR MORE REGIONS",
-            f"Account: {account_name}",
-            f"Timestamp: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
-            "",
-            "The regions below raised an error during collection. Their RDS data is "
-            "MISSING or INCOMPLETE in any exported spreadsheet. Do NOT treat a missing "
-            "RDS file/rows for these regions as 'no databases' — re-run the export.",
-            "",
-        ]
-        for region, error in failed_regions:
-            lines.append(f"  - {region}: {error}")
-        marker_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        utils.log_error(f"Wrote RDS failure marker: {marker_path}")
-        return str(marker_path)
-    except Exception as e:
-        # Never let marker-writing itself mask the underlying failure.
-        utils.log_error("Could not write RDS failure marker", e)
-        return None
-
-
 def main():
     """
     Main function to coordinate the AWS RDS instance export process.
@@ -675,33 +633,24 @@ def main():
 
     utils.log_info(f"Collecting RDS instance data across {len(regions)} AWS region(s)...")
 
-    # Track regions whose collection raised. A failed region must never be
-    # collapsed into "empty" — that is the silent-data-loss bug (07.15.2026
-    # audit). The concurrent scanner runs scan_region_rds across threads, so the
-    # shared list is guarded by a lock.
-    failed_regions = []
-    failed_lock = threading.Lock()
-
-    # Define region scan function for concurrent execution (Phase 4B)
+    # Define region scan function for concurrent execution (Phase 4B). It lets
+    # get_rds_instances raise on a region-level failure so the scanner records
+    # that region as FAILED — a failed region must never be collapsed into
+    # "empty," which is the silent-data-loss bug (07.15.2026 audit / Issue #231).
     def scan_region_rds(region):
         utils.log_info(f"Searching for RDS instances in AWS region: {region}")
-        try:
-            region_instances = get_rds_instances(region)
-        except Exception as e:
-            # Record the failure so main() can surface it; return no rows for
-            # this region (partial data from other regions is still exported).
-            with failed_lock:
-                failed_regions.append((region, str(e)))
-            utils.log_error(f"RDS collection FAILED for region {region}", e)
-            return []
+        region_instances = get_rds_instances(region)
         utils.log_info(f"Found {len(region_instances)} RDS instances in {region}")
         return region_instances
 
-    # Use concurrent region scanning (with automatic fallback to sequential on errors)
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning (with automatic fallback to sequential on
+    # errors). collect_failures=True returns the regions that raised so a failed
+    # collection is distinguishable from a genuinely empty account.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_region_rds,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -728,12 +677,7 @@ def main():
     # if some data was exported. A partial export that looks complete is exactly
     # the failure mode this guards against.
     if failed_regions:
-        region_names = ", ".join(r for r, _ in failed_regions)
-        utils.log_error(
-            f"RDS collection failed for {len(failed_regions)} of {len(regions)} region(s): "
-            f"{region_names}. Exported data is INCOMPLETE."
-        )
-        write_failure_marker(account_name, failed_regions)
+        utils.report_collection_failures(account_name, "rds-instances", failed_regions)
         print(
             "\nERROR: RDS export completed with failures — data is incomplete. "
             "See the *-rds-instances-FAILED-*.txt marker in the output directory."

--- a/scripts/route_tables_export.py
+++ b/scripts/route_tables_export.py
@@ -199,92 +199,144 @@ def get_route_destination(route):
     else:
         return "N/A"
 
+def _build_route_entries(route_table, region):
+    """
+    Build the export row(s) for a single route table.
+
+    Extracted so per-route-table processing can be wrapped in try/except by the
+    caller: a malformed route table must not discard the whole region's results.
+    Every required field is read with ``.get()`` and a safe default so a missing
+    field yields 'N/A', not a KeyError that would sink the entire region.
+
+    Args:
+        route_table (dict): A single RouteTables entry from describe_route_tables.
+        region (str): AWS region name.
+
+    Returns:
+        list: One or more route entry dictionaries for this route table.
+    """
+    rt_id = route_table.get('RouteTableId', 'N/A')
+    vpc_id = route_table.get('VpcId', 'N/A')
+
+    # Get routes
+    routes = route_table.get('Routes', [])
+
+    # Get subnet associations
+    subnet_associations = []
+    for association in route_table.get('Associations', []):
+        if 'SubnetId' in association:
+            subnet_associations.append(association['SubnetId'])
+
+    # Get edge associations (like gateways)
+    edge_associations = []
+    for association in route_table.get('Associations', []):
+        if 'GatewayId' in association:
+            edge_associations.append(association['GatewayId'])
+
+    # Get tags
+    tags = format_tags(route_table.get('Tags', []))
+
+    entries = []
+
+    # For each route, create a separate entry
+    if routes:
+        for route in routes:
+            route_destination = get_route_destination(route)
+            route_target = get_route_target(route)
+            route_state = route.get('State', 'N/A')
+            route_type = get_route_type(route)
+            propagated = route.get('Origin', '') == 'EnableVgwRoutePropagation'
+
+            # Create entry for this route
+            entries.append({
+                'Region': region,
+                'Route Table ID': rt_id,
+                'VPC ID': vpc_id,
+                'Route Destination': route_destination,
+                'Target': route_target,
+                'Route State': route_state,
+                'Route Type': route_type,
+                'Propagated': 'Yes' if propagated else 'No',
+                'Subnet Association': '; '.join(subnet_associations) if subnet_associations else 'N/A',
+                'Edge Association': '; '.join(edge_associations) if edge_associations else 'N/A',
+                'Tags': tags
+            })
+    else:
+        # Create an entry for the route table with no routes
+        entries.append({
+            'Region': region,
+            'Route Table ID': rt_id,
+            'VPC ID': vpc_id,
+            'Route Destination': 'N/A',
+            'Target': 'N/A',
+            'Route State': 'N/A',
+            'Route Type': 'N/A',
+            'Propagated': 'N/A',
+            'Subnet Association': '; '.join(subnet_associations) if subnet_associations else 'N/A',
+            'Edge Association': '; '.join(edge_associations) if edge_associations else 'N/A',
+            'Tags': tags
+        })
+
+    return entries
+
+
 def get_route_tables(region):
     """
     Get all route tables in a specific region.
+
+    Not wrapped in a broad try/except: a swallowed error here would return an
+    empty list that the caller cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written, or a zero-row sheet).
+    Region-level failures are allowed to raise so the caller can record the
+    region as *failed* rather than *empty*. Per-route-table errors are
+    contained internally (logged and skipped).
 
     Args:
         region (str): AWS region name
 
     Returns:
         list: List of dictionaries with route table information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     route_table_data = []
 
-    try:
-        # Create EC2 client for the region
-        ec2_client = utils.get_boto3_client('ec2', region_name=region)
+    # Create EC2 client for the region
+    ec2_client = utils.get_boto3_client('ec2', region_name=region)
 
-        # Get all route tables in the region
-        paginator = ec2_client.get_paginator('describe_route_tables')
-        for page in paginator.paginate():
-            for route_table in page['RouteTables']:
-                rt_id = route_table['RouteTableId']
-                vpc_id = route_table.get('VpcId', 'N/A')
+    # Get all route tables in the region
+    paginator = ec2_client.get_paginator('describe_route_tables')
+    all_route_tables = []
+    for page in paginator.paginate():
+        all_route_tables.extend(page['RouteTables'])
 
-                # Get routes
-                routes = route_table.get('Routes', [])
+    total_route_tables = len(all_route_tables)
+    if total_route_tables > 0:
+        utils.log_info(f"Found {total_route_tables} route tables in {region} to process")
 
-                # Get subnet associations
-                subnet_associations = []
-                for association in route_table.get('Associations', []):
-                    if 'SubnetId' in association:
-                        subnet_associations.append(association['SubnetId'])
+    # Process each route table. One malformed route table must not sink the
+    # region, so each is built inside try/except; failures are logged and skipped.
+    skipped = 0
+    for route_table in all_route_tables:
+        rt_id = route_table.get('RouteTableId', 'Unknown')
+        try:
+            entries = _build_route_entries(route_table, region)
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping route table '{rt_id}' in {region} due to a processing error", e
+            )
+            continue
 
-                # Get edge associations (like gateways)
-                edge_associations = []
-                for association in route_table.get('Associations', []):
-                    if 'GatewayId' in association:
-                        edge_associations.append(association['GatewayId'])
+        route_table_data.extend(entries)
 
-                # Get tags
-                tags = format_tags(route_table.get('Tags', []))
-
-                # For each route, create a separate entry
-                if routes:
-                    for route in routes:
-                        route_destination = get_route_destination(route)
-                        route_target = get_route_target(route)
-                        route_state = route.get('State', 'N/A')
-                        route_type = get_route_type(route)
-                        propagated = route.get('Origin', '') == 'EnableVgwRoutePropagation'
-
-                        # Create entry for this route
-                        route_entry = {
-                            'Region': region,
-                            'Route Table ID': rt_id,
-                            'VPC ID': vpc_id,
-                            'Route Destination': route_destination,
-                            'Target': route_target,
-                            'Route State': route_state,
-                            'Route Type': route_type,
-                            'Propagated': 'Yes' if propagated else 'No',
-                            'Subnet Association': '; '.join(subnet_associations) if subnet_associations else 'N/A',
-                            'Edge Association': '; '.join(edge_associations) if edge_associations else 'N/A',
-                            'Tags': tags
-                        }
-
-                        route_table_data.append(route_entry)
-                else:
-                    # Create an entry for the route table with no routes
-                    route_entry = {
-                        'Region': region,
-                        'Route Table ID': rt_id,
-                        'VPC ID': vpc_id,
-                        'Route Destination': 'N/A',
-                        'Target': 'N/A',
-                        'Route State': 'N/A',
-                        'Route Type': 'N/A',
-                        'Propagated': 'N/A',
-                        'Subnet Association': '; '.join(subnet_associations) if subnet_associations else 'N/A',
-                        'Edge Association': '; '.join(edge_associations) if edge_associations else 'N/A',
-                        'Tags': tags
-                    }
-
-                    route_table_data.append(route_entry)
-
-    except Exception as e:
-        print(f"Error getting route tables in region {region}: {e}")
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_route_tables} route table(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining route tables were still collected."
+        )
 
     return route_table_data
 
@@ -298,7 +350,9 @@ def export_route_tables(account_name, regions, region_suffix=""):
         region_suffix (str): Suffix to add to filename (e.g., "-us-east-1")
 
     Returns:
-        str: Path to the exported file
+        tuple: (output_path or None, failed_regions) where failed_regions is a
+            list of (region, error_str) tuples for regions whose collection
+            raised. Partial data is exported even when some regions failed.
     """
     import pandas as pd
 
@@ -314,42 +368,47 @@ def export_route_tables(account_name, regions, region_suffix=""):
     # Collect route table data from all regions (Phase 4B: concurrent)
     all_route_tables = []
 
-    # Define region scan function
+    # Define region scan function. It lets get_route_tables raise on a
+    # region-level failure so the scanner records that region as FAILED — a
+    # failed region must never be collapsed into "empty," which is the
+    # silent-data-loss bug (07.15.2026 audit / Issue #231).
     def scan_region_route_tables(region):
         print(f"  Collecting route tables from {region}...")
         region_route_tables = get_route_tables(region)
         print(f"  Found {len(region_route_tables)} route entries in {region}")
         return region_route_tables
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning (with automatic fallback to sequential on
+    # errors). collect_failures=True returns the regions that raised so a
+    # failed collection is distinguishable from a genuinely empty account.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions_to_process,
         scan_function=scan_region_route_tables,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
     for route_tables in region_results:
         all_route_tables.extend(route_tables)
 
-    # Check if we found any route tables
-    if not all_route_tables:
+    # Export whatever succeeded — a partial export is required, not optional.
+    output_path = None
+    if all_route_tables:
+        # Create DataFrame
+        df = pd.DataFrame(all_route_tables)
+
+        # Generate file name
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        filename = utils.create_export_filename(account_name, "route-tables", region_suffix, current_date)
+
+        # Export to Excel
+        output_path = utils.save_dataframe_to_excel(df, filename)
+    elif not failed_regions:
+        # Genuinely empty: every region succeeded and returned nothing.
         print("No route tables found.")
-        return None
 
-    # Create DataFrame
-    df = pd.DataFrame(all_route_tables)
-
-    # Generate file name
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    filename = utils.create_export_filename(account_name, "route-tables", region_suffix, current_date)
-
-    # Export to Excel
-    output_path = utils.save_dataframe_to_excel(df, filename)
-
-    if output_path:
-        return output_path
-    return None
+    return output_path, failed_regions
 
 def main():
     """
@@ -369,14 +428,25 @@ def main():
         # Detect partition and set partition-aware example regions
         regions = utils.prompt_region_selection()
 
-        output_file = export_route_tables(account_name, regions)
+        output_file, failed_regions = export_route_tables(account_name, regions)
 
         # Report results
         if output_file:
             print("\nExport completed successfully!")
             print(f"Output file: {output_file}")
-        else:
+        elif not failed_regions:
             print("\nExport failed or no data was found.")
+
+        # If ANY region failed, make it loud: write a marker and exit non-zero,
+        # even if some data was exported. A partial export that looks complete
+        # is exactly the failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, "route-tables", failed_regions)
+            print(
+                "\nERROR: Route Tables export completed with failures — data is incomplete. "
+                "See the *-route-tables-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\nOperation cancelled by user.")

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -78,7 +78,7 @@ def get_bucket_region(bucket_name):
 
     # Get the bucket's location
     response = s3_client.get_bucket_location(Bucket=bucket_name)
-    location = response['LocationConstraint']
+    location = response.get('LocationConstraint')
 
     # In AWS, handle the location constraint differently
     if location is None:
@@ -192,7 +192,10 @@ def get_latest_storage_lens_data(account_id):
 
         # Get list of all buckets (global S3 call)
         s3_client = utils.get_boto3_client('s3')
-        all_bucket_names = [bucket['Name'] for bucket in s3_client.list_buckets()['Buckets']]
+        all_bucket_names = [
+            bucket.get('Name') for bucket in s3_client.list_buckets().get('Buckets', [])
+            if bucket.get('Name')
+        ]
 
         # Define function to collect metrics for a single region (Phase 4B)
         def collect_cloudwatch_metrics_for_region(region):
@@ -309,23 +312,106 @@ def _load_s3_standard_rate() -> float:
         return 0.023
 
 
-@utils.aws_error_handler("Collecting S3 buckets", default_return=[])
+def _build_bucket_row(bucket, region, storage_lens_data, standard_rate, account_id):
+    """
+    Build the export row for a single S3 bucket.
+
+    Extracted so the per-bucket processing can be wrapped in try/except by the
+    caller: a malformed bucket entry (e.g. missing an expected field, or a
+    per-field lookup that degrades but still raises unexpectedly) is logged and
+    skipped rather than discarding every other bucket already collected. Required
+    fields are read with ``.get()`` and a safe default for the same reason.
+
+    Args:
+        bucket (dict): A single Buckets entry from list_buckets().
+        region (str): AWS region the bucket resolved to.
+        storage_lens_data (dict): Bucket-name-keyed Storage Lens/CloudWatch metrics.
+        standard_rate (float): S3 Standard storage rate ($/GB/month).
+        account_id (str): AWS account ID (for owner formatting).
+
+    Returns:
+        dict: The assembled bucket row.
+    """
+    bucket_name = bucket.get('Name', 'Unknown')
+    creation_date = bucket.get('CreationDate', 'N/A')
+
+    # Initialize size and object count
+    size_bytes = 0
+    object_count = 0
+
+    # Try to get info from Storage Lens if available
+    if bucket_name in storage_lens_data:
+        size_bytes = storage_lens_data[bucket_name].get('size_bytes', 0)
+        object_count = storage_lens_data[bucket_name].get('object_count', 0)
+        size_source = "Storage Lens/CloudWatch"
+    else:
+        # Fall back to counting objects directly
+        object_count = get_bucket_object_count(bucket_name, region)
+        size_source = "Not Available"
+
+    # Convert size to MB
+    size_mb = convert_to_mb(size_bytes)
+
+    # Get owner information
+    owner_id = utils.get_account_name_formatted(account_id)
+
+    # Estimate monthly storage cost (Standard tier only)
+    if size_source != "Not Available" and size_mb > 0:
+        monthly_cost = round(size_mb / 1024 * standard_rate, 4)
+        cost_note = 'Standard storage estimate only'
+    elif size_source != "Not Available":
+        monthly_cost = 0.0
+        cost_note = 'Standard storage estimate only'
+    else:
+        monthly_cost = 'N/A'
+        cost_note = 'Size data unavailable'
+
+    return {
+        'Bucket Name': bucket_name,
+        'Region': region,
+        'Creation Date': creation_date,
+        'Object Count': object_count,
+        'Size (MB)': size_mb,
+        'Size Source': size_source,
+        'Owner': owner_id,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
 def get_s3_buckets_info(use_storage_lens=False, target_region=None):
     """
-    Collect information about S3 buckets across AWS regions or a specific AWS region
+    Collect information about S3 buckets across AWS regions or a specific AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return an
+    empty list that ``main()`` cannot distinguish from a genuinely empty account,
+    producing silent data loss (no file written). Top-level failures (e.g. a
+    throttled ``list_buckets`` call) are allowed to raise so the caller sees a
+    real failure rather than "zero buckets." Per-bucket errors are contained
+    internally: they are logged, the bucket is skipped, and it is reported back
+    to the caller via the ``failed_buckets`` return value instead of aborting the
+    whole collection.
 
     Args:
         use_storage_lens (bool): Whether to try using Storage Lens for size metrics
         target_region (str): Specific AWS region to target or None for all AWS regions
 
     Returns:
-        list: List of dictionaries containing bucket information
+        tuple: (buckets_info, failed_buckets)
+            buckets_info (list): List of dictionaries containing bucket information.
+            failed_buckets (list): List of (bucket_name, error_message) tuples for
+                buckets that raised while being processed.
+
+    Raises:
+        Exception: Any AWS API error not scoped to a single bucket (e.g. listing
+            buckets, client creation) propagates to the caller.
     """
     # Initialize global S3 client to list all buckets
     s3_client = utils.get_boto3_client('s3')
     standard_rate = _load_s3_standard_rate()
 
     all_buckets_info = []
+    failed_buckets = []
     storage_lens_data = {}
 
     # Get account ID
@@ -334,19 +420,22 @@ def get_s3_buckets_info(use_storage_lens=False, target_region=None):
     # Validate target region if specified
     if target_region and not utils.is_aws_region(target_region):
         utils.log_error(f"Invalid AWS region: {target_region}")
-        return []
+        return [], []
 
     # Try to get Storage Lens data if requested
     if use_storage_lens:
         storage_lens_data = get_latest_storage_lens_data(account_id)
 
-    # Get the list of all buckets
+    # Get the list of all buckets. Not guarded here — a failure must propagate
+    # (see docstring) rather than be swallowed into an empty result.
     response = s3_client.list_buckets()
 
     # Filter the buckets based on the target AWS region
     buckets_to_process = []
-    for bucket in response['Buckets']:
-        bucket_name = bucket['Name']
+    for bucket in response.get('Buckets', []):
+        bucket_name = bucket.get('Name')
+        if not bucket_name:
+            continue
 
         # Get the bucket's region if we need to filter
         if target_region:
@@ -366,64 +455,38 @@ def get_s3_buckets_info(use_storage_lens=False, target_region=None):
           (f" in AWS region {target_region}" if target_region else " across all AWS regions") +
           ". Gathering details for each bucket...")
 
-    # Process each bucket
+    # Process each bucket. One malformed bucket must not discard every other
+    # bucket already collected, so each is built inside try/except; failures
+    # are logged, skipped, and tracked in failed_buckets.
+    skipped = 0
     for i, bucket in enumerate(buckets_to_process, 1):
-        bucket_name = bucket['Name']
-        creation_date = bucket['CreationDate']
+        bucket_name = bucket.get('Name', 'Unknown')
 
-        progress = (i / total_buckets) * 100
+        progress = (i / total_buckets) * 100 if total_buckets > 0 else 0
         utils.log_info(f"[{progress:.1f}%] Processing bucket {i}/{total_buckets}: {bucket_name}")
 
         # Get the bucket's region if we haven't already
         region = target_region or get_bucket_region(bucket_name)
 
-        # Initialize size and object count
-        size_bytes = 0
-        object_count = 0
-
-        # Try to get info from Storage Lens if available
-        if bucket_name in storage_lens_data:
-            size_bytes = storage_lens_data[bucket_name]['size_bytes']
-            object_count = storage_lens_data[bucket_name]['object_count']
-            size_source = "Storage Lens/CloudWatch"
-        else:
-            # Fall back to counting objects directly
-            object_count = get_bucket_object_count(bucket_name, region)
-            size_source = "Not Available"
-
-        # Convert size to MB
-        size_mb = convert_to_mb(size_bytes)
-
-        # Get owner information
-        owner_id = utils.get_account_name_formatted(account_id)
-
-        # Estimate monthly storage cost (Standard tier only)
-        if size_source != "Not Available" and size_mb > 0:
-            monthly_cost = round(size_mb / 1024 * standard_rate, 4)
-            cost_note = 'Standard storage estimate only'
-        elif size_source != "Not Available":
-            monthly_cost = 0.0
-            cost_note = 'Standard storage estimate only'
-        else:
-            monthly_cost = 'N/A'
-            cost_note = 'Size data unavailable'
-
-        # Add bucket info to our list
-        bucket_info = {
-            'Bucket Name': bucket_name,
-            'Region': region,
-            'Creation Date': creation_date,
-            'Object Count': object_count,
-            'Size (MB)': size_mb,
-            'Size Source': size_source,
-            'Owner': owner_id,
-            'Monthly Cost (On-Demand)': monthly_cost,
-            'Cost Note': cost_note,
-        }
+        try:
+            bucket_info = _build_bucket_row(
+                bucket, region, storage_lens_data, standard_rate, account_id
+            )
+        except Exception as e:
+            skipped += 1
+            failed_buckets.append((bucket_name, str(e)))
+            utils.log_error(f"Skipping S3 bucket '{bucket_name}' due to a processing error", e)
+            continue
 
         all_buckets_info.append(bucket_info)
 
-    return all_buckets_info
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_buckets} S3 bucket(s) were skipped due to "
+            "processing errors (see log above); the remaining buckets were still collected."
+        )
+
+    return all_buckets_info, failed_buckets
 
 def export_to_excel(buckets_info, account_name, target_region=None):
     """
@@ -681,28 +744,45 @@ def main():
     utils.log_info("This may take some time depending on the number of buckets...")
 
     # Get information about S3 buckets in AWS
-    buckets_info = get_s3_buckets_info(use_storage_lens=use_storage_lens, target_region=target_region)
+    buckets_info, failed_buckets = get_s3_buckets_info(
+        use_storage_lens=use_storage_lens, target_region=target_region
+    )
 
-    # Check if we found any buckets
-    if not buckets_info:
+    # Check if we found any buckets. A genuinely empty account (no failures,
+    # no buckets) still gets the original no-file warning. A failed collection
+    # is handled below even if buckets_info is empty or partial — partial data
+    # is exported first, then the failure is surfaced loudly.
+    if not buckets_info and not failed_buckets:
         utils.log_warning("No S3 buckets found in AWS regions or unable to retrieve bucket information.")
         return
 
-    utils.log_success(f"Found {len(buckets_info)} S3 buckets" +
-          (f" in AWS region {target_region}." if target_region else " across all AWS regions."))
+    if buckets_info:
+        utils.log_success(f"Found {len(buckets_info)} S3 buckets" +
+              (f" in AWS region {target_region}." if target_region else " across all AWS regions."))
 
-    # Export the data to the selected format
-    if args.format == 'xlsx':
-        output_file = export_to_excel(buckets_info, account_name, target_region)
-    else:
-        output_file = export_to_csv(buckets_info, account_name, target_region)
+        # Export the data to the selected format
+        if args.format == 'xlsx':
+            output_file = export_to_excel(buckets_info, account_name, target_region)
+        else:
+            output_file = export_to_csv(buckets_info, account_name, target_region)
 
-    if output_file:
-        utils.log_info("Export contains data from AWS region(s)")
-        utils.log_info(f"Total S3 buckets exported: {len(buckets_info)}")
-        print("\nScript execution completed successfully.")
-    else:
-        utils.log_error("Failed to export data. Please check the logs.")
+        if output_file:
+            utils.log_info("Export contains data from AWS region(s)")
+            utils.log_info(f"Total S3 buckets exported: {len(buckets_info)}")
+            print("\nScript execution completed successfully.")
+        else:
+            utils.log_error("Failed to export data. Please check the logs.")
+
+    # If ANY bucket failed to process, make it loud: write a marker and exit
+    # non-zero, even if some data was exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed_buckets:
+        utils.report_collection_failures(account_name, "s3-buckets", failed_buckets)
+        print(
+            "\nERROR: S3 export completed with failures — data is incomplete. "
+            "See the *-s3-buckets-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 if __name__ == "__main__":
     try:

--- a/scripts/security_groups_export.py
+++ b/scripts/security_groups_export.py
@@ -229,16 +229,313 @@ def format_security_group_reference(sg_ref, protocol, from_port, to_port, is_inb
         return f"{protocol}:{port_range} → {sg_identifier}"
 
 
-@utils.aws_error_handler("Collecting security group rules", default_return=[])
+def _build_sg_rule_rows(sg, region, vpc_map, sg_resource_map, rules_map):
+    """
+    Build all export rows (inbound, outbound, and the no-rules placeholder) for
+    a single security group.
+
+    Extracted so the per-security-group processing in ``get_security_group_rules``
+    can be wrapped in try/except by the caller: a malformed security group must
+    not discard the whole region's results. Every required field is read with
+    ``.get()`` and a safe default for the same reason.
+
+    Args:
+        sg (dict): A single SecurityGroups entry from describe_security_groups.
+        region (str): AWS region name.
+        vpc_map (dict): {vpc_id: display_name} lookup.
+        sg_resource_map (dict): {sg_id: [resource_strings]} lookup.
+        rules_map (dict): {sg_id: [rule dicts]} lookup from describe_security_group_rules.
+
+    Returns:
+        list: The assembled row dict(s) for this security group.
+    """
+    rows = []
+
+    sg_id = sg.get('GroupId', 'N/A')
+    sg_name = sg.get('GroupName', 'Unnamed')
+
+    vpc_id = sg.get('VpcId', '')
+    vpc_name = vpc_map.get(vpc_id, vpc_id) if vpc_id else "No VPC (EC2-Classic)"
+
+    resources = sg_resource_map.get(sg_id, [])
+    resources_str = '; '.join(resources) if resources else 'None'
+
+    # Get description
+    description = sg.get('Description', '')
+
+    # Get owner information
+    owner_id = sg.get('OwnerId', 'N/A')
+    owner_formatted = utils.get_account_name_formatted(owner_id)
+
+    # Process inbound rules (IpPermissions)
+    for permission in sg.get('IpPermissions', []):
+        protocol = permission.get('IpProtocol', 'All')
+        from_port = permission.get('FromPort', None)
+        to_port = permission.get('ToPort', None)
+
+        # Process IPv4 ranges
+        for ip_range in permission.get('IpRanges', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        rule.get('CidrIpv4', '') == ip_range.get('CidrIp', '') and
+                        not rule.get('IsEgress', True)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = ip_range.get('Description', '')
+            rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=True)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Inbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'CIDR': ip_range.get('CidrIp', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+        # Process IPv6 ranges
+        for ip_range in permission.get('Ipv6Ranges', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        rule.get('CidrIpv6', '') == ip_range.get('CidrIpv6', '') and
+                        not rule.get('IsEgress', True)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = ip_range.get('Description', '')
+            rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=True)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Inbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'CIDR': ip_range.get('CidrIpv6', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+        # Process security group references
+        for sg_ref in permission.get('UserIdGroupPairs', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            ref_group_id = sg_ref.get('GroupId', '')
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    referenced_group = rule.get('ReferencedGroupInfo', {}).get('GroupId', '')
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        referenced_group == ref_group_id and
+                        not rule.get('IsEgress', True)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = sg_ref.get('Description', '')
+            rule_text = format_security_group_reference(sg_ref, protocol, from_port, to_port, is_inbound=True)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Inbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'Referenced SG': sg_ref.get('GroupId', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+    # Process outbound rules (IpPermissionsEgress)
+    for permission in sg.get('IpPermissionsEgress', []):
+        protocol = permission.get('IpProtocol', 'All')
+        from_port = permission.get('FromPort', None)
+        to_port = permission.get('ToPort', None)
+
+        # Process IPv4 ranges
+        for ip_range in permission.get('IpRanges', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        rule.get('CidrIpv4', '') == ip_range.get('CidrIp', '') and
+                        rule.get('IsEgress', False)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = ip_range.get('Description', '')
+            rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=False)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Outbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'CIDR': ip_range.get('CidrIp', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+        # Process IPv6 ranges
+        for ip_range in permission.get('Ipv6Ranges', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        rule.get('CidrIpv6', '') == ip_range.get('CidrIpv6', '') and
+                        rule.get('IsEgress', False)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = ip_range.get('Description', '')
+            rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=False)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Outbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'CIDR': ip_range.get('CidrIpv6', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+        # Process security group references
+        for sg_ref in permission.get('UserIdGroupPairs', []):
+            # Find matching rule in the rules map
+            rule_id = sg_id  # Default to using the security group ID
+            ref_group_id = sg_ref.get('GroupId', '')
+            if sg_id in rules_map:
+                for rule in rules_map[sg_id]:
+                    referenced_group = rule.get('ReferencedGroupInfo', {}).get('GroupId', '')
+                    if (rule.get('IpProtocol') == protocol and
+                        rule.get('FromPort', None) == from_port and
+                        rule.get('ToPort', None) == to_port and
+                        referenced_group == ref_group_id and
+                        rule.get('IsEgress', False)):
+                        rule_id = rule.get('SecurityGroupRuleId', sg_id)
+                        break
+
+            rule_desc = sg_ref.get('Description', '')
+            rule_text = format_security_group_reference(sg_ref, protocol, from_port, to_port, is_inbound=False)
+
+            rows.append({
+                'Rule ID': rule_id,
+                'SG Name': sg_name,
+                'SG ID': sg_id,
+                'VPC': vpc_name,
+                'SG Description': description,
+                'Direction': 'Outbound',
+                'Rule': rule_text,
+                'Rule Description': rule_desc,
+                'Protocol': protocol if protocol != '-1' else 'All',
+                'From Port': from_port if from_port is not None else 'All',
+                'To Port': to_port if to_port is not None else 'All',
+                'Referenced SG': sg_ref.get('GroupId', ''),
+                'Owner ID': owner_formatted,
+                'Used By': resources_str,
+                'Region': region
+            })
+
+    # If no rules found, add a placeholder entry
+    if not sg.get('IpPermissions', []) and not sg.get('IpPermissionsEgress', []):
+        rows.append({
+            'Rule ID': sg_id,
+            'SG Name': sg_name,
+            'SG ID': sg_id,
+            'VPC': vpc_name,
+            'SG Description': description,
+            'Direction': 'N/A',
+            'Rule': 'No rules defined',
+            'Rule Description': '',
+            'Protocol': 'N/A',
+            'From Port': 'N/A',
+            'To Port': 'N/A',
+            'CIDR': '',
+            'Owner ID': owner_formatted,
+            'Used By': resources_str,
+            'Region': region
+        })
+
+    return rows
+
+
 def get_security_group_rules(region):
     """
     Get all security groups and their rules from a specific AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return an
+    empty list that ``main()`` cannot distinguish from a genuinely empty region,
+    producing silent data loss (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    Region-level failures are allowed to raise so the caller can record the
+    region as *failed* rather than *empty*. Per-security-group errors are
+    contained internally (logged and skipped).
 
     Args:
         region: AWS region name
 
     Returns:
         list: List of dictionaries with security group rule information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it as
+            a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
         utils.log_error(f"Invalid AWS region: {region}")
@@ -277,271 +574,32 @@ def get_security_group_rules(region):
     if total_sgs > 0:
         utils.log_info(f"Found {total_sgs} security groups in {region} to process")
 
+    # Process each security group. One malformed SG must not sink the region, so
+    # each is built inside try/except; failures are logged and skipped.
+    skipped = 0
     for sg_index, sg in enumerate(security_groups, 1):
-        sg_id = sg['GroupId']
+        sg_id = sg.get('GroupId', 'N/A')
         sg_name = sg.get('GroupName', 'Unnamed')
         progress = (sg_index / total_sgs) * 100 if total_sgs > 0 else 0
 
         utils.log_info(f"[{progress:.1f}%] Processing security group {sg_index}/{total_sgs}: {sg_id} ({sg_name})")
 
-        vpc_id = sg.get('VpcId', '')
-        vpc_name = vpc_map.get(vpc_id, vpc_id) if vpc_id else "No VPC (EC2-Classic)"
+        try:
+            sg_rows = _build_sg_rule_rows(sg, region, vpc_map, sg_resource_map, rules_map)
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping security group '{sg_id}' in {region} due to a processing error", e
+            )
+            continue
 
-        resources = sg_resource_map.get(sg_id, [])
-        resources_str = '; '.join(resources) if resources else 'None'
+        security_group_rules.extend(sg_rows)
 
-        # Get description
-        description = sg.get('Description', '')
-
-        # Get owner information
-        owner_id = sg.get('OwnerId', 'N/A')
-        owner_formatted = utils.get_account_name_formatted(owner_id)
-
-        # Process inbound rules (IpPermissions)
-        for permission in sg.get('IpPermissions', []):
-            protocol = permission.get('IpProtocol', 'All')
-            from_port = permission.get('FromPort', None)
-            to_port = permission.get('ToPort', None)
-
-            # Process IPv4 ranges
-            for ip_range in permission.get('IpRanges', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            rule.get('CidrIpv4', '') == ip_range.get('CidrIp', '') and
-                            not rule.get('IsEgress', True)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = ip_range.get('Description', '')
-                rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=True)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Inbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'CIDR': ip_range.get('CidrIp', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-            # Process IPv6 ranges
-            for ip_range in permission.get('Ipv6Ranges', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            rule.get('CidrIpv6', '') == ip_range.get('CidrIpv6', '') and
-                            not rule.get('IsEgress', True)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = ip_range.get('Description', '')
-                rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=True)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Inbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'CIDR': ip_range.get('CidrIpv6', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-            # Process security group references
-            for sg_ref in permission.get('UserIdGroupPairs', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                ref_group_id = sg_ref.get('GroupId', '')
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        referenced_group = rule.get('ReferencedGroupInfo', {}).get('GroupId', '')
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            referenced_group == ref_group_id and
-                            not rule.get('IsEgress', True)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = sg_ref.get('Description', '')
-                rule_text = format_security_group_reference(sg_ref, protocol, from_port, to_port, is_inbound=True)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Inbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'Referenced SG': sg_ref.get('GroupId', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-        # Process outbound rules (IpPermissionsEgress)
-        for permission in sg.get('IpPermissionsEgress', []):
-            protocol = permission.get('IpProtocol', 'All')
-            from_port = permission.get('FromPort', None)
-            to_port = permission.get('ToPort', None)
-
-            # Process IPv4 ranges
-            for ip_range in permission.get('IpRanges', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            rule.get('CidrIpv4', '') == ip_range.get('CidrIp', '') and
-                            rule.get('IsEgress', False)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = ip_range.get('Description', '')
-                rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=False)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Outbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'CIDR': ip_range.get('CidrIp', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-            # Process IPv6 ranges
-            for ip_range in permission.get('Ipv6Ranges', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            rule.get('CidrIpv6', '') == ip_range.get('CidrIpv6', '') and
-                            rule.get('IsEgress', False)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = ip_range.get('Description', '')
-                rule_text = format_ip_range(ip_range, protocol, from_port, to_port, is_inbound=False)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Outbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'CIDR': ip_range.get('CidrIpv6', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-            # Process security group references
-            for sg_ref in permission.get('UserIdGroupPairs', []):
-                # Find matching rule in the rules map
-                rule_id = sg_id  # Default to using the security group ID
-                ref_group_id = sg_ref.get('GroupId', '')
-                if sg_id in rules_map:
-                    for rule in rules_map[sg_id]:
-                        referenced_group = rule.get('ReferencedGroupInfo', {}).get('GroupId', '')
-                        if (rule.get('IpProtocol') == protocol and
-                            rule.get('FromPort', None) == from_port and
-                            rule.get('ToPort', None) == to_port and
-                            referenced_group == ref_group_id and
-                            rule.get('IsEgress', False)):
-                            rule_id = rule.get('SecurityGroupRuleId', sg_id)
-                            break
-
-                rule_desc = sg_ref.get('Description', '')
-                rule_text = format_security_group_reference(sg_ref, protocol, from_port, to_port, is_inbound=False)
-
-                security_group_rules.append({
-                    'Rule ID': rule_id,
-                    'SG Name': sg_name,
-                    'SG ID': sg_id,
-                    'VPC': vpc_name,
-                    'SG Description': description,
-                    'Direction': 'Outbound',
-                    'Rule': rule_text,
-                    'Rule Description': rule_desc,
-                    'Protocol': protocol if protocol != '-1' else 'All',
-                    'From Port': from_port if from_port is not None else 'All',
-                    'To Port': to_port if to_port is not None else 'All',
-                    'Referenced SG': sg_ref.get('GroupId', ''),
-                    'Owner ID': owner_formatted,
-                    'Used By': resources_str,
-                    'Region': region
-                })
-
-        # If no rules found, add a placeholder entry
-        if not sg.get('IpPermissions', []) and not sg.get('IpPermissionsEgress', []):
-            security_group_rules.append({
-                'Rule ID': sg_id,
-                'SG Name': sg_name,
-                'SG ID': sg_id,
-                'VPC': vpc_name,
-                'SG Description': description,
-                'Direction': 'N/A',
-                'Rule': 'No rules defined',
-                'Rule Description': '',
-                'Protocol': 'N/A',
-                'From Port': 'N/A',
-                'To Port': 'N/A',
-                'CIDR': '',
-                'Owner ID': owner_formatted,
-                'Used By': resources_str,
-                'Region': region
-            })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_sgs} security group(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining security groups were still collected."
+        )
 
     return security_group_rules
 
@@ -627,12 +685,15 @@ def main():
             utils.log_info(f"Found {len(region_rules)} security group rules in {region}")
             return region_rules
 
-        # Use concurrent region scanning
-        region_results = utils.scan_regions_concurrent(
+        # Use concurrent region scanning (with automatic fallback to sequential on
+        # errors). collect_failures=True returns the regions that raised so a
+        # failed collection is distinguishable from a genuinely empty account.
+        region_results, failed_regions = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_security_groups,
             max_workers=2,
-            show_progress=True
+            show_progress=True,
+            collect_failures=True,
         )
 
         # Flatten results
@@ -644,6 +705,7 @@ def main():
         total_rules = len(all_security_group_rules)
         utils.log_success(f"Total security group rules found across all AWS regions: {total_rules}")
 
+        # Export whatever succeeded, then decide on exit status based on failures.
         if total_rules > 0:
             # Export to Excel
             utils.log_info("Exporting security group rules to Excel format...")
@@ -656,8 +718,20 @@ def main():
             else:
                 utils.log_error("Failed to export data. Please check the logs.")
                 sys.exit(1)
-        else:
+        elif not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
             utils.log_warning("No security group rules found. Nothing to export.")
+
+        # If ANY region failed, make it loud: write a marker and exit non-zero,
+        # even if some data was exported. A partial export that looks complete is
+        # exactly the failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, "sg-rules", failed_regions)
+            print(
+                "\nERROR: Security Groups export completed with failures — data is incomplete. "
+                "See the *-sg-rules-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nScript interrupted by user. Exiting...")

--- a/scripts/vpc_data_export.py
+++ b/scripts/vpc_data_export.py
@@ -47,16 +47,153 @@ except ImportError:
         sys.exit(1)
 args = utils.parse_script_args("Export VPCs, subnets, IGWs, NAT gateways, and Elastic IPs to Excel")
 
-@utils.aws_error_handler("Collecting VPC data for region", default_return=[])
+def _build_vpc_row(vpc, region, ec2_client):
+    """
+    Build the export row for a single VPC.
+
+    Extracted so per-VPC processing can be wrapped in try/except by the
+    caller: a malformed VPC entry (missing/unexpected fields) is logged and
+    skipped rather than discarding the whole region's results. Required
+    fields are read with ``.get()`` and a safe default; a missing VpcId
+    raises so the caller's per-item guard treats the entry as malformed.
+
+    Args:
+        vpc (dict): A single Vpcs entry from describe_vpcs.
+        region (str): AWS region name.
+        ec2_client: Boto3 EC2 client for the region.
+
+    Returns:
+        dict: The assembled VPC row.
+    """
+    vpc_id = vpc.get('VpcId')
+    if not vpc_id:
+        raise ValueError("VPC entry missing VpcId")
+
+    # Extract VPC name from tags
+    vpc_name = None
+    vpc_tags = {}
+    for tag in vpc.get('Tags', []):
+        key = tag.get('Key')
+        if key is None:
+            continue
+        if key == 'Name':
+            vpc_name = tag.get('Value')
+        vpc_tags[key] = tag.get('Value')
+
+    # Get primary IPv4 CIDR
+    ipv4_cidr = vpc.get('CidrBlock', 'N/A')
+
+    # Get all IPv4 CIDR blocks (including secondary)
+    ipv4_cidrs = [ipv4_cidr]
+    for assoc in vpc.get('CidrBlockAssociationSet', []):
+        cidr = assoc.get('CidrBlock')
+        if cidr and cidr not in ipv4_cidrs:
+            ipv4_cidrs.append(cidr)
+    ipv4_cidr_combined = ', '.join(ipv4_cidrs)
+
+    # Get IPv6 CIDR if available
+    ipv6_cidr = 'N/A'
+    ipv6_cidrs = []
+    for ipv6_assoc in vpc.get('Ipv6CidrBlockAssociationSet', []):
+        if ipv6_assoc.get('Ipv6CidrBlockState', {}).get('State') == 'associated':
+            cidr = ipv6_assoc.get('Ipv6CidrBlock', 'N/A')
+            if cidr != 'N/A':
+                ipv6_cidrs.append(cidr)
+    if ipv6_cidrs:
+        ipv6_cidr = ', '.join(ipv6_cidrs)
+
+    # Get DHCP Options Set
+    dhcp_options_id = vpc.get('DhcpOptionsId', 'N/A')
+
+    # Check if default VPC
+    is_default = vpc.get('IsDefault', False)
+    default_vpc = 'Yes' if is_default else 'No'
+
+    # Get Main Route Table
+    main_route_table = 'N/A'
+    try:
+        rt_response = ec2_client.describe_route_tables(
+            Filters=[
+                {'Name': 'vpc-id', 'Values': [vpc_id]},
+                {'Name': 'association.main', 'Values': ['true']}
+            ]
+        )
+        route_tables = rt_response.get('RouteTables', [])
+        if route_tables:
+            main_route_table = route_tables[0].get('RouteTableId', 'N/A')
+    except Exception as e:
+        utils.log_warning(f"Error getting main route table for VPC {vpc_id}: {e}")
+
+    # Get Main NACL
+    main_nacl = 'N/A'
+    try:
+        nacl_response = ec2_client.describe_network_acls(
+            Filters=[
+                {'Name': 'vpc-id', 'Values': [vpc_id]},
+                {'Name': 'default', 'Values': ['true']}
+            ]
+        )
+        nacls = nacl_response.get('NetworkAcls', [])
+        if nacls:
+            main_nacl = nacls[0].get('NetworkAclId', 'N/A')
+    except Exception as e:
+        utils.log_warning(f"Error getting main NACL for VPC {vpc_id}: {e}")
+
+    # Get Block Public Access settings (VPC-level BPA for IPv4)
+    # Note: This is a newer feature and might not be available in all regions/accounts
+    block_public_access = 'Off'  # Default to 'Off' to match AWS console behavior
+    try:
+        bpa_response = ec2_client.describe_vpc_block_public_access_options(
+            VpcIds=[vpc_id]
+        )
+        bpa_options = bpa_response.get('VpcBlockPublicAccessOptions')
+        if bpa_options:
+            bpa_option = bpa_options[0]
+            internet_gateway_block_mode = bpa_option.get('InternetGatewayBlockMode', 'off')
+            # Capitalize first letter to match AWS console display
+            block_public_access = internet_gateway_block_mode.capitalize() if internet_gateway_block_mode else 'Off'
+    except Exception:
+        # If API call fails entirely (feature not available in region), show 'Off'
+        # This matches AWS console behavior where the feature just shows as disabled
+        block_public_access = 'Off'
+
+    # Format tags as string for better readability
+    tags_str = ', '.join([f"{k}={v}" for k, v in vpc_tags.items()]) if vpc_tags else 'N/A'
+
+    return {
+        'Region': region,
+        'VPC Name': vpc_name if vpc_name else 'N/A',
+        'VPC ID': vpc_id,
+        'Block Public Access': block_public_access,
+        'IPv4 CIDR': ipv4_cidr_combined,
+        'IPv6 CIDR': ipv6_cidr,
+        'DHCP Option Set': dhcp_options_id,
+        'Main Route Table': main_route_table,
+        'Main NACL': main_nacl,
+        'Default VPC': default_vpc,
+        'Tags': tags_str
+    }
+
+
 def collect_vpc_data_for_region(region):
     """
     Collect comprehensive VPC information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that the caller cannot distinguish from a genuinely empty
+    region, producing silent data loss. Region-level failures (paginator
+    errors, client creation, etc.) are allowed to raise so
+    ``scan_regions_concurrent(collect_failures=True)`` can record the region
+    as FAILED. Per-VPC errors are contained internally (logged and skipped).
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with VPC information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     vpc_data = []
 
@@ -78,114 +215,23 @@ def collect_vpc_data_for_region(region):
 
     utils.log_info(f"Found {len(vpcs)} VPCs in AWS region {region}")
 
-    # Process each VPC
+    # Process each VPC. One malformed VPC must not sink the region, so each
+    # is built inside try/except; failures are logged and skipped.
+    skipped = 0
     for vpc in vpcs:
-        vpc_id = vpc['VpcId']
-
-        # Extract VPC name from tags
-        vpc_name = None
-        vpc_tags = {}
-        if 'Tags' in vpc:
-            for tag in vpc['Tags']:
-                if tag['Key'] == 'Name':
-                    vpc_name = tag['Value']
-                vpc_tags[tag['Key']] = tag['Value']
-
-        # Get primary IPv4 CIDR
-        ipv4_cidr = vpc.get('CidrBlock', 'N/A')
-
-        # Get all IPv4 CIDR blocks (including secondary)
-        ipv4_cidrs = [ipv4_cidr]
-        if 'CidrBlockAssociationSet' in vpc:
-            for assoc in vpc['CidrBlockAssociationSet']:
-                cidr = assoc.get('CidrBlock')
-                if cidr and cidr not in ipv4_cidrs:
-                    ipv4_cidrs.append(cidr)
-        ipv4_cidr_combined = ', '.join(ipv4_cidrs)
-
-        # Get IPv6 CIDR if available
-        ipv6_cidr = 'N/A'
-        ipv6_cidrs = []
-        if 'Ipv6CidrBlockAssociationSet' in vpc:
-            for ipv6_assoc in vpc['Ipv6CidrBlockAssociationSet']:
-                if ipv6_assoc.get('Ipv6CidrBlockState', {}).get('State') == 'associated':
-                    cidr = ipv6_assoc.get('Ipv6CidrBlock', 'N/A')
-                    if cidr != 'N/A':
-                        ipv6_cidrs.append(cidr)
-        if ipv6_cidrs:
-            ipv6_cidr = ', '.join(ipv6_cidrs)
-
-        # Get DHCP Options Set
-        dhcp_options_id = vpc.get('DhcpOptionsId', 'N/A')
-
-        # Check if default VPC
-        is_default = vpc.get('IsDefault', False)
-        default_vpc = 'Yes' if is_default else 'No'
-
-        # Get Main Route Table
-        main_route_table = 'N/A'
+        vpc_id_for_log = vpc.get('VpcId', 'Unknown')
         try:
-            rt_response = ec2_client.describe_route_tables(
-                Filters=[
-                    {'Name': 'vpc-id', 'Values': [vpc_id]},
-                    {'Name': 'association.main', 'Values': ['true']}
-                ]
-            )
-            route_tables = rt_response.get('RouteTables', [])
-            if route_tables:
-                main_route_table = route_tables[0]['RouteTableId']
+            vpc_data.append(_build_vpc_row(vpc, region, ec2_client))
         except Exception as e:
-            utils.log_warning(f"Error getting main route table for VPC {vpc_id}: {e}")
+            skipped += 1
+            utils.log_error(f"Skipping VPC '{vpc_id_for_log}' in {region} due to a processing error", e)
+            continue
 
-        # Get Main NACL
-        main_nacl = 'N/A'
-        try:
-            nacl_response = ec2_client.describe_network_acls(
-                Filters=[
-                    {'Name': 'vpc-id', 'Values': [vpc_id]},
-                    {'Name': 'default', 'Values': ['true']}
-                ]
-            )
-            nacls = nacl_response.get('NetworkAcls', [])
-            if nacls:
-                main_nacl = nacls[0]['NetworkAclId']
-        except Exception as e:
-            utils.log_warning(f"Error getting main NACL for VPC {vpc_id}: {e}")
-
-        # Get Block Public Access settings (VPC-level BPA for IPv4)
-        # Note: This is a newer feature and might not be available in all regions/accounts
-        block_public_access = 'Off'  # Default to 'Off' to match AWS console behavior
-        try:
-            bpa_response = ec2_client.describe_vpc_block_public_access_options(
-                VpcIds=[vpc_id]
-            )
-            if 'VpcBlockPublicAccessOptions' in bpa_response and bpa_response['VpcBlockPublicAccessOptions']:
-                bpa_option = bpa_response['VpcBlockPublicAccessOptions'][0]
-                internet_gateway_block_mode = bpa_option.get('InternetGatewayBlockMode', 'off')
-                # Capitalize first letter to match AWS console display
-                block_public_access = internet_gateway_block_mode.capitalize() if internet_gateway_block_mode else 'Off'
-        except Exception:
-            # If API call fails entirely (feature not available in region), show 'Off'
-            # This matches AWS console behavior where the feature just shows as disabled
-            block_public_access = 'Off'
-
-        # Format tags as string for better readability
-        tags_str = ', '.join([f"{k}={v}" for k, v in vpc_tags.items()]) if vpc_tags else 'N/A'
-
-        # Append VPC data
-        vpc_data.append({
-            'Region': region,
-            'VPC Name': vpc_name if vpc_name else 'N/A',
-            'VPC ID': vpc_id,
-            'Block Public Access': block_public_access,
-            'IPv4 CIDR': ipv4_cidr_combined,
-            'IPv6 CIDR': ipv6_cidr,
-            'DHCP Option Set': dhcp_options_id,
-            'Main Route Table': main_route_table,
-            'Main NACL': main_nacl,
-            'Default VPC': default_vpc,
-            'Tags': tags_str
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(vpcs)} VPC(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining VPCs were still collected."
+        )
 
     return vpc_data
 
@@ -197,15 +243,17 @@ def collect_vpc_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with VPC information
+        tuple: (list of VPC dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING VPC INFORMATION ===")
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning. collect_failures=True lets a failed
+    # region surface instead of being collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_vpc_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -214,7 +262,8 @@ def collect_vpc_data(regions):
         all_vpc_data.extend(vpcs)
 
     utils.log_success(f"Total VPCs collected: {len(all_vpc_data)}")
-    return all_vpc_data
+    tagged_failures = [(f"{region} (vpcs)", err) for region, err in failed_regions]
+    return all_vpc_data, tagged_failures
 
 def is_subnet_public(ec2_client, subnet_id, vpc_id):
     """
@@ -271,16 +320,94 @@ def is_subnet_public(ec2_client, subnet_id, vpc_id):
         utils.log_warning(f"Error checking if subnet {subnet_id} is public: {e}")
         return "Unknown"
 
-@utils.aws_error_handler("Collecting VPC and subnet data for region", default_return=[])
+def _build_subnet_row(subnet, vpc_id, vpc_name, vpc_cidr, region, ec2_client):
+    """
+    Build the export row for a single subnet.
+
+    Extracted so per-subnet processing can be wrapped in try/except by the
+    caller. Required fields are read with ``.get()`` and a safe default; a
+    missing SubnetId raises so the caller's per-item guard treats the entry
+    as malformed.
+
+    Args:
+        subnet (dict): A single Subnets entry from describe_subnets.
+        vpc_id (str): Parent VPC ID.
+        vpc_name (str): Parent VPC name ('N/A' if unnamed).
+        vpc_cidr (str): Parent VPC CIDR block.
+        region (str): AWS region name.
+        ec2_client: Boto3 EC2 client for the region.
+
+    Returns:
+        dict: The assembled subnet row.
+    """
+    subnet_id = subnet.get('SubnetId')
+    if not subnet_id:
+        raise ValueError("Subnet entry missing SubnetId")
+
+    # Extract subnet name and all tags
+    subnet_name = None
+    subnet_tags = {}
+    for tag in subnet.get('Tags', []):
+        key = tag.get('Key')
+        if key is None:
+            continue
+        if key == 'Name':
+            subnet_name = tag.get('Value')
+        subnet_tags[key] = tag.get('Value')
+
+    availability_zone = subnet.get('AvailabilityZone', 'N/A')
+    ipv4_cidr = subnet.get('CidrBlock', 'N/A')
+    ipv4_address_count = subnet.get('AvailableIpAddressCount', 'N/A')
+
+    # Get IPv6 CIDR if available
+    ipv6_cidr = 'N/A'
+    for ipv6_assoc in subnet.get('Ipv6CidrBlockAssociationSet', []) or []:
+        if ipv6_assoc.get('Ipv6CidrBlockState', {}).get('State') == 'associated':
+            ipv6_cidr = ipv6_assoc.get('Ipv6CidrBlock', 'N/A')
+            break
+
+    # Determine if subnet is public or private
+    public_status = is_subnet_public(ec2_client, subnet_id, vpc_id)
+    public_private = "Public" if public_status else "Private"
+
+    # Format tags as string for better readability
+    tags_str = ', '.join([f"{k}={v}" for k, v in subnet_tags.items()]) if subnet_tags else 'N/A'
+
+    return {
+        'Region': region,
+        'VPC Name': vpc_name if vpc_name else 'N/A',
+        'VPC ID': vpc_id,
+        'VPC CIDR Block': vpc_cidr,
+        'Subnet ID': subnet_id,
+        'Subnet Name': subnet_name if subnet_name else 'N/A',
+        'Availability Zone': availability_zone,
+        'IPv4 CIDR Block': ipv4_cidr,
+        'IPv4 Address Count': ipv4_address_count,
+        'IPv6 CIDR Block': ipv6_cidr,
+        'Public/Private': public_private,
+        'Subnet Tags': tags_str
+    }
+
+
 def collect_vpc_subnet_data_for_region(region):
     """
     Collect VPC and subnet information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from a genuinely empty region.
+    Region-level failures (paginator errors, client creation, etc.) are
+    allowed to raise. A single VPC's subnet listing failing (e.g. a
+    describe_subnets throttle) only skips that VPC; a single malformed
+    subnet only skips that subnet.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with subnet information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     subnet_data = []
 
@@ -302,86 +429,68 @@ def collect_vpc_subnet_data_for_region(region):
 
     utils.log_info(f"Found {len(vpcs)} VPCs in AWS region {region}")
 
+    skipped_vpcs = 0
+    skipped_subnets = 0
+
     # Process each VPC
     for vpc_index, vpc in enumerate(vpcs, 1):
-        vpc_id = vpc['VpcId']
+        vpc_id = vpc.get('VpcId')
+        if not vpc_id:
+            skipped_vpcs += 1
+            utils.log_error(f"Skipping VPC entry missing VpcId in {region}")
+            continue
+
         vpc_progress = (vpc_index / len(vpcs)) * 100 if len(vpcs) > 0 else 0
         utils.log_info(f"  [{vpc_progress:.1f}%] Processing VPC {vpc_index}/{len(vpcs)}: {vpc_id}")
 
         # Extract VPC name from tags
         vpc_name = None
-        if 'Tags' in vpc:
-            for tag in vpc['Tags']:
-                if tag['Key'] == 'Name':
-                    vpc_name = tag['Value']
-                    break
+        for tag in vpc.get('Tags', []):
+            if tag.get('Key') == 'Name':
+                vpc_name = tag.get('Value')
+                break
 
         # Get VPC CIDR Block
         vpc_cidr = vpc.get('CidrBlock', 'N/A')
 
-        # Get all subnets for this VPC
-        subnet_response = ec2_client.describe_subnets(
-            Filters=[
-                {
-                    'Name': 'vpc-id',
-                    'Values': [vpc_id]
-                }
-            ]
-        )
-        subnets = subnet_response.get('Subnets', [])
+        # Get all subnets for this VPC. A describe_subnets failure for one
+        # VPC must not sink the whole region.
+        try:
+            subnet_response = ec2_client.describe_subnets(
+                Filters=[
+                    {
+                        'Name': 'vpc-id',
+                        'Values': [vpc_id]
+                    }
+                ]
+            )
+            subnets = subnet_response.get('Subnets', [])
+        except Exception as e:
+            skipped_vpcs += 1
+            utils.log_error(f"Skipping subnet collection for VPC '{vpc_id}' in {region} due to a processing error", e)
+            continue
 
         utils.log_info(f"    Found {len(subnets)} subnets")
 
-        # Process each subnet
+        # Process each subnet. One malformed subnet must not sink the VPC.
         for subnet_index, subnet in enumerate(subnets, 1):
-            subnet_id = subnet['SubnetId']
+            subnet_id_for_log = subnet.get('SubnetId', 'Unknown')
             subnet_progress = (subnet_index / len(subnets)) * 100 if len(subnets) > 0 else 0
             if len(subnets) > 1:  # Only log subnet progress if there are multiple subnets
-                utils.log_info(f"      [{subnet_progress:.1f}%] Processing subnet {subnet_index}/{len(subnets)}: {subnet_id}")
+                utils.log_info(f"      [{subnet_progress:.1f}%] Processing subnet {subnet_index}/{len(subnets)}: {subnet_id_for_log}")
 
-            # Extract subnet name and all tags
-            subnet_name = None
-            subnet_tags = {}
-            if 'Tags' in subnet:
-                for tag in subnet['Tags']:
-                    if tag['Key'] == 'Name':
-                        subnet_name = tag['Value']
-                    subnet_tags[tag['Key']] = tag['Value']
+            try:
+                subnet_data.append(_build_subnet_row(subnet, vpc_id, vpc_name, vpc_cidr, region, ec2_client))
+            except Exception as e:
+                skipped_subnets += 1
+                utils.log_error(f"Skipping subnet '{subnet_id_for_log}' in VPC '{vpc_id}' in {region} due to a processing error", e)
+                continue
 
-            availability_zone = subnet['AvailabilityZone']
-            ipv4_cidr = subnet['CidrBlock']
-            ipv4_address_count = subnet.get('AvailableIpAddressCount', 'N/A')
-
-            # Get IPv6 CIDR if available
-            ipv6_cidr = 'N/A'
-            if 'Ipv6CidrBlockAssociationSet' in subnet and subnet['Ipv6CidrBlockAssociationSet']:
-                for ipv6_assoc in subnet['Ipv6CidrBlockAssociationSet']:
-                    if ipv6_assoc.get('Ipv6CidrBlockState', {}).get('State') == 'associated':
-                        ipv6_cidr = ipv6_assoc.get('Ipv6CidrBlock', 'N/A')
-                        break
-
-            # Determine if subnet is public or private
-            public_status = is_subnet_public(ec2_client, subnet_id, vpc_id)
-            public_private = "Public" if public_status else "Private"
-
-            # Format tags as string for better readability
-            tags_str = ', '.join([f"{k}={v}" for k, v in subnet_tags.items()]) if subnet_tags else 'N/A'
-
-            # Append subnet data to the list
-            subnet_data.append({
-                'Region': region,
-                'VPC Name': vpc_name if vpc_name else 'N/A',
-                'VPC ID': vpc_id,
-                'VPC CIDR Block': vpc_cidr,
-                'Subnet ID': subnet_id,
-                'Subnet Name': subnet_name if subnet_name else 'N/A',
-                'Availability Zone': availability_zone,
-                'IPv4 CIDR Block': ipv4_cidr,
-                'IPv4 Address Count': ipv4_address_count,
-                'IPv6 CIDR Block': ipv6_cidr,
-                'Public/Private': public_private,
-                'Subnet Tags': tags_str
-            })
+    if skipped_vpcs or skipped_subnets:
+        utils.log_warning(
+            f"{skipped_vpcs} VPC(s) and {skipped_subnets} subnet(s) in {region} were skipped "
+            "due to processing errors (see log above); the remaining data was still collected."
+        )
 
     return subnet_data
 
@@ -393,15 +502,17 @@ def collect_vpc_subnet_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with subnet information
+        tuple: (list of subnet dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING VPC AND SUBNET INFORMATION ===")
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning. collect_failures=True lets a failed
+    # region surface instead of being collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_vpc_subnet_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -410,7 +521,8 @@ def collect_vpc_subnet_data(regions):
         all_subnet_data.extend(subnets)
 
     utils.log_success(f"Total subnets collected: {len(all_subnet_data)}")
-    return all_subnet_data
+    tagged_failures = [(f"{region} (subnets)", err) for region, err in failed_regions]
+    return all_subnet_data, tagged_failures
 
 def _load_natgw_monthly_cost() -> float:
     """Return NAT Gateway base hourly cost × 730 from pricing JSON."""
@@ -424,16 +536,100 @@ def _load_natgw_monthly_cost() -> float:
         return 32.85
 
 
-@utils.aws_error_handler("Collecting NAT Gateway data for region", default_return=[])
+def _build_natgw_row(nat_gw, region, natgw_monthly_cost):
+    """
+    Build the export row for a single NAT Gateway.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller. A missing NatGatewayId raises so the caller's per-item guard
+    treats the entry as malformed.
+
+    Args:
+        nat_gw (dict): A single NatGateways entry from describe_nat_gateways.
+        region (str): AWS region name.
+        natgw_monthly_cost (float): Estimated monthly base cost.
+
+    Returns:
+        dict: The assembled NAT Gateway row.
+    """
+    nat_gw_id = nat_gw.get('NatGatewayId')
+    if not nat_gw_id:
+        raise ValueError("NAT Gateway entry missing NatGatewayId")
+
+    state = nat_gw.get('State', '')
+    connectivity = nat_gw.get('ConnectivityType', '')
+    vpc_id = nat_gw.get('VpcId', '')
+    subnet_id = nat_gw.get('SubnetId', '')
+
+    # Get creation timestamp and format it
+    creation_timestamp = nat_gw.get('CreateTime', '')
+    if creation_timestamp:
+        # Convert to datetime object and then to string format
+        creation_date = creation_timestamp.strftime('%Y-%m-%d') if isinstance(creation_timestamp, datetime.datetime) else str(creation_timestamp)
+    else:
+        creation_date = ""
+
+    # Extract name from tags
+    name = None
+    for tag in nat_gw.get('Tags', []):
+        if tag.get('Key') == 'Name':
+            name = tag.get('Value')
+            break
+
+    # Get primary network interface details
+    primary_public_ip = ""
+    primary_private_ip = ""
+    primary_eni_id = ""
+
+    nat_addresses = nat_gw.get('NatGatewayAddresses', [])
+    if nat_addresses:
+        primary_nat_address = nat_addresses[0]
+        primary_public_ip = primary_nat_address.get('PublicIp', '')
+        primary_private_ip = primary_nat_address.get('PrivateIp', '')
+        primary_eni_id = primary_nat_address.get('NetworkInterfaceId', '')
+
+    # Cost: hourly base charge applies to 'available' gateways only
+    if state == 'available':
+        monthly_cost = natgw_monthly_cost
+        cost_note = 'Hourly base only; excludes data processing charges'
+    else:
+        monthly_cost = 0.0
+        cost_note = f'Not billed (state: {state})'
+
+    return {
+        'Region': region,
+        'Name': name if name else 'N/A',
+        'NAT Gateway ID': nat_gw_id,
+        'State': state,
+        'Connectivity': connectivity,
+        'Primary Public IPv4': primary_public_ip,
+        'Primary Private IPv4': primary_private_ip,
+        'Primary Network Interface ID': primary_eni_id,
+        'VPC': vpc_id,
+        'Subnet': subnet_id,
+        'Creation Date': creation_date,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
 def collect_nat_gateway_data_for_region(region):
     """
     Collect NAT Gateway information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from a genuinely empty region.
+    Region-level failures are allowed to raise. Per-gateway errors are
+    contained internally (logged and skipped).
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with NAT Gateway information
+
+    Raises:
+        Exception: Any AWS error for the region.
     """
     nat_gateways = []
     natgw_monthly_cost = _load_natgw_monthly_cost()
@@ -453,68 +649,24 @@ def collect_nat_gateway_data_for_region(region):
     nat_gws = nat_gw_response.get('NatGateways', [])
     utils.log_info(f"  Found {len(nat_gws)} NAT Gateways")
 
-    # Process each NAT Gateway
+    # Process each NAT Gateway. One malformed gateway must not sink the region.
+    skipped = 0
     for nat_gw in nat_gws:
-        nat_gw_id = nat_gw.get('NatGatewayId', '')
-        utils.log_info(f"    Processing NAT Gateway: {nat_gw_id}")
+        nat_gw_id_for_log = nat_gw.get('NatGatewayId', 'Unknown')
+        utils.log_info(f"    Processing NAT Gateway: {nat_gw_id_for_log}")
 
-        state = nat_gw.get('State', '')
-        connectivity = nat_gw.get('ConnectivityType', '')
-        vpc_id = nat_gw.get('VpcId', '')
-        subnet_id = nat_gw.get('SubnetId', '')
+        try:
+            nat_gateways.append(_build_natgw_row(nat_gw, region, natgw_monthly_cost))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping NAT Gateway '{nat_gw_id_for_log}' in {region} due to a processing error", e)
+            continue
 
-        # Get creation timestamp and format it
-        creation_timestamp = nat_gw.get('CreateTime', '')
-        if creation_timestamp:
-            # Convert to datetime object and then to string format
-            creation_date = creation_timestamp.strftime('%Y-%m-%d') if isinstance(creation_timestamp, datetime.datetime) else str(creation_timestamp)
-        else:
-            creation_date = ""
-
-        # Extract name from tags
-        name = None
-        if 'Tags' in nat_gw:
-            for tag in nat_gw['Tags']:
-                if tag['Key'] == 'Name':
-                    name = tag['Value']
-                    break
-
-        # Get primary network interface details
-        primary_public_ip = ""
-        primary_private_ip = ""
-        primary_eni_id = ""
-
-        nat_addresses = nat_gw.get('NatGatewayAddresses', [])
-        if nat_addresses:
-            primary_nat_address = nat_addresses[0]
-            primary_public_ip = primary_nat_address.get('PublicIp', '')
-            primary_private_ip = primary_nat_address.get('PrivateIp', '')
-            primary_eni_id = primary_nat_address.get('NetworkInterfaceId', '')
-
-        # Cost: hourly base charge applies to 'available' gateways only
-        if state == 'available':
-            monthly_cost = natgw_monthly_cost
-            cost_note = 'Hourly base only; excludes data processing charges'
-        else:
-            monthly_cost = 0.0
-            cost_note = f'Not billed (state: {state})'
-
-        # Add to results
-        nat_gateways.append({
-            'Region': region,
-            'Name': name if name else 'N/A',
-            'NAT Gateway ID': nat_gw_id,
-            'State': state,
-            'Connectivity': connectivity,
-            'Primary Public IPv4': primary_public_ip,
-            'Primary Private IPv4': primary_private_ip,
-            'Primary Network Interface ID': primary_eni_id,
-            'VPC': vpc_id,
-            'Subnet': subnet_id,
-            'Creation Date': creation_date,
-            'Monthly Cost (On-Demand)': monthly_cost,
-            'Cost Note': cost_note,
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(nat_gws)} NAT Gateway(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining gateways were still collected."
+        )
 
     return nat_gateways
 
@@ -526,15 +678,17 @@ def collect_nat_gateway_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with NAT Gateway information
+        tuple: (list of NAT Gateway dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING NAT GATEWAY INFORMATION ===")
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning. collect_failures=True lets a failed
+    # region surface instead of being collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_nat_gateway_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -543,18 +697,87 @@ def collect_nat_gateway_data(regions):
         all_nat_gateways.extend(nat_gws)
 
     utils.log_success(f"Total NAT Gateways collected: {len(all_nat_gateways)}")
-    return all_nat_gateways
+    tagged_failures = [(f"{region} (nat-gateways)", err) for region, err in failed_regions]
+    return all_nat_gateways, tagged_failures
 
-@utils.aws_error_handler("Collecting VPC Peering data for region", default_return=[])
+def _build_peering_row(peering):
+    """
+    Build the export row for a single VPC Peering Connection.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller. A missing VpcPeeringConnectionId raises so the caller's
+    per-item guard treats the entry as malformed.
+
+    Args:
+        peering (dict): A single VpcPeeringConnections entry.
+
+    Returns:
+        dict: The assembled VPC Peering Connection row.
+    """
+    peering_id = peering.get('VpcPeeringConnectionId')
+    if not peering_id:
+        raise ValueError("VPC Peering entry missing VpcPeeringConnectionId")
+
+    # Get peering status
+    status = peering.get('Status', {}).get('Code', '')
+
+    # Get requester VPC information
+    requester_info = peering.get('RequesterVpcInfo', {})
+    requester_vpc = requester_info.get('VpcId', '')
+    requester_cidr = requester_info.get('CidrBlock', '')
+    requester_owner = requester_info.get('OwnerId', '')
+    requester_region = requester_info.get('Region', '')
+
+    # Get accepter VPC information
+    accepter_info = peering.get('AccepterVpcInfo', {})
+    accepter_vpc = accepter_info.get('VpcId', '')
+    accepter_cidr = accepter_info.get('CidrBlock', '')
+    accepter_owner = accepter_info.get('OwnerId', '')
+    accepter_region = accepter_info.get('Region', '')
+
+    # Format account owner IDs with names if available
+    requester_owner_formatted = utils.get_account_name_formatted(requester_owner)
+    accepter_owner_formatted = utils.get_account_name_formatted(accepter_owner)
+
+    # Extract name from tags
+    name = None
+    for tag in peering.get('Tags', []):
+        if tag.get('Key') == 'Name':
+            name = tag.get('Value')
+            break
+
+    return {
+        'Name': name if name else 'N/A',
+        'Peering Connection ID': peering_id,
+        'Status': status,
+        'Requester VPC': requester_vpc,
+        'Accepter VPC': accepter_vpc,
+        'Requester CIDR': requester_cidr,
+        'Accepter CIDR': accepter_cidr,
+        'Requester Owner ID': requester_owner_formatted,
+        'Accepter Owner ID': accepter_owner_formatted,
+        'Requester Region': requester_region,
+        'Accepter Region': accepter_region
+    }
+
+
 def collect_vpc_peering_data_for_region(region):
     """
     Collect VPC Peering Connection information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from a genuinely empty region.
+    Region-level failures are allowed to raise. Per-connection errors are
+    contained internally (logged and skipped).
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with VPC Peering information
+
+    Raises:
+        Exception: Any AWS error for the region.
     """
     vpc_peerings = []
 
@@ -573,54 +796,24 @@ def collect_vpc_peering_data_for_region(region):
     peerings = peering_response.get('VpcPeeringConnections', [])
     utils.log_info(f"  Found {len(peerings)} VPC Peering Connections")
 
-    # Process each VPC Peering Connection
+    # Process each VPC Peering Connection. One malformed entry must not sink the region.
+    skipped = 0
     for peering in peerings:
-        peering_id = peering.get('VpcPeeringConnectionId', '')
-        utils.log_info(f"    Processing VPC Peering Connection: {peering_id}")
+        peering_id_for_log = peering.get('VpcPeeringConnectionId', 'Unknown')
+        utils.log_info(f"    Processing VPC Peering Connection: {peering_id_for_log}")
 
-        # Get peering status
-        status = peering.get('Status', {}).get('Code', '')
+        try:
+            vpc_peerings.append(_build_peering_row(peering))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping VPC Peering Connection '{peering_id_for_log}' in {region} due to a processing error", e)
+            continue
 
-        # Get requester VPC information
-        requester_info = peering.get('RequesterVpcInfo', {})
-        requester_vpc = requester_info.get('VpcId', '')
-        requester_cidr = requester_info.get('CidrBlock', '')
-        requester_owner = requester_info.get('OwnerId', '')
-        requester_region = requester_info.get('Region', '')
-
-        # Get accepter VPC information
-        accepter_info = peering.get('AccepterVpcInfo', {})
-        accepter_vpc = accepter_info.get('VpcId', '')
-        accepter_cidr = accepter_info.get('CidrBlock', '')
-        accepter_owner = accepter_info.get('OwnerId', '')
-        accepter_region = accepter_info.get('Region', '')
-
-        # Format account owner IDs with names if available
-        requester_owner_formatted = utils.get_account_name_formatted(requester_owner)
-        accepter_owner_formatted = utils.get_account_name_formatted(accepter_owner)
-
-        # Extract name from tags
-        name = None
-        if 'Tags' in peering:
-            for tag in peering['Tags']:
-                if tag['Key'] == 'Name':
-                    name = tag['Value']
-                    break
-
-        # Add to results
-        vpc_peerings.append({
-            'Name': name if name else 'N/A',
-            'Peering Connection ID': peering_id,
-            'Status': status,
-            'Requester VPC': requester_vpc,
-            'Accepter VPC': accepter_vpc,
-            'Requester CIDR': requester_cidr,
-            'Accepter CIDR': accepter_cidr,
-            'Requester Owner ID': requester_owner_formatted,
-            'Accepter Owner ID': accepter_owner_formatted,
-            'Requester Region': requester_region,
-            'Accepter Region': accepter_region
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(peerings)} VPC Peering Connection(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining connections were still collected."
+        )
 
     return vpc_peerings
 
@@ -632,15 +825,17 @@ def collect_vpc_peering_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with VPC Peering information
+        tuple: (list of VPC Peering dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING VPC PEERING CONNECTION INFORMATION ===")
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning. collect_failures=True lets a failed
+    # region surface instead of being collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_vpc_peering_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -649,18 +844,72 @@ def collect_vpc_peering_data(regions):
         all_vpc_peerings.extend(peerings)
 
     utils.log_success(f"Total VPC Peering Connections collected: {len(all_vpc_peerings)}")
-    return all_vpc_peerings
+    tagged_failures = [(f"{region} (vpc-peering)", err) for region, err in failed_regions]
+    return all_vpc_peerings, tagged_failures
 
-@utils.aws_error_handler("Collecting Internet Gateway data for region", default_return=[])
+def _build_igw_row(igw, region):
+    """
+    Build the export row for a single Internet Gateway.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller. A missing InternetGatewayId raises so the caller's per-item
+    guard treats the entry as malformed.
+
+    Args:
+        igw (dict): A single InternetGateways entry.
+        region (str): AWS region name.
+
+    Returns:
+        dict: The assembled Internet Gateway row.
+    """
+    igw_id = igw.get('InternetGatewayId')
+    if not igw_id:
+        raise ValueError("Internet Gateway entry missing InternetGatewayId")
+
+    owner_id = igw.get('OwnerId', '')
+
+    name = None
+    for tag in igw.get('Tags', []):
+        if tag.get('Key') == 'Name':
+            name = tag.get('Value')
+            break
+
+    attachments = igw.get('Attachments', [])
+    if attachments:
+        vpc_id = attachments[0].get('VpcId', '')
+        attachment_state = attachments[0].get('State', '')
+    else:
+        vpc_id = ''
+        attachment_state = 'detached'
+
+    return {
+        'Region': region,
+        'Name': name if name else 'N/A',
+        'Internet Gateway ID': igw_id,
+        'Attached VPC ID': vpc_id,
+        'Attachment State': attachment_state,
+        'Owner Account ID': owner_id,
+    }
+
+
 def collect_internet_gateway_data_for_region(region):
     """
     Collect Internet Gateway information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from a genuinely empty region.
+    Region-level failures (paginator errors, client creation, etc.) are
+    allowed to raise. Per-gateway errors are contained internally (logged
+    and skipped).
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with Internet Gateway information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     igw_data = []
 
@@ -679,33 +928,22 @@ def collect_internet_gateway_data_for_region(region):
 
     utils.log_info(f"  Found {len(igws)} Internet Gateways")
 
+    # Process each Internet Gateway. One malformed entry must not sink the region.
+    skipped = 0
     for igw in igws:
-        igw_id = igw.get('InternetGatewayId', '')
-        owner_id = igw.get('OwnerId', '')
+        igw_id_for_log = igw.get('InternetGatewayId', 'Unknown')
+        try:
+            igw_data.append(_build_igw_row(igw, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping Internet Gateway '{igw_id_for_log}' in {region} due to a processing error", e)
+            continue
 
-        name = None
-        if 'Tags' in igw:
-            for tag in igw['Tags']:
-                if tag['Key'] == 'Name':
-                    name = tag['Value']
-                    break
-
-        attachments = igw.get('Attachments', [])
-        if attachments:
-            vpc_id = attachments[0].get('VpcId', '')
-            attachment_state = attachments[0].get('State', '')
-        else:
-            vpc_id = ''
-            attachment_state = 'detached'
-
-        igw_data.append({
-            'Region': region,
-            'Name': name if name else 'N/A',
-            'Internet Gateway ID': igw_id,
-            'Attached VPC ID': vpc_id,
-            'Attachment State': attachment_state,
-            'Owner Account ID': owner_id,
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(igws)} Internet Gateway(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining gateways were still collected."
+        )
 
     return igw_data
 
@@ -718,14 +956,17 @@ def collect_internet_gateway_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with Internet Gateway information
+        tuple: (list of Internet Gateway dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING INTERNET GATEWAY INFORMATION ===")
 
-    region_results = utils.scan_regions_concurrent(
+    # collect_failures=True lets a failed region surface instead of being
+    # collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_internet_gateway_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     all_igws = []
@@ -733,19 +974,82 @@ def collect_internet_gateway_data(regions):
         all_igws.extend(igws)
 
     utils.log_success(f"Total Internet Gateways collected: {len(all_igws)}")
-    return all_igws
+    tagged_failures = [(f"{region} (internet-gateways)", err) for region, err in failed_regions]
+    return all_igws, tagged_failures
 
 
-@utils.aws_error_handler("Collecting Elastic IP data for region", default_return=[])
+def _build_eip_row(eip, region):
+    """
+    Build the export row for a single Elastic IP.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller. A missing AllocationId AND PublicIp raises so the caller's
+    per-item guard treats the entry as malformed (EC2-Classic EIPs lack
+    AllocationId, so only require it when there's no public IP either).
+
+    Args:
+        eip (dict): A single Addresses entry from describe_addresses.
+        region (str): AWS region name.
+
+    Returns:
+        dict: The assembled Elastic IP row.
+    """
+    allocated_ip = eip.get('PublicIp', '')
+    allocation_id = eip.get('AllocationId', '')
+    if not allocated_ip and not allocation_id:
+        raise ValueError("Elastic IP entry missing both PublicIp and AllocationId")
+
+    domain_type = eip.get('Domain', '')  # 'vpc' or 'standard'
+
+    # Get associated information if available
+    instance_id = eip.get('InstanceId', '')
+    private_ip = eip.get('PrivateIpAddress', '')
+    association_id = eip.get('AssociationId', '')
+    network_interface_owner_id = eip.get('NetworkInterfaceOwnerId', '')
+    network_border_group = eip.get('NetworkBorderGroup', '')
+
+    # Get Public DNS (Reverse DNS record)
+    public_dns = eip.get('PublicDnsName', '')
+
+    # Extract name from tags
+    name = None
+    for tag in eip.get('Tags', []):
+        if tag.get('Key') == 'Name':
+            name = tag.get('Value')
+            break
+
+    return {
+        'Region': region,
+        'Name': name if name else 'N/A',
+        'Allocated IPv4': allocated_ip,
+        'Type': domain_type,
+        'Allocation ID': allocation_id,
+        'Reverse DNS Record': public_dns,
+        'Associated Instance ID': instance_id,
+        'Private IPv4': private_ip,
+        'Association ID': association_id,
+        'Network Interface Owner ID': network_interface_owner_id,
+        'Network Border Group': network_border_group
+    }
+
+
 def collect_elastic_ip_data_for_region(region):
     """
     Collect Elastic IP information from a single AWS region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list indistinguishable from a genuinely empty region.
+    Region-level failures are allowed to raise. Per-address errors are
+    contained internally (logged and skipped).
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with Elastic IP information
+
+    Raises:
+        Exception: Any AWS error for the region.
     """
     elastic_ips = []
 
@@ -764,47 +1068,24 @@ def collect_elastic_ip_data_for_region(region):
     eips = eip_response.get('Addresses', [])
     utils.log_info(f"  Found {len(eips)} Elastic IPs")
 
-    # Process each Elastic IP
+    # Process each Elastic IP. One malformed entry must not sink the region.
+    skipped = 0
     for eip in eips:
-        allocated_ip = eip.get('PublicIp', '')
-        utils.log_info(f"    Processing Elastic IP: {allocated_ip}")
+        allocated_ip_for_log = eip.get('PublicIp', 'Unknown')
+        utils.log_info(f"    Processing Elastic IP: {allocated_ip_for_log}")
 
-        # Get EIP attributes
-        allocation_id = eip.get('AllocationId', '')
-        domain_type = eip.get('Domain', '')  # 'vpc' or 'standard'
+        try:
+            elastic_ips.append(_build_eip_row(eip, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(f"Skipping Elastic IP '{allocated_ip_for_log}' in {region} due to a processing error", e)
+            continue
 
-        # Get associated information if available
-        instance_id = eip.get('InstanceId', '')
-        private_ip = eip.get('PrivateIpAddress', '')
-        association_id = eip.get('AssociationId', '')
-        network_interface_owner_id = eip.get('NetworkInterfaceOwnerId', '')
-        network_border_group = eip.get('NetworkBorderGroup', '')
-
-        # Get Public DNS (Reverse DNS record)
-        public_dns = eip.get('PublicDnsName', '')
-
-        # Extract name from tags
-        name = None
-        if 'Tags' in eip:
-            for tag in eip['Tags']:
-                if tag['Key'] == 'Name':
-                    name = tag['Value']
-                    break
-
-        # Add to results
-        elastic_ips.append({
-            'Region': region,
-            'Name': name if name else 'N/A',
-            'Allocated IPv4': allocated_ip,
-            'Type': domain_type,
-            'Allocation ID': allocation_id,
-            'Reverse DNS Record': public_dns,
-            'Associated Instance ID': instance_id,
-            'Private IPv4': private_ip,
-            'Association ID': association_id,
-            'Network Interface Owner ID': network_interface_owner_id,
-            'Network Border Group': network_border_group
-        })
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(eips)} Elastic IP(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining addresses were still collected."
+        )
 
     return elastic_ips
 
@@ -816,15 +1097,17 @@ def collect_elastic_ip_data(regions):
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with Elastic IP information
+        tuple: (list of Elastic IP dictionaries, list of (scope, error) failures)
     """
     utils.log_info("=== COLLECTING ELASTIC IP INFORMATION ===")
 
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    # Use concurrent region scanning. collect_failures=True lets a failed
+    # region surface instead of being collapsed into an empty result.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_elastic_ip_data_for_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -833,7 +1116,8 @@ def collect_elastic_ip_data(regions):
         all_elastic_ips.extend(eips)
 
     utils.log_success(f"Total Elastic IPs collected: {len(all_elastic_ips)}")
-    return all_elastic_ips
+    tagged_failures = [(f"{region} (elastic-ips)", err) for region, err in failed_regions]
+    return all_elastic_ips, tagged_failures
 
 def export_vpc_subnet_natgw_peering_info(account_id, account_name):
     """
@@ -872,38 +1156,50 @@ def export_vpc_subnet_natgw_peering_info(account_id, account_name):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
+    # Accumulates (scope, error) tuples from every collector below. A region
+    # can fail for one resource type (e.g. NAT Gateways) while succeeding for
+    # another (e.g. VPCs) in the same pass, so failures are tagged per
+    # collector rather than deduplicated by region alone.
+    all_failed_regions = []
+
     # STEP 1: Collect VPC information (if VPC/Subnet selected)
     if export_vpc_subnet:
-        all_vpc_data = collect_vpc_data(regions)
+        all_vpc_data, failed = collect_vpc_data(regions)
+        all_failed_regions.extend(failed)
         if all_vpc_data:
             data_frames['VPCs'] = pd.DataFrame(all_vpc_data)
 
     # STEP 2: Collect VPC and Subnet information (if selected)
     if export_vpc_subnet:
-        all_subnet_data = collect_vpc_subnet_data(regions)
+        all_subnet_data, failed = collect_vpc_subnet_data(regions)
+        all_failed_regions.extend(failed)
         if all_subnet_data:
             data_frames['VPCs and Subnets'] = pd.DataFrame(all_subnet_data)
 
     # STEP 3: Collect NAT Gateway information (if selected)
     if export_nat_gateways:
-        all_nat_gateway_data = collect_nat_gateway_data(regions)
+        all_nat_gateway_data, failed = collect_nat_gateway_data(regions)
+        all_failed_regions.extend(failed)
         if all_nat_gateway_data:
             data_frames['NAT Gateways'] = pd.DataFrame(all_nat_gateway_data)
 
     # STEP 4: Collect Internet Gateway information
-    all_igw_data = collect_internet_gateway_data(regions)
+    all_igw_data, failed = collect_internet_gateway_data(regions)
+    all_failed_regions.extend(failed)
     if all_igw_data:
         data_frames['Internet Gateways'] = pd.DataFrame(all_igw_data)
 
     # STEP 5: Collect VPC Peering information (if selected)
     if export_vpc_peering:
-        all_vpc_peering_data = collect_vpc_peering_data(regions)
+        all_vpc_peering_data, failed = collect_vpc_peering_data(regions)
+        all_failed_regions.extend(failed)
         if all_vpc_peering_data:
             data_frames['VPC Peering Connections'] = pd.DataFrame(all_vpc_peering_data)
 
     # STEP 6: Collect Elastic IP information (if selected)
     if export_elastic_ip:
-        all_elastic_ip_data = collect_elastic_ip_data(regions)
+        all_elastic_ip_data, failed = collect_elastic_ip_data(regions)
+        all_failed_regions.extend(failed)
         if all_elastic_ip_data:
             data_frames['Elastic IPs'] = pd.DataFrame(all_elastic_ip_data)
 
@@ -913,28 +1209,40 @@ def export_vpc_subnet_natgw_peering_info(account_id, account_name):
             utils.prepare_dataframe_for_export(data_frames[sheet_name])
         )
 
-    # STEP 8: Save the Excel file using utils module
-    if not data_frames:
+    # STEP 8: Save the Excel file using utils module. Export whatever
+    # succeeded (partial export is required — see the 07.16.2026 audit),
+    # then decide on exit status based on collected failures below.
+    if data_frames:
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("AWS VPC data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not all_failed_regions:
+        # Genuinely empty account: every collector succeeded and returned nothing.
         utils.log_warning("No data was collected. Nothing to export.")
-        return
 
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("AWS VPC data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY collector failed for ANY region, make it loud: write a marker and
+    # exit non-zero, even if some data was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if all_failed_regions:
+        utils.report_collection_failures(account_name, resource_type, all_failed_regions)
+        print(
+            "\nERROR: VPC export completed with failures — data is incomplete. "
+            f"See the *-{resource_type}-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 def main():
     """Main function to execute the script."""

--- a/tests/sslib/test_concurrency.py
+++ b/tests/sslib/test_concurrency.py
@@ -12,12 +12,15 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+import utils
 from utils import (
     ConcurrentScanningError,
     _scan_regions_sequential,
     build_dataframe_in_batches,
     paginate_with_progress,
+    report_collection_failures,
     scan_regions_concurrent,
+    write_failure_marker,
 )
 
 # ---------------------------------------------------------------------------
@@ -98,7 +101,7 @@ class TestScanRegionsConcurrent:
     def test_disabled_config_falls_back_to_sequential(self):
         config_with_disabled = {"advanced_settings": {"concurrent_scanning": {"enabled": False}}}
 
-        with patch("utils.get_config", return_value=({}, config_with_disabled)), patch("utils._scan_regions_sequential", side_effect=lambda r, f, p: []) as mock_seq:
+        with patch("utils.get_config", return_value=({}, config_with_disabled)), patch("utils._scan_regions_sequential", side_effect=lambda r, f, p, collect_failures=False: []) as mock_seq:
             scan_regions_concurrent(
                 ["us-east-1"],
                 lambda r: r,
@@ -184,3 +187,100 @@ class TestBuildDataframeInBatches:
         data = [{"x": i} for i in range(1000)]
         df = build_dataframe_in_batches(data, batch_size=1000)
         assert len(df) == 1000
+
+
+# ---------------------------------------------------------------------------
+# collect_failures — failed vs empty distinction (Issue #233)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFailures:
+    def test_sequential_returns_failed_regions(self):
+        def scan(region):
+            if region == "us-west-2":
+                raise RuntimeError("Throttling")
+            return [f"ok-{region}"]
+
+        results, failed = _scan_regions_sequential(
+            ["us-east-1", "us-west-2", "eu-west-1"], scan, False, collect_failures=True
+        )
+
+        assert results == [["ok-us-east-1"], ["ok-eu-west-1"]]
+        assert len(failed) == 1
+        assert failed[0][0] == "us-west-2"
+        assert "Throttling" in failed[0][1]
+
+    def test_sequential_no_failures_returns_empty_failed_list(self):
+        results, failed = _scan_regions_sequential(
+            ["us-east-1", "us-west-2"], lambda r: [r], False, collect_failures=True
+        )
+        assert failed == []
+        assert len(results) == 2
+
+    def test_concurrent_returns_tuple_when_collect_failures(self):
+        def scan(region):
+            if region == "r2":
+                raise RuntimeError("boom")
+            return [region]
+
+        with patch("utils.get_config", return_value=_noop_config()):
+            results, failed = scan_regions_concurrent(
+                ["r1", "r2", "r3"],
+                scan,
+                max_workers=3,
+                show_progress=False,
+                fallback_on_error=False,
+                collect_failures=True,
+            )
+
+        assert isinstance(results, list)
+        assert [r[0] for r in failed] == ["r2"]
+
+    def test_concurrent_default_returns_bare_list(self):
+        """Legacy callers (no collect_failures) still receive a plain list."""
+        with patch("utils.get_config", return_value=_noop_config()):
+            results = scan_regions_concurrent(
+                ["us-east-1", "us-west-2"],
+                lambda r: r,
+                max_workers=2,
+                show_progress=False,
+                fallback_on_error=False,
+            )
+        assert isinstance(results, list)
+        assert not (len(results) == 2 and isinstance(results, tuple))
+
+
+# ---------------------------------------------------------------------------
+# write_failure_marker / report_collection_failures (Issue #233)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureMarker:
+    def test_write_failure_marker_names_scopes(self, tmp_path):
+        with patch.object(utils, "get_output_filepath", lambda name: tmp_path / name):
+            marker = write_failure_marker(
+                "ACME-PROD",
+                "ec2",
+                [("us-east-1", "Throttling: Rate exceeded"), ("us-gov-west-1", "KeyError")],
+            )
+
+        assert marker is not None
+        content = (tmp_path / Path(marker).name).read_text()
+        assert "us-east-1" in content
+        assert "us-gov-west-1" in content
+        assert "FAILED" in content
+        assert Path(marker).name.startswith("ACME-PROD-ec2-FAILED-")
+
+    def test_report_collection_failures_returns_none_when_empty(self, tmp_path):
+        with patch.object(utils, "get_output_filepath", lambda name: tmp_path / name):
+            assert report_collection_failures("ACME-PROD", "ec2", []) is None
+        # No marker written for a clean run.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_report_collection_failures_writes_marker(self, tmp_path):
+        with patch.object(utils, "get_output_filepath", lambda name: tmp_path / name):
+            marker = report_collection_failures(
+                "ACME-PROD", "vpc", [("us-east-1", "AccessDenied")]
+            )
+        assert marker is not None
+        assert (tmp_path / Path(marker).name).exists()

--- a/tests/test_exporters/test_ebs_snapshots_export.py
+++ b/tests/test_exporters/test_ebs_snapshots_export.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ebs_snapshots_export.py.
+
+Covers:
+- get_snapshots()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ebs_snapshots_export  # noqa: E402
+from ebs_snapshots_export import get_snapshots  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_snapshot(ec2):
+    volume = ec2.create_volume(Size=8, AvailabilityZone=f"{REGION}a")
+    snapshot = ec2.create_snapshot(VolumeId=volume["VolumeId"])
+    return snapshot["SnapshotId"]
+
+
+class TestGetSnapshots:
+    """Tests for get_snapshots()."""
+
+    @mock_aws
+    def test_created_snapshot_appears_in_results(self):
+        """A newly created EBS snapshot is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        snapshot_id = _create_snapshot(ec2)
+
+        result = get_snapshots(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert any(row["Snapshot ID"] == snapshot_id for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        _create_snapshot(ec2)
+
+        result = get_snapshots(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Name", "Snapshot ID", "Volume ID", "Region", "Encryption"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_empty_region_returns_list_without_created_snapshot(self):
+        """
+        Region with no volume-backed snapshots created by the test does not
+        contain a snapshot this test never made. (moto seeds baseline
+        AMI-owned snapshots for 'self' in a fresh account, so this asserts
+        non-presence rather than strict emptiness.)
+        """
+        result = get_snapshots(REGION)
+        assert isinstance(result, list)
+        assert not any(row["Description"] == "unique-marker-not-created" for row in result)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit / 07.16.2026 blast-radius sweep:
+    exporters silently lost data because a collection error was swallowed to
+    an empty list, indistinguishable from a genuinely empty region. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One snapshot that fails to process must not discard the whole
+        region's results — the healthy snapshot is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        good_id = _create_snapshot(ec2)
+        bad_id = _create_snapshot(ec2)
+
+        original = ebs_snapshots_export._build_snapshot_row
+
+        def raise_for_bad(snapshot, region):
+            if snapshot.get("SnapshotId") == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(snapshot, region)
+
+        monkeypatch.setattr(ebs_snapshots_export, "_build_snapshot_row", raise_for_bad)
+
+        result = get_snapshots(REGION)
+
+        ids = {row["Snapshot ID"] for row in result}
+        assert good_id in ids, "healthy snapshot was lost when a sibling failed"
+        assert bad_id not in ids, "malformed snapshot should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeSnapshots",
+            )
+
+        monkeypatch.setattr(ebs_snapshots_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_snapshots(REGION)

--- a/tests/test_exporters/test_ebs_volumes_export.py
+++ b/tests/test_exporters/test_ebs_volumes_export.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ebs_volumes_export.py.
+
+Covers:
+- get_ebs_volumes()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ebs_volumes_export  # noqa: E402
+from ebs_volumes_export import get_ebs_volumes  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class TestGetEbsVolumes:
+    """Tests for get_ebs_volumes()."""
+
+    @mock_aws
+    def test_created_volume_appears_in_results(self):
+        """A newly created EBS volume is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        volume = ec2.create_volume(Size=8, AvailabilityZone=f"{REGION}a", VolumeType="gp3")
+
+        result = get_ebs_volumes(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert any(row["Volume ID"] == volume["VolumeId"] for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        ec2.create_volume(Size=8, AvailabilityZone=f"{REGION}a", VolumeType="gp3")
+
+        result = get_ebs_volumes(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Volume ID", "Size (GB)", "State", "Region"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no EBS volumes returns an empty list."""
+        result = get_ebs_volumes(REGION)
+        assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the silent-collection-failure sweep: EBS volume data
+    silently lost because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One volume that fails to process must not discard the whole region's
+        results — the healthy volume is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        good_volume = ec2.create_volume(Size=8, AvailabilityZone=f"{REGION}a", VolumeType="gp3")
+        bad_volume = ec2.create_volume(Size=8, AvailabilityZone=f"{REGION}a", VolumeType="gp3")
+
+        original = ebs_volumes_export._build_volume_data
+
+        def raise_for_bad(volume, *args, **kwargs):
+            if volume.get("VolumeId") == bad_volume["VolumeId"]:
+                raise KeyError("SomeUnexpectedField")
+            return original(volume, *args, **kwargs)
+
+        monkeypatch.setattr(ebs_volumes_export, "_build_volume_data", raise_for_bad)
+
+        result = get_ebs_volumes(REGION)
+
+        ids = {row["Volume ID"] for row in result}
+        assert good_volume["VolumeId"] in ids, "healthy volume was lost when a sibling failed"
+        assert bad_volume["VolumeId"] not in ids, "malformed volume should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeVolumes",
+            )
+
+        monkeypatch.setattr(ebs_volumes_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_ebs_volumes(REGION)

--- a/tests/test_exporters/test_ec2_export.py
+++ b/tests/test_exporters/test_ec2_export.py
@@ -10,10 +10,12 @@ import sys
 from pathlib import Path
 
 import boto3
+import botocore
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ec2_export  # noqa: E402
 from ec2_export import get_instance_data  # noqa: E402
 
 REGION = "us-east-1"
@@ -86,3 +88,60 @@ class TestGetInstanceData:
         """Region with no EC2 instances returns an empty list."""
         result = get_instance_data(REGION)
         assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit: exporter data silently lost
+    because a collection error was swallowed to an empty list, indistinguishable
+    from a genuinely empty region. See
+    .collab/audit/07.15.2026-rds-silent-collection-failure.md and the
+    07.16.2026 blast-radius sweep.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One instance that fails to process must not discard the whole region's
+        results — the healthy instance is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        good = ec2.run_instances(
+            ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t3.micro"
+        )["Instances"][0]["InstanceId"]
+        bad = ec2.run_instances(
+            ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t3.micro"
+        )["Instances"][0]["InstanceId"]
+
+        original = ec2_export._build_instance_row
+
+        def raise_for_bad(instance, *args, **kwargs):
+            if instance.get("InstanceId") == bad:
+                raise KeyError("SomeMissingField")
+            return original(instance, *args, **kwargs)
+
+        monkeypatch.setattr(ec2_export, "_build_instance_row", raise_for_bad)
+
+        result = get_instance_data(REGION)
+
+        ids = {row["Instance ID"] for row in result}
+        assert good in ids, "healthy instance was lost when a sibling failed"
+        assert bad not in ids, "malformed instance should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeInstances",
+            )
+
+        monkeypatch.setattr(ec2_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_instance_data(REGION)

--- a/tests/test_exporters/test_elb_export.py
+++ b/tests/test_exporters/test_elb_export.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for elb_export.py.
+
+Covers:
+- get_classic_load_balancers()
+- get_application_network_load_balancers()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import elb_export  # noqa: E402
+from elb_export import (  # noqa: E402
+    get_application_network_load_balancers,
+    get_classic_load_balancers,
+)
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_vpc_and_subnets():
+    """Create a VPC with two subnets across AZs, required for ALB/NLB creation."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+    subnet_a = ec2.create_subnet(
+        VpcId=vpc["VpcId"], CidrBlock="10.0.1.0/24", AvailabilityZone=f"{REGION}a"
+    )["Subnet"]
+    subnet_b = ec2.create_subnet(
+        VpcId=vpc["VpcId"], CidrBlock="10.0.2.0/24", AvailabilityZone=f"{REGION}b"
+    )["Subnet"]
+    return vpc, [subnet_a["SubnetId"], subnet_b["SubnetId"]]
+
+
+class TestGetClassicLoadBalancers:
+    """Tests for get_classic_load_balancers()."""
+
+    @mock_aws
+    def test_created_lb_appears_in_results(self):
+        """A newly created Classic LB is returned by the collector."""
+        elb = boto3.client("elb", region_name=REGION)
+        elb.create_load_balancer(
+            LoadBalancerName="test-classic-lb",
+            Listeners=[{"Protocol": "HTTP", "LoadBalancerPort": 80, "InstancePort": 80}],
+            AvailabilityZones=[f"{REGION}a"],
+        )
+
+        result = get_classic_load_balancers(REGION)
+
+        assert isinstance(result, list)
+        assert any(row["Name"] == "test-classic-lb" for row in result)
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no Classic LBs returns an empty list."""
+        result = get_classic_load_balancers(REGION)
+        assert result == []
+
+
+class TestGetApplicationNetworkLoadBalancers:
+    """Tests for get_application_network_load_balancers()."""
+
+    @mock_aws
+    def test_created_alb_appears_in_results(self):
+        """A newly created ALB is returned by the collector."""
+        _, subnet_ids = _create_vpc_and_subnets()
+        elbv2 = boto3.client("elbv2", region_name=REGION)
+        elbv2.create_load_balancer(
+            Name="test-alb",
+            Subnets=subnet_ids,
+            Type="application",
+        )
+
+        result = get_application_network_load_balancers(REGION)
+
+        assert isinstance(result, list)
+        assert any(row["Name"] == "test-alb" for row in result)
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no ALB/NLBs returns an empty list."""
+        result = get_application_network_load_balancers(REGION)
+        assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit / 07.16.2026 blast-radius sweep:
+    ELB data silently lost because a collection error was swallowed to an
+    empty list, indistinguishable from a genuinely empty region.
+    See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_classic_lb_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One Classic LB that fails to process must not discard the whole
+        region's results — the healthy LB is still collected.
+        """
+        elb = boto3.client("elb", region_name=REGION)
+        for name in ("good-classic-lb", "bad-classic-lb"):
+            elb.create_load_balancer(
+                LoadBalancerName=name,
+                Listeners=[{"Protocol": "HTTP", "LoadBalancerPort": 80, "InstancePort": 80}],
+                AvailabilityZones=[f"{REGION}a"],
+            )
+
+        original = elb_export._build_classic_lb_row
+
+        def raise_for_bad(lb, *args, **kwargs):
+            if lb.get("LoadBalancerName") == "bad-classic-lb":
+                raise KeyError("SomeField")
+            return original(lb, *args, **kwargs)
+
+        monkeypatch.setattr(elb_export, "_build_classic_lb_row", raise_for_bad)
+
+        result = get_classic_load_balancers(REGION)
+
+        names = {row["Name"] for row in result}
+        assert "good-classic-lb" in names, "healthy LB was lost when a sibling failed"
+        assert "bad-classic-lb" not in names, "malformed LB should have been skipped"
+
+    @mock_aws
+    def test_classic_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeLoadBalancers",
+            )
+
+        monkeypatch.setattr(elb_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_classic_load_balancers(REGION)
+
+    @mock_aws
+    def test_malformed_albnlb_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One ALB/NLB that fails to process must not discard the whole
+        region's results — the healthy LB is still collected.
+        """
+        _, subnet_ids = _create_vpc_and_subnets()
+        elbv2 = boto3.client("elbv2", region_name=REGION)
+        for name in ("good-alb", "bad-alb"):
+            elbv2.create_load_balancer(
+                Name=name,
+                Subnets=subnet_ids,
+                Type="application",
+            )
+
+        original = elb_export._build_albnlb_row
+
+        def raise_for_bad(lb, *args, **kwargs):
+            if lb.get("LoadBalancerName") == "bad-alb":
+                raise KeyError("SomeField")
+            return original(lb, *args, **kwargs)
+
+        monkeypatch.setattr(elb_export, "_build_albnlb_row", raise_for_bad)
+
+        result = get_application_network_load_balancers(REGION)
+
+        names = {row["Name"] for row in result}
+        assert "good-alb" in names, "healthy LB was lost when a sibling failed"
+        assert "bad-alb" not in names, "malformed LB should have been skipped"
+
+    @mock_aws
+    def test_albnlb_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeLoadBalancers",
+            )
+
+        monkeypatch.setattr(elb_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_application_network_load_balancers(REGION)

--- a/tests/test_exporters/test_iam_export.py
+++ b/tests/test_exporters/test_iam_export.py
@@ -10,11 +10,18 @@ import sys
 from pathlib import Path
 
 import boto3
+import botocore.exceptions
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
-from iam_export import collect_iam_user_information  # noqa: E402
+import iam_export  # noqa: E402
+from iam_export import (  # noqa: E402
+    collect_iam_role_information,
+    collect_iam_user_information,
+    collect_inline_policies,
+    collect_managed_policies,
+)
 
 REGION = "us-east-1"
 
@@ -72,3 +79,161 @@ class TestCollectIamUserInformation:
         """Account with no IAM users returns an empty list."""
         result = collect_iam_user_information()
         assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits: IAM's account-scope collectors used to swallow a collection error
+    into an empty list, indistinguishable from a genuinely empty account. IAM
+    is global/account-scope (not multi-region), so each top-level collector
+    (users, roles, managed policies, inline policies) is verified separately:
+    a malformed item must be skipped without sinking the whole collection,
+    and an account-scope API failure must raise rather than return [].
+    See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    # -- Users ---------------------------------------------------------
+
+    @mock_aws
+    def test_malformed_user_is_skipped_not_fatal(self, monkeypatch):
+        """One user that fails to process must not discard the others."""
+        iam = boto3.client("iam", region_name=REGION)
+        iam.create_user(UserName="good-user")
+        iam.create_user(UserName="bad-user")
+
+        original = iam_export._build_user_row
+
+        def raise_for_bad(iam_client, user):
+            if user.get("UserName") == "bad-user":
+                raise KeyError("SomeUnexpectedField")
+            return original(iam_client, user)
+
+        monkeypatch.setattr(iam_export, "_build_user_row", raise_for_bad)
+
+        result = collect_iam_user_information()
+
+        names = {row["User Name"] for row in result}
+        assert "good-user" in names, "healthy user was lost when a sibling failed"
+        assert "bad-user" not in names, "malformed user should have been skipped"
+
+    @mock_aws
+    def test_users_account_scope_failure_raises_not_empty(self, monkeypatch):
+        """An account-scope API failure must propagate, not collapse to []."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListUsers",
+            )
+
+        monkeypatch.setattr(iam_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_iam_user_information()
+
+    # -- Roles -----------------------------------------------------------
+
+    @mock_aws
+    def test_malformed_role_is_skipped_not_fatal(self, monkeypatch):
+        """One role that fails to process must not discard the others."""
+        iam = boto3.client("iam", region_name=REGION)
+        trust_policy = (
+            '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", '
+            '"Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}]}'
+        )
+        iam.create_role(RoleName="good-role", AssumeRolePolicyDocument=trust_policy)
+        iam.create_role(RoleName="bad-role", AssumeRolePolicyDocument=trust_policy)
+
+        original = iam_export._build_role_row
+
+        def raise_for_bad(iam_client, role):
+            if role.get("RoleName") == "bad-role":
+                raise KeyError("SomeUnexpectedField")
+            return original(iam_client, role)
+
+        monkeypatch.setattr(iam_export, "_build_role_row", raise_for_bad)
+
+        result = collect_iam_role_information()
+
+        names = {row["Role Name"] for row in result}
+        assert "good-role" in names, "healthy role was lost when a sibling failed"
+        assert "bad-role" not in names, "malformed role should have been skipped"
+
+    @mock_aws
+    def test_roles_account_scope_failure_raises_not_empty(self, monkeypatch):
+        """An account-scope API failure must propagate, not collapse to []."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListRoles",
+            )
+
+        monkeypatch.setattr(iam_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_iam_role_information()
+
+    # -- Managed policies --------------------------------------------------
+
+    @mock_aws
+    def test_malformed_managed_policy_is_skipped_not_fatal(self, monkeypatch):
+        """One policy that fails to process must not discard the others."""
+        iam = boto3.client("iam", region_name=REGION)
+        policy_doc = (
+            '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", '
+            '"Action": "s3:GetObject", "Resource": "*"}]}'
+        )
+        iam.create_policy(PolicyName="good-policy", PolicyDocument=policy_doc)
+        iam.create_policy(PolicyName="bad-policy", PolicyDocument=policy_doc)
+
+        original = iam_export.process_managed_policy
+
+        def raise_for_bad(iam_client, policy, policy_type):
+            if policy.get("PolicyName") == "bad-policy":
+                raise KeyError("SomeUnexpectedField")
+            return original(iam_client, policy, policy_type)
+
+        monkeypatch.setattr(iam_export, "process_managed_policy", raise_for_bad)
+
+        iam_client = boto3.client("iam", region_name=REGION)
+        result = collect_managed_policies(iam_client)
+
+        names = {row["Policy Name"] for row in result}
+        assert "good-policy" in names, "healthy policy was lost when a sibling failed"
+        assert "bad-policy" not in names, "malformed policy should have been skipped"
+
+    @mock_aws
+    def test_managed_policies_account_scope_failure_raises_not_empty(self, monkeypatch):
+        """An account-scope API failure must propagate, not collapse to []."""
+        iam_client = boto3.client("iam", region_name=REGION)
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListPolicies",
+            )
+
+        monkeypatch.setattr(iam_client, "get_paginator", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_managed_policies(iam_client)
+
+    # -- Inline policies -----------------------------------------------------
+
+    @mock_aws
+    def test_inline_policies_account_scope_failure_raises_not_empty(self, monkeypatch):
+        """An account-scope API failure must propagate, not collapse to []."""
+        iam_client = boto3.client("iam", region_name=REGION)
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListUsers",
+            )
+
+        monkeypatch.setattr(iam_client, "get_paginator", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_inline_policies(iam_client)

--- a/tests/test_exporters/test_iam_identity_center_export.py
+++ b/tests/test_exporters/test_iam_identity_center_export.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for iam_identity_center_export.py.
+
+Covers:
+- get_identity_center_instance() — "not enabled" vs "API failure" distinction
+- collect_identity_center_users() — account-scope collection
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import iam_identity_center_export  # noqa: E402
+from iam_identity_center_export import (  # noqa: E402
+    collect_identity_center_users,
+    get_identity_center_instance,
+)
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class TestGetIdentityCenterInstance:
+    """Tests for get_identity_center_instance()."""
+
+    @mock_aws
+    def test_instance_is_discovered(self):
+        """The moto-provisioned default Identity Center instance is returned."""
+        instance_arn, identity_store_id = get_identity_center_instance()
+        assert instance_arn is not None
+        assert identity_store_id is not None
+        assert instance_arn.startswith("arn:")
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the account-scope silent-collection-failure fix
+    (07.15.2026 audit / 07.16.2026 blast-radius sweep). IAM Identity Center is
+    account-scope (not multi-region): a collection error must raise so the
+    caller can record a FAILED scope, and IAM Identity Center being genuinely
+    "not enabled" in an account must never be conflated with an API failure.
+    See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_user_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One user record that fails to process must not discard the whole
+        account's results — the healthy user is still collected.
+        """
+        instance_arn, identity_store_id = get_identity_center_instance()
+
+        identitystore = boto3.client("identitystore", region_name=REGION)
+        identitystore.create_user(
+            IdentityStoreId=identity_store_id,
+            UserName="good-user",
+            DisplayName="Good User",
+            Name={"GivenName": "Good", "FamilyName": "User"},
+            Emails=[{"Value": "good-user@example.com", "Primary": True}],
+        )
+        identitystore.create_user(
+            IdentityStoreId=identity_store_id,
+            UserName="bad-user",
+            DisplayName="Bad User",
+            Name={"GivenName": "Bad", "FamilyName": "User"},
+            Emails=[{"Value": "bad-user@example.com", "Primary": True}],
+        )
+
+        original = iam_identity_center_export._build_identity_center_user_row
+
+        def raise_for_bad(identitystore_client, sso_admin_client, identity_store_id, instance_arn, user):
+            if user.get("UserName") == "bad-user":
+                raise KeyError("SomeMalformedField")
+            return original(identitystore_client, sso_admin_client, identity_store_id, instance_arn, user)
+
+        monkeypatch.setattr(
+            iam_identity_center_export, "_build_identity_center_user_row", raise_for_bad
+        )
+
+        result = collect_identity_center_users(identity_store_id, instance_arn)
+
+        names = {row["User Name"] for row in result}
+        assert "good-user" in names, "healthy user was lost when a sibling failed"
+        assert "bad-user" not in names, "malformed user should have been skipped"
+
+    @mock_aws
+    def test_collector_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        An account-scope API failure must propagate (so the caller can record
+        a FAILED scope) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListUsers",
+            )
+
+        monkeypatch.setattr(iam_identity_center_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_identity_center_users("d-fakestoreid", "arn:aws:sso:::instance/ssoins-fake")
+
+    @mock_aws
+    def test_no_instances_is_not_enabled_not_a_failure(self, monkeypatch):
+        """
+        A clean, valid API response with zero IAM Identity Center instances is
+        a legitimate account state ("not enabled") and must return (None,
+        None) WITHOUT raising — it must never be reported as a failed scope.
+        """
+
+        class _EmptyInstancesClient:
+            def list_instances(self):
+                return {"Instances": []}
+
+        monkeypatch.setattr(
+            iam_identity_center_export.utils,
+            "get_boto3_client",
+            lambda *args, **kwargs: _EmptyInstancesClient(),
+        )
+
+        instance_arn, identity_store_id = get_identity_center_instance()
+
+        assert instance_arn is None
+        assert identity_store_id is None
+
+    @mock_aws
+    def test_instance_discovery_api_failure_raises(self, monkeypatch):
+        """
+        An API failure during instance discovery (throttling, access denied,
+        etc.) must propagate rather than being conflated with "not enabled".
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+                "ListInstances",
+            )
+
+        monkeypatch.setattr(iam_identity_center_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_identity_center_instance()

--- a/tests/test_exporters/test_kms_export.py
+++ b/tests/test_exporters/test_kms_export.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for kms_export.py.
+
+Covers:
+- scan_kms_keys_in_region()
+- scan_kms_aliases_in_region()
+- scan_kms_grants_in_region()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import kms_export  # noqa: E402
+from kms_export import (  # noqa: E402
+    scan_kms_aliases_in_region,
+    scan_kms_grants_in_region,
+    scan_kms_keys_in_region,
+)
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class TestScanKmsKeysInRegion:
+    """Tests for scan_kms_keys_in_region()."""
+
+    @mock_aws
+    def test_created_key_appears_in_results(self):
+        """A newly created KMS key is returned by the collector."""
+        kms = boto3.client("kms", region_name=REGION)
+        created = kms.create_key(Description="test-key")
+        key_id = created["KeyMetadata"]["KeyId"]
+
+        result = scan_kms_keys_in_region(REGION, ACCOUNT_ID)
+
+        assert isinstance(result, list)
+        assert any(row["Key ID"] == key_id for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        kms = boto3.client("kms", region_name=REGION)
+        kms.create_key(Description="col-check-key")
+
+        result = scan_kms_keys_in_region(REGION, ACCOUNT_ID)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Key ID", "Key State", "Region", "Key Manager"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no customer-created KMS keys still returns a list."""
+        result = scan_kms_keys_in_region(REGION, ACCOUNT_ID)
+        assert isinstance(result, list)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 blast-radius audit: KMS collectors
+    swallowed region-level errors into empty lists, indistinguishable from a
+    genuinely empty region/account. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+    All three KMS collectors (keys, aliases, grants) are per-region top-level
+    scans -- each produces its own independent sheet -- so all three are
+    treated as scope-level collectors here and must raise on a region-level
+    failure. Per-item processing (a single key's metadata, a single alias, a
+    single key's grants) is guarded separately and degrades gracefully.
+    """
+
+    @mock_aws
+    def test_malformed_key_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One key that fails to process must not discard the whole region's
+        results -- the healthy key is still collected.
+        """
+        kms = boto3.client("kms", region_name=REGION)
+        good = kms.create_key(Description="good-key")["KeyMetadata"]["KeyId"]
+        bad = kms.create_key(Description="bad-key")["KeyMetadata"]["KeyId"]
+
+        original = kms_export._build_key_row
+
+        def raise_for_bad(kms_client, key, region):
+            if key.get("KeyId") == bad:
+                raise KeyError("SomeUnexpectedField")
+            return original(kms_client, key, region)
+
+        monkeypatch.setattr(kms_export, "_build_key_row", raise_for_bad)
+
+        result = scan_kms_keys_in_region(REGION, ACCOUNT_ID)
+
+        ids = {row["Key ID"] for row in result}
+        assert good in ids, "healthy key was lost when a sibling failed"
+        assert bad not in ids, "malformed key should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure while listing keys must propagate (so the
+        caller can record a FAILED region) rather than being swallowed into
+        an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListKeys",
+            )
+
+        monkeypatch.setattr(kms_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_kms_keys_in_region(REGION, ACCOUNT_ID)
+
+    @mock_aws
+    def test_alias_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        scan_kms_aliases_in_region is also a per-region top-level collector
+        (its own independent list_aliases scan) -- a region-level failure
+        must propagate rather than collapse into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListAliases",
+            )
+
+        monkeypatch.setattr(kms_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_kms_aliases_in_region(REGION)
+
+    @mock_aws
+    def test_grant_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        scan_kms_grants_in_region's initial key listing is also a per-region
+        top-level operation -- a failure there must propagate rather than
+        collapse into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListKeys",
+            )
+
+        monkeypatch.setattr(kms_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_kms_grants_in_region(REGION)
+
+    @mock_aws
+    def test_grant_per_key_failure_degrades_gracefully(self, monkeypatch):
+        """
+        Unlike the region-level key/alias listing, a single key's grants
+        failing to list is per-item enrichment scoped to that one key -- it
+        must be logged and skipped, not raised, so the rest of the region's
+        grants are still collected.
+        """
+        kms = boto3.client("kms", region_name=REGION)
+        good_key = kms.create_key(Description="good-key")["KeyMetadata"]["KeyId"]
+        bad_key = kms.create_key(Description="bad-key")["KeyMetadata"]["KeyId"]
+
+        real_client = boto3.client("kms", region_name=REGION)
+
+        class GrantFailureClient:
+            """Proxies a real KMS client but fails list_grants for one key."""
+
+            def __init__(self, real, bad_key_id):
+                self._real = real
+                self._bad_key_id = bad_key_id
+
+            def get_paginator(self, operation_name):
+                if operation_name == "list_grants":
+                    real_paginator = self._real.get_paginator("list_grants")
+                    bad_key_id = self._bad_key_id
+
+                    class _Wrapped:
+                        def paginate(self, **kwargs):
+                            if kwargs.get("KeyId") == bad_key_id:
+                                raise botocore.exceptions.ClientError(
+                                    {
+                                        "Error": {
+                                            "Code": "NotFoundException",
+                                            "Message": "boom",
+                                        }
+                                    },
+                                    "ListGrants",
+                                )
+                            return real_paginator.paginate(**kwargs)
+
+                    return _Wrapped()
+                return self._real.get_paginator(operation_name)
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        monkeypatch.setattr(
+            kms_export.utils,
+            "get_boto3_client",
+            lambda *args, **kwargs: GrantFailureClient(real_client, bad_key),
+        )
+
+        # Must not raise -- per-key grant failures degrade gracefully.
+        result = scan_kms_grants_in_region(REGION)
+
+        assert isinstance(result, list)
+        assert all(row["Key ID"] != bad_key for row in result)
+        _ = good_key  # good_key had no grants created; presence isn't asserted

--- a/tests/test_exporters/test_lambda_export.py
+++ b/tests/test_exporters/test_lambda_export.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for lambda_export.py.
+
+Covers:
+- collect_lambda_functions_for_region()
+"""
+
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import lambda_export  # noqa: E402
+from lambda_export import collect_lambda_functions_for_region  # noqa: E402
+
+REGION = "us-east-1"
+ROLE_NAME = "test-lambda-role"
+
+_LAMBDA_TRUST_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
+
+
+def _lambda_role_arn():
+    """Create (or reuse) an IAM role Lambda can assume, and return its ARN."""
+    iam = boto3.client("iam", region_name=REGION)
+    try:
+        response = iam.get_role(RoleName=ROLE_NAME)
+    except botocore.exceptions.ClientError:
+        response = iam.create_role(
+            RoleName=ROLE_NAME,
+            AssumeRolePolicyDocument=_LAMBDA_TRUST_POLICY,
+        )
+    return response["Role"]["Arn"]
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _zip_bytes():
+    """Build a minimal in-memory Lambda deployment package."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("lambda_function.py", "def handler(event, context):\n    return event\n")
+    buf.seek(0)
+    return buf.read()
+
+
+def _create_function(client, name):
+    client.create_function(
+        FunctionName=name,
+        Runtime="python3.12",
+        Role=_lambda_role_arn(),
+        Handler="lambda_function.handler",
+        Code={"ZipFile": _zip_bytes()},
+        Description="test function",
+        Timeout=30,
+        MemorySize=128,
+        Publish=True,
+    )
+
+
+class TestCollectLambdaFunctionsForRegion:
+    """Tests for collect_lambda_functions_for_region()."""
+
+    @mock_aws
+    def test_created_function_appears_in_results(self):
+        """A newly created Lambda function is returned by the collector."""
+        client = boto3.client("lambda", region_name=REGION)
+        _create_function(client, "test-function")
+
+        result = collect_lambda_functions_for_region(REGION)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert any(row["Function Name"] == "test-function" for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        client = boto3.client("lambda", region_name=REGION)
+        _create_function(client, "col-check-fn")
+
+        result = collect_lambda_functions_for_region(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Function Name", "Runtime", "Region", "Handler"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_runtime_is_preserved(self):
+        """The runtime from the created function appears in results."""
+        client = boto3.client("lambda", region_name=REGION)
+        _create_function(client, "runtime-check-fn")
+
+        result = collect_lambda_functions_for_region(REGION)
+
+        row = next(r for r in result if r["Function Name"] == "runtime-check-fn")
+        assert "python3.12" in row["Runtime"]
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        """Region with no Lambda functions returns an empty list."""
+        result = collect_lambda_functions_for_region(REGION)
+        assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 audits: exporters
+    silently lost data because a collection error was swallowed to an empty
+    list, indistinguishable from a genuinely empty region. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One function that fails to process must not discard the whole
+        region's results — the healthy function is still collected.
+        """
+        client = boto3.client("lambda", region_name=REGION)
+        _create_function(client, "good-fn")
+        _create_function(client, "bad-fn")
+
+        original = lambda_export._build_function_row
+
+        def raise_for_bad(func, region):
+            if func.get("FunctionName") == "bad-fn":
+                raise KeyError("SomeUnexpectedField")
+            return original(func, region)
+
+        monkeypatch.setattr(lambda_export, "_build_function_row", raise_for_bad)
+
+        result = collect_lambda_functions_for_region(REGION)
+
+        names = {row["Function Name"] for row in result}
+        assert "good-fn" in names, "healthy function was lost when a sibling failed"
+        assert "bad-fn" not in names, "malformed function should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListFunctions",
+            )
+
+        monkeypatch.setattr(lambda_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_lambda_functions_for_region(REGION)

--- a/tests/test_exporters/test_rds_export.py
+++ b/tests/test_exporters/test_rds_export.py
@@ -153,22 +153,3 @@ class TestSilentCollectionFailureRegression:
 
         with pytest.raises(botocore.exceptions.ClientError):
             get_rds_instances(REGION)
-
-    def test_write_failure_marker_records_failed_regions(self, monkeypatch, tmp_path):
-        """The failure marker names each failed region and warns against treating
-        the export as complete."""
-
-        monkeypatch.setattr(
-            rds_export.utils, "get_output_filepath", lambda name: tmp_path / name
-        )
-
-        marker = rds_export.write_failure_marker(
-            "ACME-PROD",
-            [("us-east-1", "Throttling: Rate exceeded"), ("us-gov-west-1", "KeyError")],
-        )
-
-        assert marker is not None
-        content = (tmp_path / Path(marker).name).read_text()
-        assert "us-east-1" in content
-        assert "us-gov-west-1" in content
-        assert "FAILED" in content

--- a/tests/test_exporters/test_route_tables_export.py
+++ b/tests/test_exporters/test_route_tables_export.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for route_tables_export.py.
+
+Covers:
+- get_route_tables()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import route_tables_export  # noqa: E402
+from route_tables_export import get_route_tables  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_route_table(ec2, vpc_id, name):
+    """Create a route table tagged with a Name for identification in tests."""
+    response = ec2.create_route_table(
+        VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "route-table",
+                "Tags": [{"Key": "Name", "Value": name}],
+            }
+        ],
+    )
+    return response["RouteTable"]["RouteTableId"]
+
+
+class TestGetRouteTables:
+    """Tests for get_route_tables()."""
+
+    @mock_aws
+    def test_created_route_table_appears_in_results(self):
+        """A newly created route table is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        vpc_id = vpc["Vpc"]["VpcId"]
+        rt_id = _create_route_table(ec2, vpc_id, "test-rt")
+
+        result = get_route_tables(REGION)
+
+        assert isinstance(result, list)
+        assert any(row["Route Table ID"] == rt_id for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        vpc_id = vpc["Vpc"]["VpcId"]
+        _create_route_table(ec2, vpc_id, "col-check-rt")
+
+        result = get_route_tables(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Route Table ID", "VPC ID", "Region", "Route Destination", "Target"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_region_with_no_custom_route_tables_still_returns_a_list(self):
+        """
+        A region with no explicitly-created route tables still returns a list
+        (moto provisions a default VPC with a main route table), not None.
+        """
+        result = get_route_tables(REGION)
+        assert isinstance(result, list)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit: exporter data silently lost
+    because a collection error was swallowed to an empty list, indistinguishable
+    from a genuinely empty region. See
+    .collab/audit/07.15.2026-rds-silent-collection-failure.md and
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One route table that fails to process must not discard the whole
+        region's results — the healthy route table is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        vpc_id = vpc["Vpc"]["VpcId"]
+        good_rt_id = _create_route_table(ec2, vpc_id, "good-rt")
+        bad_rt_id = _create_route_table(ec2, vpc_id, "bad-rt")
+
+        original = route_tables_export._build_route_entries
+
+        def raise_for_bad(route_table, region):
+            if route_table.get("RouteTableId") == bad_rt_id:
+                raise KeyError("SomeMalformedField")
+            return original(route_table, region)
+
+        monkeypatch.setattr(route_tables_export, "_build_route_entries", raise_for_bad)
+
+        result = get_route_tables(REGION)
+
+        ids = {row["Route Table ID"] for row in result}
+        assert good_rt_id in ids, "healthy route table was lost when a sibling failed"
+        assert bad_rt_id not in ids, "malformed route table should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeRouteTables",
+            )
+
+        monkeypatch.setattr(route_tables_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_route_tables(REGION)

--- a/tests/test_exporters/test_s3_export.py
+++ b/tests/test_exporters/test_s3_export.py
@@ -10,10 +10,12 @@ import sys
 from pathlib import Path
 
 import boto3
+import botocore
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import s3_export  # noqa: E402
 from s3_export import get_s3_buckets_info  # noqa: E402
 
 REGION = "us-east-1"
@@ -37,9 +39,10 @@ class TestGetS3BucketsInfo:
         s3 = boto3.client("s3", region_name=REGION)
         s3.create_bucket(Bucket="my-test-bucket-abc123")
 
-        result = get_s3_buckets_info()
+        result, failed = get_s3_buckets_info()
 
         assert isinstance(result, list)
+        assert failed == []
         assert len(result) >= 1
         assert any(row["Bucket Name"] == "my-test-bucket-abc123" for row in result)
 
@@ -49,8 +52,9 @@ class TestGetS3BucketsInfo:
         s3 = boto3.client("s3", region_name=REGION)
         s3.create_bucket(Bucket="col-check-bucket-xyz")
 
-        result = get_s3_buckets_info()
+        result, failed = get_s3_buckets_info()
 
+        assert failed == []
         assert len(result) >= 1
         row = result[0]
         for col in ("Bucket Name", "Region", "Creation Date"):
@@ -63,12 +67,79 @@ class TestGetS3BucketsInfo:
         s3.create_bucket(Bucket="objects-bucket-test1")
         s3.put_object(Bucket="objects-bucket-test1", Key="file.txt", Body=b"hello")
 
-        result = get_s3_buckets_info()
+        result, failed = get_s3_buckets_info()
 
+        assert failed == []
         assert any(row["Bucket Name"] == "objects-bucket-test1" for row in result)
 
     @mock_aws
     def test_empty_account_returns_empty_list(self):
-        """Account with no S3 buckets returns an empty list."""
-        result = get_s3_buckets_info()
+        """Account with no S3 buckets returns an empty list and no failures."""
+        result, failed = get_s3_buckets_info()
         assert result == []
+        assert failed == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 audit: exporters could silently lose
+    data because a collection error was swallowed into an empty result,
+    indistinguishable from a genuinely empty account. See
+    .collab/audit/07.15.2026-rds-silent-collection-failure.md and the
+    07.16.2026 blast-radius sweep.
+
+    S3 is structured differently from the region-scanned exporters: buckets
+    (not regions) are the unit of collection, and get_s3_buckets_info() runs
+    its own internal per-bucket loop. So failures are tracked per-bucket and
+    returned as (buckets_info, failed_buckets) instead of via
+    scan_regions_concurrent(collect_failures=True).
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One bucket that fails to process must not discard the other buckets'
+        results — the healthy bucket is still collected, and the bad one is
+        reported back via failed_buckets instead of raising.
+        """
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket="good-bucket")
+        s3.create_bucket(Bucket="bad-bucket")
+
+        original = s3_export._build_bucket_row
+
+        def raise_for_bad(bucket, *args, **kwargs):
+            if bucket.get("Name") == "bad-bucket":
+                raise KeyError("SomeUnexpectedField")
+            return original(bucket, *args, **kwargs)
+
+        monkeypatch.setattr(s3_export, "_build_bucket_row", raise_for_bad)
+
+        result, failed = get_s3_buckets_info()
+
+        names = {row["Bucket Name"] for row in result}
+        assert "good-bucket" in names, "healthy bucket was lost when a sibling failed"
+        assert "bad-bucket" not in names, "malformed bucket should have been skipped"
+
+        failed_names = {name for name, _ in failed}
+        assert "bad-bucket" in failed_names, "bad bucket should be reported in failed_buckets"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A top-level API failure (e.g. list_buckets throttling, or client
+        creation) must propagate (so the caller can distinguish a failed
+        collection from an empty account) rather than being swallowed into an
+        empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListBuckets",
+            )
+
+        monkeypatch.setattr(s3_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_s3_buckets_info()

--- a/tests/test_exporters/test_security_groups_export.py
+++ b/tests/test_exporters/test_security_groups_export.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for security_groups_export.py.
+
+Covers:
+- get_security_group_rules()
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import security_groups_export  # noqa: E402
+from security_groups_export import get_security_group_rules  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_sg(ec2, name, vpc_id, with_ingress=True):
+    sg = ec2.create_security_group(GroupName=name, Description=f"{name} desc", VpcId=vpc_id)
+    if with_ingress:
+        ec2.authorize_security_group_ingress(
+            GroupId=sg["GroupId"],
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+    return sg["GroupId"]
+
+
+class TestGetSecurityGroupRules:
+    """Tests for get_security_group_rules()."""
+
+    @mock_aws
+    def test_created_sg_appears_in_results(self):
+        """A newly created security group with a rule is returned by the collector."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+        sg_id = _create_sg(ec2, "test-sg", vpc["VpcId"])
+
+        result = get_security_group_rules(REGION)
+
+        assert isinstance(result, list)
+        assert any(row["SG ID"] == sg_id for row in result)
+
+    @mock_aws
+    def test_result_contains_expected_columns(self):
+        """Each row contains the expected column keys."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+        _create_sg(ec2, "col-check-sg", vpc["VpcId"])
+
+        result = get_security_group_rules(REGION)
+
+        assert len(result) >= 1
+        row = result[0]
+        for col in ("Rule ID", "SG Name", "SG ID", "VPC", "Direction", "Region"):
+            assert col in row, f"Missing column: {col}"
+
+    @mock_aws
+    def test_sg_with_no_rules_gets_placeholder_row(self):
+        """A security group with no ingress/egress-only-default rules still yields a row."""
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+        sg_id = _create_sg(ec2, "no-ingress-sg", vpc["VpcId"], with_ingress=False)
+
+        result = get_security_group_rules(REGION)
+
+        # moto always gives a default egress rule, so this SG should have an
+        # Outbound row rather than the N/A placeholder — just confirm it appears.
+        assert any(row["SG ID"] == sg_id for row in result)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the silent-collection-failure sweep (07.16.2026 audit):
+    a collection error was swallowed to an empty list, indistinguishable from a
+    genuinely empty region. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One security group that fails to process must not discard the whole
+        region's results — the healthy security group is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+        good_id = _create_sg(ec2, "good-sg", vpc["VpcId"])
+        bad_id = _create_sg(ec2, "bad-sg", vpc["VpcId"])
+
+        original = security_groups_export._build_sg_rule_rows
+
+        def raise_for_bad(sg, *args, **kwargs):
+            if sg.get("GroupId") == bad_id:
+                raise KeyError("SomeMalformedField")
+            return original(sg, *args, **kwargs)
+
+        monkeypatch.setattr(security_groups_export, "_build_sg_rule_rows", raise_for_bad)
+
+        result = get_security_group_rules(REGION)
+
+        ids = {row["SG ID"] for row in result}
+        assert good_id in ids, "healthy security group was lost when a sibling failed"
+        assert bad_id not in ids, "malformed security group should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeSecurityGroups",
+            )
+
+        monkeypatch.setattr(security_groups_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_security_group_rules(REGION)

--- a/tests/test_exporters/test_vpc_export.py
+++ b/tests/test_exporters/test_vpc_export.py
@@ -10,11 +10,16 @@ import sys
 from pathlib import Path
 
 import boto3
+import botocore
 import pytest
 from moto import mock_aws
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
-from vpc_data_export import collect_vpc_subnet_data_for_region  # noqa: E402
+import vpc_data_export  # noqa: E402
+from vpc_data_export import (  # noqa: E402
+    collect_vpc_data_for_region,
+    collect_vpc_subnet_data_for_region,
+)
 
 REGION = "us-east-1"
 
@@ -81,3 +86,55 @@ class TestCollectVpcSubnetDataForRegion:
         result = collect_vpc_subnet_data_for_region(REGION)
 
         assert all(row["Region"] == REGION for row in result)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 blast-radius audit: VPC collectors
+    swallowed region-level errors into an empty list, indistinguishable from
+    a genuinely empty region. See
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One VPC that fails to process must not discard the whole region's
+        results — the healthy VPC is still collected.
+        """
+        ec2 = boto3.client("ec2", region_name=REGION)
+        good_vpc_id = ec2.create_vpc(CidrBlock="10.10.0.0/16")["Vpc"]["VpcId"]
+        bad_vpc_id = ec2.create_vpc(CidrBlock="10.11.0.0/16")["Vpc"]["VpcId"]
+
+        original = vpc_data_export._build_vpc_row
+
+        def raise_for_bad(vpc, *args, **kwargs):
+            if vpc.get("VpcId") == bad_vpc_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(vpc, *args, **kwargs)
+
+        monkeypatch.setattr(vpc_data_export, "_build_vpc_row", raise_for_bad)
+
+        result = collect_vpc_data_for_region(REGION)
+
+        ids = {row["VPC ID"] for row in result}
+        assert good_vpc_id in ids, "healthy VPC was lost when a sibling failed"
+        assert bad_vpc_id not in ids, "malformed VPC should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeVpcs",
+            )
+
+        monkeypatch.setattr(vpc_data_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_vpc_data_for_region(REGION)

--- a/utils.py
+++ b/utils.py
@@ -2524,7 +2524,8 @@ def scan_regions_concurrent(
     max_workers: Optional[int] = None,
     show_progress: Optional[bool] = True,
     fallback_on_error: Optional[bool] = None,
-) -> list[Any]:
+    collect_failures: bool = False,
+) -> Any:
     """
     Scan multiple AWS regions concurrently with automatic fallback to sequential.
 
@@ -2540,15 +2541,31 @@ def scan_regions_concurrent(
         max_workers: Maximum concurrent workers (default: from config or 4)
         show_progress: Show progress as regions complete (default: True)
         fallback_on_error: Fallback to sequential on errors (default: from config or True)
+        collect_failures: When True, also return the list of regions whose
+                      scan_function raised. **Requires scan_function to raise on
+                      failure** rather than swallow-and-return-empty — otherwise a
+                      failed region is silently indistinguishable from an empty one
+                      (the silent-data-loss bug; see Issue #233). Default False
+                      preserves the legacy return type for existing callers.
 
     Returns:
-        list: List of results from all regions
+        - When ``collect_failures`` is False (default): ``list`` of results from
+          all regions (legacy behavior, unchanged).
+        - When ``collect_failures`` is True: a ``(results, failed_regions)`` tuple,
+          where ``failed_regions`` is a list of ``(region, error_message)`` tuples
+          for regions whose scan raised. ``results`` holds only the regions that
+          succeeded.
 
     Example:
         >>> def collect_region_instances(region):
         ...     ec2 = get_boto3_client('ec2', region_name=region)
         ...     return ec2.describe_instances()['Reservations']
         >>> results = scan_regions_concurrent(regions, collect_region_instances)
+        >>> # Failure-aware form (scan_function must raise on error):
+        >>> results, failed = scan_regions_concurrent(
+        ...     regions, collect_region_instances, collect_failures=True)
+        >>> if failed:
+        ...     utils.report_collection_failures(account, "ec2", failed)
 
     Note:
         - Automatically loads settings from config.json (advanced_settings)
@@ -2570,7 +2587,9 @@ def scan_regions_concurrent(
         logging.getLogger(__name__).info(
             "Concurrent scanning disabled in config, using sequential scanning"
         )
-        return _scan_regions_sequential(regions, scan_function, show_progress)
+        return _scan_regions_sequential(
+            regions, scan_function, show_progress, collect_failures=collect_failures
+        )
 
     try:
         logging.getLogger(__name__).info(
@@ -2578,6 +2597,7 @@ def scan_regions_concurrent(
         )
 
         results = []
+        failed: list[tuple[str, str]] = []
         completed = 0
         total = len(regions)
         error_count = 0
@@ -2604,6 +2624,7 @@ def scan_regions_concurrent(
 
                 except Exception as e:
                     error_count += 1
+                    failed.append((region, str(e)))
                     logging.getLogger(__name__).error("Error scanning region %s: %s", region, e)
 
                     if fallback_on_error and error_count >= max(2, total // 2):
@@ -2616,7 +2637,7 @@ def scan_regions_concurrent(
 
                     completed += 1
 
-        return results
+        return (results, failed) if collect_failures else results
 
     except ConcurrentScanningError:
         if fallback_on_error:
@@ -2629,7 +2650,11 @@ def scan_regions_concurrent(
             logging.getLogger(__name__).warning(
                 "To disable concurrent scanning, run: python advanced_settings.py"
             )
-            return _scan_regions_sequential(regions, scan_function, show_progress)
+            # The sequential retry re-runs every region, so its (results, failed)
+            # supersede the partial concurrent tallies above.
+            return _scan_regions_sequential(
+                regions, scan_function, show_progress, collect_failures=collect_failures
+            )
         else:
             raise
 
@@ -2641,7 +2666,9 @@ def scan_regions_concurrent(
             logging.getLogger(__name__).warning(
                 "To disable concurrent scanning, run: python advanced_settings.py"
             )
-            return _scan_regions_sequential(regions, scan_function, show_progress)
+            return _scan_regions_sequential(
+                regions, scan_function, show_progress, collect_failures=collect_failures
+            )
         else:
             raise
 
@@ -2650,7 +2677,8 @@ def _scan_regions_sequential(
     regions: list[str],
     scan_function: Callable[[str], Any],
     show_progress: bool = True,
-) -> list[Any]:
+    collect_failures: bool = False,
+) -> Any:
     """
     Fallback: Scan regions sequentially (one at a time).
 
@@ -2661,13 +2689,16 @@ def _scan_regions_sequential(
         regions: List of AWS regions to scan
         scan_function: Function that takes a region and returns data
         show_progress: Show progress as regions complete
+        collect_failures: When True, return ``(results, failed_regions)`` instead
+            of just ``results``; see :func:`scan_regions_concurrent`.
 
     Returns:
-        list: List of results from all regions
+        list, or ``(results, failed_regions)`` when ``collect_failures`` is True.
     """
     logging.getLogger(__name__).info("Scanning %d region(s) sequentially", len(regions))
 
     results = []
+    failed: list[tuple[str, str]] = []
     total = len(regions)
 
     for i, region in enumerate(regions, 1):
@@ -2679,9 +2710,92 @@ def _scan_regions_sequential(
             results.append(result)
 
         except Exception as e:
+            failed.append((region, str(e)))
             logging.getLogger(__name__).error("Error scanning region %s: %s", region, e)
 
-    return results
+    return (results, failed) if collect_failures else results
+
+
+def write_failure_marker(
+    account_name: str,
+    resource_type: str,
+    failed_scopes: list,
+) -> Optional[str]:
+    """
+    Write a ``{ACCOUNT}-{resource_type}-FAILED-{date}.txt`` marker into the output
+    directory recording which scopes (regions or account-level steps) failed to
+    collect.
+
+    This is the visible signal a downstream consumer needs to tell a *failed*
+    export apart from a *genuinely empty* account. Without it, a scope that errors
+    is indistinguishable from a scope that legitimately has no resources — the
+    silent-data-loss bug (Issue #231 / #233).
+
+    Args:
+        account_name: AWS account name (used in the filename).
+        resource_type: Resource slug matching the export filename (e.g.
+            ``"rds-instances"``, ``"ec2"``, ``"vpc"``).
+        failed_scopes: List of ``(scope, error_message)`` tuples, where ``scope``
+            is a region name or a logical collection step.
+
+    Returns:
+        Path to the marker file as a string, or ``None`` if it could not be
+        written (marker-writing never masks the underlying failure).
+    """
+    try:
+        today = get_export_date()
+        marker_name = f"{account_name}-{resource_type}-FAILED-{today}.txt"
+        marker_path = get_output_filepath(marker_name)
+        lines = [
+            f"{resource_type.upper()} EXPORT FAILED FOR ONE OR MORE SCOPES",
+            f"Account: {account_name}",
+            f"Timestamp: {get_log_timestamp()}",
+            "",
+            "The scopes below raised an error during collection. Their data is "
+            "MISSING or INCOMPLETE in any exported spreadsheet. Do NOT treat a "
+            "missing file/rows for these scopes as 'no resources' — re-run the export.",
+            "",
+        ]
+        for scope, error in failed_scopes:
+            lines.append(f"  - {scope}: {error}")
+        marker_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        log_error(f"Wrote failure marker: {marker_path}")
+        return str(marker_path)
+    except Exception as e:
+        # Never let marker-writing itself mask the underlying failure.
+        log_error("Could not write failure marker", e)
+        return None
+
+
+def report_collection_failures(
+    account_name: str,
+    resource_type: str,
+    failed_scopes: list,
+) -> Optional[str]:
+    """
+    Log a failure summary and write a failure marker for a partially-failed export.
+
+    Shared by exporters so a *failed* collection is never silently collapsed into
+    "no resources." Does NOT ``sys.exit`` or ``print`` — deciding the process exit
+    code and any user-facing message is the caller's (CLI-layer) responsibility.
+
+    Args:
+        account_name: AWS account name.
+        resource_type: Resource slug matching the export filename.
+        failed_scopes: List of ``(scope, error_message)`` tuples.
+
+    Returns:
+        The marker path (str) if failures were reported, else ``None`` when
+        ``failed_scopes`` is empty.
+    """
+    if not failed_scopes:
+        return None
+    scopes = ", ".join(str(scope) for scope, _ in failed_scopes)
+    log_error(
+        f"{resource_type}: collection FAILED for {len(failed_scopes)} scope(s): "
+        f"{scopes}. Exported data is INCOMPLETE."
+    )
+    return write_failure_marker(account_name, resource_type, failed_scopes)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #233 (blast-radius follow-up to #231/#232). First phase of the phased rollout: **shared plumbing + the 12 Tier-1 (near-universal) exporters**.

## Root cause recap
96/102 exporters swallow a collection error into an empty result; `main()` can't tell a *failed* collection from a *genuinely empty* account → silent data loss (no file, or a zero-row sheet). Full report: `.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md`.

## Shared plumbing (`utils.py`)
- **`scan_regions_concurrent(collect_failures=True)`** → returns `(results, failed_regions)`, surfacing the per-region exceptions it already caught instead of dropping them. Default `False` keeps the legacy `list` return — **all 60 existing callers unaffected**.
- **`write_failure_marker()` / `report_collection_failures()`** → standard `{ACCOUNT}-{resource_type}-FAILED-{date}.txt` marker + logged summary. No `print()`/`sys.exit` in the library layer (Issue #171).
- `rds_export.py` migrated onto the shared helpers (drops its local marker copy).

## Tier-1 exporters fixed (12)
`vpc_data` · `security_groups` · `ebs_volumes` · `ebs_snapshots` · `ec2` · `elb` · `iam` · `iam_identity_center` · `s3` · `route_tables` · `kms` · `lambda`

Each one:
1. **Stops swallowing at the scope collector** (region- or account-level) so failures propagate; per-**field** helpers keep degrading gracefully.
2. **Guards per-item processing** (`try/except + continue`, `.get()` defaults) — one malformed resource is skipped, not fatal to the scope.
3. **Exports partial data, writes the FAILED marker, exits non-zero** when any scope failed; a genuinely empty account stays a plain warning with no marker.

Account-scope scripts (`iam`, `iam_identity_center`) track failed collectors directly (no region scanner); `iam_identity_center` distinguishes "not enabled" from "failed."

## Bonus fix
`kms_export.py` called `scan_regions_concurrent(..., account_id=...)` — an invalid kwarg that would raise `TypeError` on **every** run. Rebound via a closure (kms export was already broken; now fixed + tested).

## Tests
Each script gains a `TestSilentCollectionFailureRegression` suite (malformed item skipped-not-fatal; scope API failure raises-not-empty), plus plumbing unit tests in `tests/sslib/test_concurrency.py`.

**Full suite: 767 passed, 2 skipped, 0 failed. `ruff` clean (py39).**

## Scope notes / follow-ups (tracked in #233)
- `elb`: `get_target_groups`/`get_listeners` are separate `scan_regions_concurrent` calls still swallowing — core LB data is protected; their sheets remain PARTIAL-class. Follow-up.
- `s3`: a *total* top-level `list_buckets` failure propagates to the `__main__` catch-all (logged + exit 1) rather than a marker — non-silent, but no marker for that specific case.
- Tier-2 (36 remaining VULNERABLE) and Tier-3 (48 PARTIAL) are subsequent phased PRs.

Does **not** touch `pyproject.toml`/`configure.py` (unrelated in-flight working-tree changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)