### PR TITLE
Fix main-menu root entry points refused by subprocess guard

### DIFF
--- a/stratusscan.py
+++ b/stratusscan.py
@@ -271,6 +271,13 @@ def ensure_directory_structure():
 
     return scripts_dir, output_dir
 
+
+# Root-level scripts (siblings of stratusscan.py, not under scripts/) that the
+# main menu is allowed to launch. Kept as an explicit allowlist so the CWE-78
+# containment guard in execute_script() can positively validate them by name.
+ROOT_ENTRY_POINT_SCRIPTS = frozenset({"configure.py", "smart_scan.py"})
+
+
 def execute_script(script_path):
     """
     Execute the selected export script.
@@ -285,21 +292,28 @@ def execute_script(script_path):
     script_name = script_path.name
 
     # Security guard (CWE-78 containment): script_path is built from a static
-    # menu of hardcoded exporter filenames, but validate positively before it
-    # ever reaches subprocess. Only an existing .py file located directly in
-    # this project's scripts/ directory may be executed — anything else is
-    # refused. Downstream execution uses the validated `resolved_path`.
-    scripts_dir = (Path(__file__).parent / "scripts").resolve()
+    # menu of hardcoded filenames, but validate positively before it ever
+    # reaches subprocess. Permit only (a) an existing .py file located directly
+    # in this project's scripts/ directory, or (b) one of the known root-level
+    # entry-point scripts the main menu launches (Configure, Service Discovery).
+    # Anything else is refused. Downstream execution uses `resolved_path`.
+    project_root = Path(__file__).parent.resolve()
+    scripts_dir = (project_root / "scripts").resolve()
     resolved_path = Path(script_path).resolve()
+    in_scripts_dir = resolved_path.parent == scripts_dir
+    is_root_entry_point = (
+        resolved_path.parent == project_root
+        and resolved_path.name in ROOT_ENTRY_POINT_SCRIPTS
+    )
     if (
-        resolved_path.parent != scripts_dir
+        not (in_scripts_dir or is_root_entry_point)
         or resolved_path.suffix != ".py"
         or not resolved_path.is_file()
     ):
         utils.log_error(
-            f"Refused to execute script outside exporter directory: {script_path}"
+            f"Refused to execute script outside the allowed set: {script_path}"
         )
-        print(f"Error: '{script_name}' is not a recognized exporter script; refusing to run.")
+        print(f"Error: '{script_name}' is not a recognized StratusScan script; refusing to run.")
         return False
 
     try:

--- a/tests/test_stratusscan_execute_guard.py
+++ b/tests/test_stratusscan_execute_guard.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for the CWE-78 containment guard in ``stratusscan.execute_script``.
+
+Background: PR #228 (Veracode remediation) added a subprocess-containment guard
+that only permitted targets located directly under ``scripts/``. That silently
+broke the two root-level menu entry points — ``[0] Configure StratusScan``
+(``configure.py``) and ``[1] Service Discovery`` (``smart_scan.py``) — which live
+at the project root, not under ``scripts/``. The guard refused them and the main
+menu just looped. These tests lock in that both legitimate root entry points are
+runnable while arbitrary / traversal paths stay refused.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import stratusscan
+
+PROJECT_ROOT = Path(stratusscan.__file__).resolve().parent
+
+
+def _run_guard(script_path):
+    """
+    Drive execute_script() far enough to exercise only the containment guard.
+
+    subprocess.run is mocked to a benign success so a target that PASSES the
+    guard returns True without actually spawning anything; a target that FAILS
+    the guard returns False before subprocess is ever reached.
+    """
+    class _Result:
+        returncode = 0
+
+    with patch("stratusscan.subprocess.run", return_value=_Result()) as mock_run, \
+         patch("stratusscan.clear_screen"):
+        result = stratusscan.execute_script(script_path)
+    return result, mock_run
+
+
+class TestRootEntryPointsAllowed:
+    """The two root-level menu entry points must pass the guard (the #228 regression)."""
+
+    @pytest.mark.parametrize("name", ["configure.py", "smart_scan.py"])
+    def test_root_entry_point_is_permitted(self, name):
+        target = PROJECT_ROOT / name
+        assert target.is_file(), f"expected root entry point {name} to exist"
+
+        result, mock_run = _run_guard(target)
+
+        assert result is True
+        mock_run.assert_called_once()
+
+    def test_allowlist_matches_menu_entry_points(self):
+        # Guard against drift: the allowlist should name exactly the root scripts
+        # the menu dispatches via execute_script().
+        assert set(stratusscan.ROOT_ENTRY_POINT_SCRIPTS) == {
+            "configure.py",
+            "smart_scan.py",
+        }
+
+
+class TestExporterScriptsAllowed:
+    """Normal exporters under scripts/ must still run."""
+
+    def test_scripts_dir_exporter_is_permitted(self):
+        target = PROJECT_ROOT / "scripts" / "ec2_export.py"
+        assert target.is_file()
+
+        result, mock_run = _run_guard(target)
+
+        assert result is True
+        mock_run.assert_called_once()
+
+
+class TestUnsafeTargetsRefused:
+    """Containment must hold: nothing outside the allowed set reaches subprocess."""
+
+    def test_traversal_root_script_name_is_refused(self, tmp_path):
+        # A file NAMED like an entry point but living elsewhere must not slip through.
+        decoy = tmp_path / "configure.py"
+        decoy.write_text("print('should never run')\n")
+
+        result, mock_run = _run_guard(decoy)
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_non_allowlisted_root_script_is_refused(self, tmp_path):
+        # A root-level .py that is not on the allowlist is refused even at the
+        # real project root name check — use a name that isn't an entry point.
+        target = PROJECT_ROOT / "utils.py"  # real root .py, but not an entry point
+        assert target.is_file()
+
+        result, mock_run = _run_guard(target)
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_nonexistent_scripts_target_is_refused(self):
+        target = PROJECT_ROOT / "scripts" / "does_not_exist_export.py"
+
+        result, mock_run = _run_guard(target)
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_non_py_suffix_is_refused(self, tmp_path):
+        target = tmp_path / "payload.sh"
+        target.write_text("echo nope\n")
+
+        result, mock_run = _run_guard(target)
+
+        assert result is False
+        mock_run.assert_not_called()


### PR DESCRIPTION
Closes #235.

## Problem
Selecting **[0] Configure StratusScan** or **[1] Service Discovery** from the main menu did nothing and looped back to the menu. Every exporter under `scripts/` still worked.

## Root cause
The CWE-78 subprocess-containment guard from PR #228 (`stratusscan.py:execute_script()`) only permitted targets **directly under `scripts/`**. Options [0] and [1] launch root-level scripts (`configure.py`, `smart_scan.py`) that are siblings of `stratusscan.py`, so the guard refused them on every call. Regression shipped with #228 on 07.15; not caught because the guard was only tested against exporter paths and traversal attempts.

## Fix
- Add an explicit `ROOT_ENTRY_POINT_SCRIPTS = frozenset({"configure.py", "smart_scan.py"})` allowlist.
- Guard now permits **either** an existing `.py` under `scripts/` **or** a root-level file whose name is on the allowlist. Traversal / arbitrary / non-`.py` / nonexistent targets remain refused — CWE-78 containment preserved.

## Tests
New `tests/test_stratusscan_execute_guard.py` (8 cases) drives the real `execute_script` with `subprocess.run` mocked:
- both root entry points permitted (the regression);
- a normal `scripts/` exporter permitted;
- a same-named decoy outside the project refused;
- a non-allowlisted root `.py` (`utils.py`) refused;
- nonexistent `scripts/` target refused;
- non-`.py` suffix refused.

Local: 8 passed, `ruff check` clean (py39 floor).

## Notes
Independent of the silent-collection / Tier work (#233/#234) — this is purely the #228 guard. Verified by the user: [0] and [1] were dead on current `dev`.