### PR TITLE
Silent collection failure: Tier-2a (compute & container exporters)

### DIFF
--- a/scripts/ami_export.py
+++ b/scripts/ami_export.py
@@ -52,10 +52,108 @@ except ImportError:
 args = utils.parse_script_args("Export Amazon Machine Images (AMIs) to Excel")
 
 
-@utils.aws_error_handler("Collecting AMIs from region", default_return=[])
+def _build_ami_row(ami: dict, region: str) -> dict[str, Any]:
+    """Build a single AMI export row from a describe_images response item."""
+    ami_id = ami.get('ImageId', '')
+    ami_name = ami.get('Name', 'N/A')
+    description = ami.get('Description', 'N/A')
+    state = ami.get('State', '')
+    creation_date = ami.get('CreationDate', 'N/A')
+
+    # Architecture
+    architecture = ami.get('Architecture', 'N/A')
+
+    # Virtualization type
+    virtualization_type = ami.get('VirtualizationType', 'N/A')
+
+    # Root device type and name
+    root_device_type = ami.get('RootDeviceType', 'N/A')
+    root_device_name = ami.get('RootDeviceName', 'N/A')
+
+    # Platform (Windows or blank for Linux)
+    platform = ami.get('Platform', 'Linux')
+    platform_details = ami.get('PlatformDetails', 'N/A')
+
+    # Public/Private
+    is_public = ami.get('Public', False)
+    visibility = 'Public' if is_public else 'Private'
+
+    # Image location
+    image_location = ami.get('ImageLocation', 'N/A')
+
+    # EBS snapshots (from block device mappings)
+    block_device_mappings = ami.get('BlockDeviceMappings', [])
+    snapshot_ids = []
+    total_volume_size = 0
+
+    for bdm in block_device_mappings:
+        ebs = bdm.get('Ebs', {})
+        if ebs:
+            snapshot_id = ebs.get('SnapshotId', '')
+            volume_size = ebs.get('VolumeSize', 0)
+            if snapshot_id:
+                snapshot_ids.append(snapshot_id)
+            total_volume_size += volume_size
+
+    snapshots_str = ', '.join(snapshot_ids) if snapshot_ids else 'N/A'
+
+    # ENA support
+    ena_support = ami.get('EnaSupport', False)
+
+    # Kernel and ramdisk IDs (older AMIs)
+    kernel_id = ami.get('KernelId', 'N/A')
+    ramdisk_id = ami.get('RamdiskId', 'N/A')
+
+    # Boot mode
+    boot_mode = ami.get('BootMode', 'N/A')
+
+    # Deprecation time
+    deprecation_time = ami.get('DeprecationTime', 'N/A')
+
+    # Tags
+    tags = ami.get('Tags', [])
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags if tag.get('Key') and 'Value' in tag}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    return {
+        'Region': region,
+        'AMI ID': ami_id,
+        'AMI Name': ami_name,
+        'State': state,
+        'Visibility': visibility,
+        'Architecture': architecture,
+        'Platform': platform,
+        'Platform Details': platform_details,
+        'Virtualization Type': virtualization_type,
+        'Root Device Type': root_device_type,
+        'Root Device Name': root_device_name,
+        'Total Volume Size (GB)': total_volume_size,
+        'Snapshot IDs': snapshots_str,
+        'ENA Support': ena_support,
+        'Boot Mode': boot_mode,
+        'Creation Date': creation_date,
+        'Deprecation Time': deprecation_time,
+        'Image Location': image_location,
+        'Kernel ID': kernel_id,
+        'Ramdisk ID': ramdisk_id,
+        'Description': description,
+        'Tags': tags_str
+    }
+
+
 def collect_amis_in_region(region: str, account_id: str) -> list[dict[str, Any]]:
     """
     Collect account-owned AMI information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no AMIs" (the silent-collection-
+    loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed AMIs are skipped (logged) rather than aborting the
+    whole region.
 
     Args:
         region: AWS region to scan
@@ -64,116 +162,60 @@ def collect_amis_in_region(region: str, account_id: str) -> list[dict[str, Any]]
     Returns:
         list: List of dictionaries with AMI information
     """
-    region_amis = []
-
     if not utils.is_aws_region(region):
         utils.log_error(f"Skipping invalid AWS region: {region}")
         return []
 
     print(f"  Processing region: {region}")
 
-    try:
-        ec2_client = utils.get_boto3_client('ec2', region_name=region)
+    ec2_client = utils.get_boto3_client('ec2', region_name=region)
 
-        # Get AMIs owned by this account
-        paginator = ec2_client.get_paginator('describe_images')
-        amis = []
-        for page in paginator.paginate(Owners=['self']):
-            amis.extend(page.get('Images', []))
+    # Get AMIs owned by this account
+    paginator = ec2_client.get_paginator('describe_images')
+    amis = []
+    for page in paginator.paginate(Owners=['self']):
+        amis.extend(page.get('Images', []))
 
-        print(f"  Found {len(amis)} account-owned AMIs")
+    print(f"  Found {len(amis)} account-owned AMIs")
 
-        for ami in amis:
-            ami_id = ami.get('ImageId', '')
-            ami_name = ami.get('Name', 'N/A')
-            description = ami.get('Description', 'N/A')
-            state = ami.get('State', '')
-            creation_date = ami.get('CreationDate', 'N/A')
-
-            # Architecture
-            architecture = ami.get('Architecture', 'N/A')
-
-            # Virtualization type
-            virtualization_type = ami.get('VirtualizationType', 'N/A')
-
-            # Root device type and name
-            root_device_type = ami.get('RootDeviceType', 'N/A')
-            root_device_name = ami.get('RootDeviceName', 'N/A')
-
-            # Platform (Windows or blank for Linux)
-            platform = ami.get('Platform', 'Linux')
-            platform_details = ami.get('PlatformDetails', 'N/A')
-
-            # Public/Private
-            is_public = ami.get('Public', False)
-            visibility = 'Public' if is_public else 'Private'
-
-            # Image location
-            image_location = ami.get('ImageLocation', 'N/A')
-
-            # EBS snapshots (from block device mappings)
-            block_device_mappings = ami.get('BlockDeviceMappings', [])
-            snapshot_ids = []
-            total_volume_size = 0
-
-            for bdm in block_device_mappings:
-                ebs = bdm.get('Ebs', {})
-                if ebs:
-                    snapshot_id = ebs.get('SnapshotId', '')
-                    volume_size = ebs.get('VolumeSize', 0)
-                    if snapshot_id:
-                        snapshot_ids.append(snapshot_id)
-                    total_volume_size += volume_size
-
-            snapshots_str = ', '.join(snapshot_ids) if snapshot_ids else 'N/A'
-
-            # ENA support
-            ena_support = ami.get('EnaSupport', False)
-
-            # Kernel and ramdisk IDs (older AMIs)
-            kernel_id = ami.get('KernelId', 'N/A')
-            ramdisk_id = ami.get('RamdiskId', 'N/A')
-
-            # Boot mode
-            boot_mode = ami.get('BootMode', 'N/A')
-
-            # Deprecation time
-            deprecation_time = ami.get('DeprecationTime', 'N/A')
-
-            # Tags
-            tags = ami.get('Tags', [])
-            tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
-            tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-            region_amis.append({
-                'Region': region,
-                'AMI ID': ami_id,
-                'AMI Name': ami_name,
-                'State': state,
-                'Visibility': visibility,
-                'Architecture': architecture,
-                'Platform': platform,
-                'Platform Details': platform_details,
-                'Virtualization Type': virtualization_type,
-                'Root Device Type': root_device_type,
-                'Root Device Name': root_device_name,
-                'Total Volume Size (GB)': total_volume_size,
-                'Snapshot IDs': snapshots_str,
-                'ENA Support': ena_support,
-                'Boot Mode': boot_mode,
-                'Creation Date': creation_date,
-                'Deprecation Time': deprecation_time,
-                'Image Location': image_location,
-                'Kernel ID': kernel_id,
-                'Ramdisk ID': ramdisk_id,
-                'Description': description,
-                'Tags': tags_str
-            })
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for AMIs", e)
+    region_amis = []
+    for ami in amis:
+        try:
+            region_amis.append(_build_ami_row(ami, region))
+        except Exception as e:
+            # One malformed AMI is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed AMI in {region}: {ami.get('ImageId', '<unknown>')}",
+                e,
+            )
+            continue
 
     return region_amis
+
+
+def collect_amis(regions: list[str], account_id: str) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AMI information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(amis, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
+    def scan_region_amis(region):
+        return collect_amis_in_region(region, account_id)
+
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=scan_region_amis,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_amis = [ami for result in region_results for ami in result]
+    return all_amis, failed_regions
 
 
 def export_ami_data(account_id: str, account_name: str):
@@ -190,63 +232,63 @@ def export_ami_data(account_id: str, account_name: str):
     # Import pandas for DataFrame handling
     import pandas as pd
 
-    # Collect AMIs using concurrent region scanning (Phase 4B)
+    # Collect AMIs using concurrent region scanning (Phase 4B). This is the
+    # primary scope collector — region failures must propagate as
+    # failed_regions, never collapse into "empty".
     print("\n=== COLLECTING ACCOUNT-OWNED AMIs ===")
 
-    # Define region scan function
-    def scan_region_amis(region):
-        return collect_amis_in_region(region, account_id)
-
-    # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
-        regions=regions,
-        scan_function=scan_region_amis,
-        show_progress=True
-    )
-
-    # Flatten results
-    amis = []
-    for region_amis in region_results:
-        amis.extend(region_amis)
+    amis, failed_regions = collect_amis(regions, account_id)
 
     utils.log_success(f"Total AMIs collected: {len(amis)}")
 
-    # Check if we have any data
-    if not amis:
+    # Export whatever succeeded — a partial export is required even on
+    # partial failure (see the silent-collection-failure blast-radius audit).
+    if amis:
+        # Create DataFrame
+        df = pd.DataFrame(amis)
+
+        # Prepare DataFrame for export
+        df = utils.prepare_dataframe_for_export(df)
+
+        # Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'ami',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_dataframe_to_excel(df, final_excel_file, sheet_name='AMIs')
+
+            if output_path:
+                utils.log_success("AMI data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+                utils.log_info(f"Total AMIs: {len(df)} records")
+                print(f"Total AMIs: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No AMI data was collected. Nothing to export.")
         print("\nNo account-owned AMIs found in the selected region(s).")
-        return
 
-    # Create DataFrame
-    df = pd.DataFrame(amis)
-
-    # Prepare DataFrame for export
-    df = utils.prepare_dataframe_for_export(df)
-
-    # Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'ami',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_dataframe_to_excel(df, final_excel_file, sheet_name='AMIs')
-
-        if output_path:
-            utils.log_success("AMI data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-            utils.log_info(f"Total AMIs: {len(df)} records")
-            print(f"Total AMIs: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary AMI scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ami', failed_regions)
+        print(
+            "\nERROR: AMI export completed with failures — data is incomplete. "
+            "See the *-ami-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/autoscaling_export.py
+++ b/scripts/autoscaling_export.py
@@ -50,130 +50,160 @@ except ImportError:
 args = utils.parse_script_args("Export Auto Scaling Groups to Excel")
 
 
-@utils.aws_error_handler("Collecting Auto Scaling Groups", default_return=[])
-def collect_autoscaling_groups(regions: list[str]) -> list[dict[str, Any]]:
+def _scan_asgs_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect Auto Scaling Group information from AWS regions.
+    Collect Auto Scaling Groups from a single region.
 
-    Args:
-        regions: List of AWS regions to scan
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Auto Scaling Groups" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed ASGs are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    asg_client = utils.get_boto3_client('autoscaling', region_name=region)
+    paginator = asg_client.get_paginator('describe_auto_scaling_groups')
+    region_asgs = []
+    asg_count = 0
+
+    for page in paginator.paginate():
+        asgs = page.get('AutoScalingGroups', [])
+        asg_count += len(asgs)
+
+        for asg in asgs:
+            try:
+                region_asgs.append(_build_asg_row(asg, region))
+            except Exception as e:
+                # One malformed ASG is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Auto Scaling Group in {region}: "
+                    f"{asg.get('AutoScalingGroupName', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    print(f"  Found {asg_count} Auto Scaling Groups")
+    return region_asgs
+
+
+def _build_asg_row(asg: dict, region: str) -> dict[str, Any]:
+    """Build a single Auto Scaling Group export row from a describe response."""
+    asg_name = asg.get('AutoScalingGroupName', '')
+    print(f"  Processing ASG: {asg_name}")
+
+    # Basic information
+    asg_arn = asg.get('AutoScalingGroupARN', '')
+    min_size = asg.get('MinSize', 0)
+    max_size = asg.get('MaxSize', 0)
+    desired_capacity = asg.get('DesiredCapacity', 0)
+    default_cooldown = asg.get('DefaultCooldown', 0)
+    health_check_type = asg.get('HealthCheckType', 'N/A')
+    health_check_grace_period = asg.get('HealthCheckGracePeriod', 0)
+
+    # Launch configuration or template
+    launch_config_name = asg.get('LaunchConfigurationName', 'N/A')
+    launch_template = asg.get('LaunchTemplate', {})
+    mixed_instances_policy = asg.get('MixedInstancesPolicy', {})
+
+    if launch_template:
+        launch_source = f"LT: {launch_template.get('LaunchTemplateName', '')} ({launch_template.get('Version', '')})"
+    elif mixed_instances_policy:
+        lt_spec = mixed_instances_policy.get('LaunchTemplate', {}).get('LaunchTemplateSpecification', {})
+        launch_source = f"Mixed: {lt_spec.get('LaunchTemplateName', '')} ({lt_spec.get('Version', '')})"
+    else:
+        launch_source = f"LC: {launch_config_name}"
+
+    # VPC and subnets
+    vpc_zone_identifier = asg.get('VPCZoneIdentifier', '')
+    subnet_ids = vpc_zone_identifier.split(',') if vpc_zone_identifier else []
+    subnet_count = len(subnet_ids)
+    availability_zones = asg.get('AvailabilityZones', [])
+    az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
+
+    # Load balancers
+    load_balancer_names = asg.get('LoadBalancerNames', [])
+    target_group_arns = asg.get('TargetGroupARNs', [])
+    lb_count = len(load_balancer_names) + len(target_group_arns)
+
+    # Instance information
+    instances = asg.get('Instances', [])
+    instance_count = len(instances)
+    healthy_count = sum(1 for i in instances if i.get('HealthStatus') == 'Healthy')
+    unhealthy_count = instance_count - healthy_count
+
+    # Service-linked role
+    service_linked_role_arn = asg.get('ServiceLinkedRoleARN', 'N/A')
+
+    # New instances protected from scale in
+    new_instances_protected = asg.get('NewInstancesProtectedFromScaleIn', False)
+
+    # Capacity rebalance
+    capacity_rebalance = asg.get('CapacityRebalance', False)
+
+    # Creation time
+    created_time = asg.get('CreatedTime', '')
+    if created_time:
+        created_time = created_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_time, datetime.datetime) else str(created_time)
+
+    # Tags
+    tags = asg.get('Tags', [])
+    tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    return {
+        'Region': region,
+        'ASG Name': asg_name,
+        'Min Size': min_size,
+        'Max Size': max_size,
+        'Desired Capacity': desired_capacity,
+        'Current Instances': instance_count,
+        'Healthy Instances': healthy_count,
+        'Unhealthy Instances': unhealthy_count,
+        'Launch Source': launch_source,
+        'Availability Zones': az_list,
+        'Subnet Count': subnet_count,
+        'Load Balancer Count': lb_count,
+        'Health Check Type': health_check_type,
+        'Health Check Grace Period (s)': health_check_grace_period,
+        'Default Cooldown (s)': default_cooldown,
+        'New Instance Protection': new_instances_protected,
+        'Capacity Rebalance': capacity_rebalance,
+        'Service Linked Role': service_linked_role_arn,
+        'Created Time': created_time,
+        'Tags': tags_str,
+        'ASG ARN': asg_arn
+    }
+
+
+def collect_autoscaling_groups(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Auto Scaling Group information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with Auto Scaling Group information
+        tuple: ``(asgs, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
     """
-    all_asgs = []
-
-    for region in regions:
-        if not utils.is_aws_region(region):
-            utils.log_error(f"Skipping invalid AWS region: {region}")
-            continue
-
-        print(f"\nProcessing region: {region}")
-
-        try:
-            asg_client = utils.get_boto3_client('autoscaling', region_name=region)
-
-            # Get Auto Scaling Groups
-            paginator = asg_client.get_paginator('describe_auto_scaling_groups')
-            asg_count = 0
-
-            for page in paginator.paginate():
-                asgs = page.get('AutoScalingGroups', [])
-                asg_count += len(asgs)
-
-                for asg in asgs:
-                    asg_name = asg.get('AutoScalingGroupName', '')
-                    print(f"  Processing ASG: {asg_name}")
-
-                    # Basic information
-                    asg_arn = asg.get('AutoScalingGroupARN', '')
-                    min_size = asg.get('MinSize', 0)
-                    max_size = asg.get('MaxSize', 0)
-                    desired_capacity = asg.get('DesiredCapacity', 0)
-                    default_cooldown = asg.get('DefaultCooldown', 0)
-                    health_check_type = asg.get('HealthCheckType', 'N/A')
-                    health_check_grace_period = asg.get('HealthCheckGracePeriod', 0)
-
-                    # Launch configuration or template
-                    launch_config_name = asg.get('LaunchConfigurationName', 'N/A')
-                    launch_template = asg.get('LaunchTemplate', {})
-                    mixed_instances_policy = asg.get('MixedInstancesPolicy', {})
-
-                    if launch_template:
-                        launch_source = f"LT: {launch_template.get('LaunchTemplateName', '')} ({launch_template.get('Version', '')})"
-                    elif mixed_instances_policy:
-                        lt_spec = mixed_instances_policy.get('LaunchTemplate', {}).get('LaunchTemplateSpecification', {})
-                        launch_source = f"Mixed: {lt_spec.get('LaunchTemplateName', '')} ({lt_spec.get('Version', '')})"
-                    else:
-                        launch_source = f"LC: {launch_config_name}"
-
-                    # VPC and subnets
-                    vpc_zone_identifier = asg.get('VPCZoneIdentifier', '')
-                    subnet_ids = vpc_zone_identifier.split(',') if vpc_zone_identifier else []
-                    subnet_count = len(subnet_ids)
-                    availability_zones = asg.get('AvailabilityZones', [])
-                    az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
-
-                    # Load balancers
-                    load_balancer_names = asg.get('LoadBalancerNames', [])
-                    target_group_arns = asg.get('TargetGroupARNs', [])
-                    lb_count = len(load_balancer_names) + len(target_group_arns)
-
-                    # Instance information
-                    instances = asg.get('Instances', [])
-                    instance_count = len(instances)
-                    healthy_count = sum(1 for i in instances if i.get('HealthStatus') == 'Healthy')
-                    unhealthy_count = instance_count - healthy_count
-
-                    # Service-linked role
-                    service_linked_role_arn = asg.get('ServiceLinkedRoleARN', 'N/A')
-
-                    # New instances protected from scale in
-                    new_instances_protected = asg.get('NewInstancesProtectedFromScaleIn', False)
-
-                    # Capacity rebalance
-                    capacity_rebalance = asg.get('CapacityRebalance', False)
-
-                    # Creation time
-                    created_time = asg.get('CreatedTime', '')
-                    if created_time:
-                        created_time = created_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_time, datetime.datetime) else str(created_time)
-
-                    # Tags
-                    tags = asg.get('Tags', [])
-                    tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-                    all_asgs.append({
-                        'Region': region,
-                        'ASG Name': asg_name,
-                        'Min Size': min_size,
-                        'Max Size': max_size,
-                        'Desired Capacity': desired_capacity,
-                        'Current Instances': instance_count,
-                        'Healthy Instances': healthy_count,
-                        'Unhealthy Instances': unhealthy_count,
-                        'Launch Source': launch_source,
-                        'Availability Zones': az_list,
-                        'Subnet Count': subnet_count,
-                        'Load Balancer Count': lb_count,
-                        'Health Check Type': health_check_type,
-                        'Health Check Grace Period (s)': health_check_grace_period,
-                        'Default Cooldown (s)': default_cooldown,
-                        'New Instance Protection': new_instances_protected,
-                        'Capacity Rebalance': capacity_rebalance,
-                        'Service Linked Role': service_linked_role_arn,
-                        'Created Time': created_time,
-                        'Tags': tags_str,
-                        'ASG ARN': asg_arn
-                    })
-
-            print(f"  Found {asg_count} Auto Scaling Groups")
-
-        except Exception as e:
-            utils.log_error(f"Error processing region {region} for Auto Scaling Groups", e)
-
-    return all_asgs
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_asgs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_asgs = [asg for result in region_results for asg in result]
+    return all_asgs, failed_regions
 
 
 @utils.aws_error_handler("Collecting ASG instances", default_return=[])
@@ -388,16 +418,10 @@ def export_autoscaling_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Auto Scaling Groups (Phase 4B: concurrent)
+    # STEP 1: Collect Auto Scaling Groups (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
     print("\n=== COLLECTING AUTO SCALING GROUPS ===")
-    asg_results = utils.scan_regions_concurrent(
-        regions=regions,
-        scan_function=lambda r: collect_autoscaling_groups([r]),
-        show_progress=True
-    )
-    asgs = []
-    for result in asg_results:
-        asgs.extend(result)
+    asgs, failed_regions = collect_autoscaling_groups(regions)
     utils.log_success(f"Total Auto Scaling Groups collected: {len(asgs)}")
     if asgs:
         data_frames['Auto Scaling Groups'] = pd.DataFrame(asgs)
@@ -435,43 +459,55 @@ def export_autoscaling_data(account_id: str, account_name: str):
     if hooks:
         data_frames['Lifecycle Hooks'] = pd.DataFrame(hooks)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'autoscaling',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Auto Scaling data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Auto Scaling Group data was collected. Nothing to export.")
         print("\nNo Auto Scaling Groups found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'autoscaling',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Auto Scaling data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary ASG scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'autoscaling', failed_regions)
+        print(
+            "\nERROR: Auto Scaling export completed with failures — data is incomplete. "
+            "See the *-autoscaling-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/comprehend_export.py
+++ b/scripts/comprehend_export.py
@@ -28,385 +28,559 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Amazon Comprehend resources to Excel")
 
-@utils.aws_error_handler("Collecting Comprehend entity recognizers", default_return=[])
-def collect_entity_recognizers(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect custom entity recognizer information from AWS regions."""
-    all_recognizers = []
-
-    for region in regions:
-        utils.log_info(f"Collecting entity recognizers in {region}...")
-        comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
-
-        try:
-            paginator = comprehend_client.get_paginator('list_entity_recognizers')
-            for page in paginator.paginate():
-                recognizers = page.get('EntityRecognizerPropertiesList', [])
-
-                for recognizer in recognizers:
-                    recognizer_arn = recognizer.get('EntityRecognizerArn', 'N/A')
-                    language_code = recognizer.get('LanguageCode', 'N/A')
-                    status = recognizer.get('Status', 'N/A')
-
-                    submit_time = recognizer.get('SubmitTime', 'N/A')
-                    if submit_time != 'N/A':
-                        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    end_time = recognizer.get('EndTime', 'N/A')
-                    if end_time != 'N/A':
-                        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Training metrics
-                    recognizer_metadata = recognizer.get('RecognizerMetadata', {})
-                    number_of_trained_documents = recognizer_metadata.get('NumberOfTrainedDocuments', 0)
-                    number_of_test_documents = recognizer_metadata.get('NumberOfTestDocuments', 0)
-
-                    # Evaluation metrics
-                    eval_metrics = recognizer_metadata.get('EvaluationMetrics', {})
-                    precision = eval_metrics.get('Precision', 0)
-                    recall = eval_metrics.get('Recall', 0)
-                    f1_score = eval_metrics.get('F1Score', 0)
-
-                    # Extract recognizer name from ARN
-                    recognizer_name = 'N/A'
-                    if recognizer_arn != 'N/A' and '/' in recognizer_arn:
-                        recognizer_name = recognizer_arn.split('/')[-1]
-
-                    # Data access role
-                    data_access_role = recognizer.get('DataAccessRoleArn', 'N/A')
-
-                    # Input config
-                    # Message
-                    message = recognizer.get('Message', 'N/A')
-
-                    all_recognizers.append({
-                        'Region': region,
-                        'Recognizer Name': recognizer_name,
-                        'ARN': recognizer_arn,
-                        'Language': language_code,
-                        'Status': status,
-                        'Submitted': submit_time,
-                        'Ended': end_time,
-                        'Trained Documents': number_of_trained_documents,
-                        'Test Documents': number_of_test_documents,
-                        'Precision': f"{precision:.4f}" if precision else 'N/A',
-                        'Recall': f"{recall:.4f}" if recall else 'N/A',
-                        'F1 Score': f"{f1_score:.4f}" if f1_score else 'N/A',
-                        'Data Access Role ARN': data_access_role,
-                        'Message': message
-                    })
-
-        except Exception as e:
-            utils.log_warning(f"Error listing entity recognizers in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_recognizers)} entity recognizers")
-    return all_recognizers
-
-
-@utils.aws_error_handler("Collecting Comprehend document classifiers", default_return=[])
-def collect_document_classifiers(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect custom document classifier information."""
-    all_classifiers = []
-
-    for region in regions:
-        utils.log_info(f"Collecting document classifiers in {region}...")
-        comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
-
-        try:
-            paginator = comprehend_client.get_paginator('list_document_classifiers')
-            for page in paginator.paginate():
-                classifiers = page.get('DocumentClassifierPropertiesList', [])
-
-                for classifier in classifiers:
-                    classifier_arn = classifier.get('DocumentClassifierArn', 'N/A')
-                    language_code = classifier.get('LanguageCode', 'N/A')
-                    status = classifier.get('Status', 'N/A')
-                    mode = classifier.get('Mode', 'N/A')
-
-                    submit_time = classifier.get('SubmitTime', 'N/A')
-                    if submit_time != 'N/A':
-                        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    end_time = classifier.get('EndTime', 'N/A')
-                    if end_time != 'N/A':
-                        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Training metrics
-                    classifier_metadata = classifier.get('ClassifierMetadata', {})
-                    number_of_labels = classifier_metadata.get('NumberOfLabels', 0)
-                    number_of_trained_documents = classifier_metadata.get('NumberOfTrainedDocuments', 0)
-                    number_of_test_documents = classifier_metadata.get('NumberOfTestDocuments', 0)
-
-                    # Evaluation metrics
-                    eval_metrics = classifier_metadata.get('EvaluationMetrics', {})
-                    accuracy = eval_metrics.get('Accuracy', 0)
-                    precision = eval_metrics.get('Precision', 0)
-                    recall = eval_metrics.get('Recall', 0)
-                    f1_score = eval_metrics.get('F1Score', 0)
-                    micro_precision = eval_metrics.get('MicroPrecision', 0)
-                    micro_recall = eval_metrics.get('MicroRecall', 0)
-                    micro_f1 = eval_metrics.get('MicroF1Score', 0)
-
-                    # Extract classifier name from ARN
-                    classifier_name = 'N/A'
-                    if classifier_arn != 'N/A' and '/' in classifier_arn:
-                        classifier_name = classifier_arn.split('/')[-1]
-
-                    # Data access role
-                    data_access_role = classifier.get('DataAccessRoleArn', 'N/A')
-
-                    # Message
-                    message = classifier.get('Message', 'N/A')
-
-                    all_classifiers.append({
-                        'Region': region,
-                        'Classifier Name': classifier_name,
-                        'ARN': classifier_arn,
-                        'Language': language_code,
-                        'Mode': mode,
-                        'Status': status,
-                        'Submitted': submit_time,
-                        'Ended': end_time,
-                        'Number of Labels': number_of_labels,
-                        'Trained Documents': number_of_trained_documents,
-                        'Test Documents': number_of_test_documents,
-                        'Accuracy': f"{accuracy:.4f}" if accuracy else 'N/A',
-                        'Precision': f"{precision:.4f}" if precision else 'N/A',
-                        'Recall': f"{recall:.4f}" if recall else 'N/A',
-                        'F1 Score': f"{f1_score:.4f}" if f1_score else 'N/A',
-                        'Micro Precision': f"{micro_precision:.4f}" if micro_precision else 'N/A',
-                        'Micro Recall': f"{micro_recall:.4f}" if micro_recall else 'N/A',
-                        'Micro F1': f"{micro_f1:.4f}" if micro_f1 else 'N/A',
-                        'Data Access Role ARN': data_access_role,
-                        'Message': message
-                    })
-
-        except Exception as e:
-            utils.log_warning(f"Error listing document classifiers in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_classifiers)} document classifiers")
-    return all_classifiers
-
-
-@utils.aws_error_handler("Collecting Comprehend endpoints", default_return=[])
-def collect_endpoints(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Comprehend endpoint information for real-time inference."""
-    all_endpoints = []
-
-    for region in regions:
-        utils.log_info(f"Collecting endpoints in {region}...")
-        comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
-
-        try:
-            paginator = comprehend_client.get_paginator('list_endpoints')
-            for page in paginator.paginate():
-                endpoints = page.get('EndpointPropertiesList', [])
-
-                for endpoint in endpoints:
-                    endpoint_arn = endpoint.get('EndpointArn', 'N/A')
-                    status = endpoint.get('Status', 'N/A')
-
-                    # Model ARN
-                    model_arn = endpoint.get('ModelArn', 'N/A')
-
-                    # Extract model type
-                    model_type = 'N/A'
-                    if 'entity-recognizer' in model_arn:
-                        model_type = 'Entity Recognizer'
-                    elif 'document-classifier' in model_arn:
-                        model_type = 'Document Classifier'
-
-                    # Extract endpoint name from ARN
-                    endpoint_name = 'N/A'
-                    if endpoint_arn != 'N/A' and '/' in endpoint_arn:
-                        endpoint_name = endpoint_arn.split('/')[-1]
-
-                    # Desired inference units
-                    desired_inference_units = endpoint.get('DesiredInferenceUnits', 0)
-                    current_inference_units = endpoint.get('CurrentInferenceUnits', 0)
-
-                    creation_time = endpoint.get('CreationTime', 'N/A')
-                    if creation_time != 'N/A':
-                        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    last_modified = endpoint.get('LastModifiedTime', 'N/A')
-                    if last_modified != 'N/A':
-                        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Data access role
-                    data_access_role = endpoint.get('DataAccessRoleArn', 'N/A')
-
-                    # Message
-                    message = endpoint.get('Message', 'N/A')
-
-                    all_endpoints.append({
-                        'Region': region,
-                        'Endpoint Name': endpoint_name,
-                        'ARN': endpoint_arn,
-                        'Status': status,
-                        'Model Type': model_type,
-                        'Model ARN': model_arn,
-                        'Created': creation_time,
-                        'Last Modified': last_modified,
-                        'Desired Inference Units': desired_inference_units,
-                        'Current Inference Units': current_inference_units,
-                        'Data Access Role ARN': data_access_role,
-                        'Message': message
-                    })
-
-        except Exception as e:
-            utils.log_warning(f"Error listing endpoints in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_endpoints)} endpoints")
-    return all_endpoints
-
-
-@utils.aws_error_handler("Collecting Comprehend document classification jobs", default_return=[])
-def collect_document_classification_jobs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect document classification job information (limited to recent 30 per region)."""
-    all_jobs = []
-
-    for region in regions:
-        utils.log_info(f"Collecting document classification jobs in {region}...")
-        comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
-
-        try:
-            # List recent jobs (limit to 30)
-            paginator = comprehend_client.get_paginator('list_document_classification_jobs')
-            job_count = 0
-            for page in paginator.paginate(PaginationConfig={'MaxItems': 30}):
-                jobs = page.get('DocumentClassificationJobPropertiesList', [])
-
-                for job in jobs:
-                    job_id = job.get('JobId', 'N/A')
-                    job_name = job.get('JobName', 'N/A')
-                    job_status = job.get('JobStatus', 'N/A')
-
-                    submit_time = job.get('SubmitTime', 'N/A')
-                    if submit_time != 'N/A':
-                        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    end_time = job.get('EndTime', 'N/A')
-                    if end_time != 'N/A':
-                        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Document classifier ARN
-                    document_classifier_arn = job.get('DocumentClassifierArn', 'N/A')
-
-                    # Input config
-                    input_config = job.get('InputDataConfig', {})
-                    input_s3_uri = input_config.get('S3Uri', 'N/A')
-
-                    # Output config
-                    output_config = job.get('OutputDataConfig', {})
-                    output_s3_uri = output_config.get('S3Uri', 'N/A')
-
-                    # Data access role
-                    data_access_role = job.get('DataAccessRoleArn', 'N/A')
-
-                    # Message
-                    message = job.get('Message', 'N/A')
-
-                    all_jobs.append({
-                        'Region': region,
-                        'Job ID': job_id,
-                        'Job Name': job_name,
-                        'Status': job_status,
-                        'Submitted': submit_time,
-                        'Ended': end_time,
-                        'Document Classifier ARN': document_classifier_arn,
-                        'Input S3 URI': input_s3_uri,
-                        'Output S3 URI': output_s3_uri,
-                        'Data Access Role ARN': data_access_role,
-                        'Message': message
-                    })
-
-                    job_count += 1
-                    if job_count >= 30:
-                        break
-
-        except Exception as e:
-            utils.log_warning(f"Error listing document classification jobs in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_jobs)} document classification jobs (limited to 30 most recent per region)")
-    return all_jobs
-
-
-@utils.aws_error_handler("Collecting Comprehend entities detection jobs", default_return=[])
-def collect_entities_detection_jobs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect entities detection job information (limited to recent 30 per region)."""
-    all_jobs = []
-
-    for region in regions:
-        utils.log_info(f"Collecting entities detection jobs in {region}...")
-        comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
-
-        try:
-            # List recent jobs (limit to 30)
-            paginator = comprehend_client.get_paginator('list_entities_detection_jobs')
-            job_count = 0
-            for page in paginator.paginate(PaginationConfig={'MaxItems': 30}):
-                jobs = page.get('EntitiesDetectionJobPropertiesList', [])
-
-                for job in jobs:
-                    job_id = job.get('JobId', 'N/A')
-                    job_name = job.get('JobName', 'N/A')
-                    job_status = job.get('JobStatus', 'N/A')
-                    language_code = job.get('LanguageCode', 'N/A')
-
-                    submit_time = job.get('SubmitTime', 'N/A')
-                    if submit_time != 'N/A':
-                        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    end_time = job.get('EndTime', 'N/A')
-                    if end_time != 'N/A':
-                        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Entity recognizer ARN (if custom)
-                    entity_recognizer_arn = job.get('EntityRecognizerArn', 'Built-in')
-
-                    # Input config
-                    input_config = job.get('InputDataConfig', {})
-                    input_s3_uri = input_config.get('S3Uri', 'N/A')
-
-                    # Output config
-                    output_config = job.get('OutputDataConfig', {})
-                    output_s3_uri = output_config.get('S3Uri', 'N/A')
-
-                    # Data access role
-                    data_access_role = job.get('DataAccessRoleArn', 'N/A')
-
-                    # Message
-                    message = job.get('Message', 'N/A')
-
-                    all_jobs.append({
-                        'Region': region,
-                        'Job ID': job_id,
-                        'Job Name': job_name,
-                        'Status': job_status,
-                        'Language': language_code,
-                        'Submitted': submit_time,
-                        'Ended': end_time,
-                        'Entity Recognizer ARN': entity_recognizer_arn,
-                        'Input S3 URI': input_s3_uri,
-                        'Output S3 URI': output_s3_uri,
-                        'Data Access Role ARN': data_access_role,
-                        'Message': message
-                    })
-
-                    job_count += 1
-                    if job_count >= 30:
-                        break
-
-        except Exception as e:
-            utils.log_warning(f"Error listing entities detection jobs in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_jobs)} entities detection jobs (limited to 30 most recent per region)")
-    return all_jobs
+
+def _build_recognizer_row(recognizer: dict, region: str) -> dict[str, Any]:
+    """Build a single entity recognizer export row from a list_entity_recognizers entry."""
+    recognizer_arn = recognizer.get('EntityRecognizerArn', 'N/A')
+    language_code = recognizer.get('LanguageCode', 'N/A')
+    status = recognizer.get('Status', 'N/A')
+
+    submit_time = recognizer.get('SubmitTime', 'N/A')
+    if submit_time != 'N/A':
+        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    end_time = recognizer.get('EndTime', 'N/A')
+    if end_time != 'N/A':
+        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Training metrics
+    recognizer_metadata = recognizer.get('RecognizerMetadata', {}) or {}
+    number_of_trained_documents = recognizer_metadata.get('NumberOfTrainedDocuments', 0)
+    number_of_test_documents = recognizer_metadata.get('NumberOfTestDocuments', 0)
+
+    # Evaluation metrics
+    eval_metrics = recognizer_metadata.get('EvaluationMetrics', {}) or {}
+    precision = eval_metrics.get('Precision', 0)
+    recall = eval_metrics.get('Recall', 0)
+    f1_score = eval_metrics.get('F1Score', 0)
+
+    # Extract recognizer name from ARN
+    recognizer_name = 'N/A'
+    if recognizer_arn != 'N/A' and '/' in recognizer_arn:
+        recognizer_name = recognizer_arn.split('/')[-1]
+
+    # Data access role
+    data_access_role = recognizer.get('DataAccessRoleArn', 'N/A')
+
+    # Message
+    message = recognizer.get('Message', 'N/A')
+
+    return {
+        'Region': region,
+        'Recognizer Name': recognizer_name,
+        'ARN': recognizer_arn,
+        'Language': language_code,
+        'Status': status,
+        'Submitted': submit_time,
+        'Ended': end_time,
+        'Trained Documents': number_of_trained_documents,
+        'Test Documents': number_of_test_documents,
+        'Precision': f"{precision:.4f}" if precision else 'N/A',
+        'Recall': f"{recall:.4f}" if recall else 'N/A',
+        'F1 Score': f"{f1_score:.4f}" if f1_score else 'N/A',
+        'Data Access Role ARN': data_access_role,
+        'Message': message
+    }
+
+
+def _scan_recognizers_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect custom entity recognizers from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no recognizers" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed recognizers are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting entity recognizers in {region}...")
+    comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
+
+    region_recognizers = []
+    paginator = comprehend_client.get_paginator('list_entity_recognizers')
+    for page in paginator.paginate():
+        recognizers = page.get('EntityRecognizerPropertiesList', [])
+
+        for recognizer in recognizers:
+            try:
+                region_recognizers.append(_build_recognizer_row(recognizer, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed entity recognizer in {region}: "
+                    f"{recognizer.get('EntityRecognizerArn', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_recognizers)} entity recognizers in {region}")
+    return region_recognizers
+
+
+def collect_entity_recognizers(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect custom entity recognizer information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(recognizers, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_recognizers_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_recognizers = [r for result in region_results for r in result]
+    utils.log_info(f"Collected {len(all_recognizers)} entity recognizers total")
+    return all_recognizers, failed_regions
+
+
+def _build_classifier_row(classifier: dict, region: str) -> dict[str, Any]:
+    """Build a single document classifier export row from a list_document_classifiers entry."""
+    classifier_arn = classifier.get('DocumentClassifierArn', 'N/A')
+    language_code = classifier.get('LanguageCode', 'N/A')
+    status = classifier.get('Status', 'N/A')
+    mode = classifier.get('Mode', 'N/A')
+
+    submit_time = classifier.get('SubmitTime', 'N/A')
+    if submit_time != 'N/A':
+        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    end_time = classifier.get('EndTime', 'N/A')
+    if end_time != 'N/A':
+        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Training metrics
+    classifier_metadata = classifier.get('ClassifierMetadata', {}) or {}
+    number_of_labels = classifier_metadata.get('NumberOfLabels', 0)
+    number_of_trained_documents = classifier_metadata.get('NumberOfTrainedDocuments', 0)
+    number_of_test_documents = classifier_metadata.get('NumberOfTestDocuments', 0)
+
+    # Evaluation metrics
+    eval_metrics = classifier_metadata.get('EvaluationMetrics', {}) or {}
+    accuracy = eval_metrics.get('Accuracy', 0)
+    precision = eval_metrics.get('Precision', 0)
+    recall = eval_metrics.get('Recall', 0)
+    f1_score = eval_metrics.get('F1Score', 0)
+    micro_precision = eval_metrics.get('MicroPrecision', 0)
+    micro_recall = eval_metrics.get('MicroRecall', 0)
+    micro_f1 = eval_metrics.get('MicroF1Score', 0)
+
+    # Extract classifier name from ARN
+    classifier_name = 'N/A'
+    if classifier_arn != 'N/A' and '/' in classifier_arn:
+        classifier_name = classifier_arn.split('/')[-1]
+
+    # Data access role
+    data_access_role = classifier.get('DataAccessRoleArn', 'N/A')
+
+    # Message
+    message = classifier.get('Message', 'N/A')
+
+    return {
+        'Region': region,
+        'Classifier Name': classifier_name,
+        'ARN': classifier_arn,
+        'Language': language_code,
+        'Mode': mode,
+        'Status': status,
+        'Submitted': submit_time,
+        'Ended': end_time,
+        'Number of Labels': number_of_labels,
+        'Trained Documents': number_of_trained_documents,
+        'Test Documents': number_of_test_documents,
+        'Accuracy': f"{accuracy:.4f}" if accuracy else 'N/A',
+        'Precision': f"{precision:.4f}" if precision else 'N/A',
+        'Recall': f"{recall:.4f}" if recall else 'N/A',
+        'F1 Score': f"{f1_score:.4f}" if f1_score else 'N/A',
+        'Micro Precision': f"{micro_precision:.4f}" if micro_precision else 'N/A',
+        'Micro Recall': f"{micro_recall:.4f}" if micro_recall else 'N/A',
+        'Micro F1': f"{micro_f1:.4f}" if micro_f1 else 'N/A',
+        'Data Access Role ARN': data_access_role,
+        'Message': message
+    }
+
+
+def _scan_classifiers_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect custom document classifiers from a single region.
+
+    Region-level failures propagate (see ``_scan_recognizers_region`` docstring
+    for the rationale); malformed individual classifiers are skipped and logged.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting document classifiers in {region}...")
+    comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
+
+    region_classifiers = []
+    paginator = comprehend_client.get_paginator('list_document_classifiers')
+    for page in paginator.paginate():
+        classifiers = page.get('DocumentClassifierPropertiesList', [])
+
+        for classifier in classifiers:
+            try:
+                region_classifiers.append(_build_classifier_row(classifier, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed document classifier in {region}: "
+                    f"{classifier.get('DocumentClassifierArn', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_classifiers)} document classifiers in {region}")
+    return region_classifiers
+
+
+def collect_document_classifiers(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect custom document classifier information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(classifiers, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_classifiers_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_classifiers = [c for result in region_results for c in result]
+    utils.log_info(f"Collected {len(all_classifiers)} document classifiers total")
+    return all_classifiers, failed_regions
+
+
+def _build_endpoint_row(endpoint: dict, region: str) -> dict[str, Any]:
+    """Build a single endpoint export row from a list_endpoints entry."""
+    endpoint_arn = endpoint.get('EndpointArn', 'N/A')
+    status = endpoint.get('Status', 'N/A')
+
+    # Model ARN
+    model_arn = endpoint.get('ModelArn', 'N/A')
+
+    # Extract model type
+    model_type = 'N/A'
+    if 'entity-recognizer' in model_arn:
+        model_type = 'Entity Recognizer'
+    elif 'document-classifier' in model_arn:
+        model_type = 'Document Classifier'
+
+    # Extract endpoint name from ARN
+    endpoint_name = 'N/A'
+    if endpoint_arn != 'N/A' and '/' in endpoint_arn:
+        endpoint_name = endpoint_arn.split('/')[-1]
+
+    # Desired inference units
+    desired_inference_units = endpoint.get('DesiredInferenceUnits', 0)
+    current_inference_units = endpoint.get('CurrentInferenceUnits', 0)
+
+    creation_time = endpoint.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_modified = endpoint.get('LastModifiedTime', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Data access role
+    data_access_role = endpoint.get('DataAccessRoleArn', 'N/A')
+
+    # Message
+    message = endpoint.get('Message', 'N/A')
+
+    return {
+        'Region': region,
+        'Endpoint Name': endpoint_name,
+        'ARN': endpoint_arn,
+        'Status': status,
+        'Model Type': model_type,
+        'Model ARN': model_arn,
+        'Created': creation_time,
+        'Last Modified': last_modified,
+        'Desired Inference Units': desired_inference_units,
+        'Current Inference Units': current_inference_units,
+        'Data Access Role ARN': data_access_role,
+        'Message': message
+    }
+
+
+def _scan_endpoints_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Comprehend endpoints from a single region.
+
+    Region-level failures propagate (see ``_scan_recognizers_region`` docstring
+    for the rationale); malformed individual endpoints are skipped and logged.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting endpoints in {region}...")
+    comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
+
+    region_endpoints = []
+    paginator = comprehend_client.get_paginator('list_endpoints')
+    for page in paginator.paginate():
+        endpoints = page.get('EndpointPropertiesList', [])
+
+        for endpoint in endpoints:
+            try:
+                region_endpoints.append(_build_endpoint_row(endpoint, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed endpoint in {region}: "
+                    f"{endpoint.get('EndpointArn', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_endpoints)} endpoints in {region}")
+    return region_endpoints
+
+
+def collect_endpoints(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Comprehend endpoint information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(endpoints, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_endpoints_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_endpoints = [e for result in region_results for e in result]
+    utils.log_info(f"Collected {len(all_endpoints)} endpoints total")
+    return all_endpoints, failed_regions
+
+
+def _build_classification_job_row(job: dict, region: str) -> dict[str, Any]:
+    """Build a single document classification job export row."""
+    job_id = job.get('JobId', 'N/A')
+    job_name = job.get('JobName', 'N/A')
+    job_status = job.get('JobStatus', 'N/A')
+
+    submit_time = job.get('SubmitTime', 'N/A')
+    if submit_time != 'N/A':
+        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    end_time = job.get('EndTime', 'N/A')
+    if end_time != 'N/A':
+        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Document classifier ARN
+    document_classifier_arn = job.get('DocumentClassifierArn', 'N/A')
+
+    # Input config
+    input_config = job.get('InputDataConfig', {}) or {}
+    input_s3_uri = input_config.get('S3Uri', 'N/A')
+
+    # Output config
+    output_config = job.get('OutputDataConfig', {}) or {}
+    output_s3_uri = output_config.get('S3Uri', 'N/A')
+
+    # Data access role
+    data_access_role = job.get('DataAccessRoleArn', 'N/A')
+
+    # Message
+    message = job.get('Message', 'N/A')
+
+    return {
+        'Region': region,
+        'Job ID': job_id,
+        'Job Name': job_name,
+        'Status': job_status,
+        'Submitted': submit_time,
+        'Ended': end_time,
+        'Document Classifier ARN': document_classifier_arn,
+        'Input S3 URI': input_s3_uri,
+        'Output S3 URI': output_s3_uri,
+        'Data Access Role ARN': data_access_role,
+        'Message': message
+    }
+
+
+def _scan_classification_jobs_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect document classification jobs (limited to 30 most recent) from a
+    single region.
+
+    Region-level failures propagate (see ``_scan_recognizers_region`` docstring
+    for the rationale); malformed individual jobs are skipped and logged.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting document classification jobs in {region}...")
+    comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
+
+    region_jobs = []
+    paginator = comprehend_client.get_paginator('list_document_classification_jobs')
+    job_count = 0
+    for page in paginator.paginate(PaginationConfig={'MaxItems': 30}):
+        jobs = page.get('DocumentClassificationJobPropertiesList', [])
+
+        for job in jobs:
+            try:
+                region_jobs.append(_build_classification_job_row(job, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed document classification job in {region}: "
+                    f"{job.get('JobId', '<unknown>')}",
+                    e,
+                )
+            finally:
+                job_count += 1
+
+            if job_count >= 30:
+                break
+
+    utils.log_info(f"Collected {len(region_jobs)} document classification jobs in {region}")
+    return region_jobs
+
+
+def collect_document_classification_jobs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect document classification job information across regions, surfacing
+    failures.
+
+    Returns:
+        tuple: ``(jobs, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_classification_jobs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_jobs = [j for result in region_results for j in result]
+    utils.log_info(f"Collected {len(all_jobs)} document classification jobs total (limited to 30 most recent per region)")
+    return all_jobs, failed_regions
+
+
+def _build_entities_job_row(job: dict, region: str) -> dict[str, Any]:
+    """Build a single entities detection job export row."""
+    job_id = job.get('JobId', 'N/A')
+    job_name = job.get('JobName', 'N/A')
+    job_status = job.get('JobStatus', 'N/A')
+    language_code = job.get('LanguageCode', 'N/A')
+
+    submit_time = job.get('SubmitTime', 'N/A')
+    if submit_time != 'N/A':
+        submit_time = submit_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    end_time = job.get('EndTime', 'N/A')
+    if end_time != 'N/A':
+        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Entity recognizer ARN (if custom)
+    entity_recognizer_arn = job.get('EntityRecognizerArn', 'Built-in')
+
+    # Input config
+    input_config = job.get('InputDataConfig', {}) or {}
+    input_s3_uri = input_config.get('S3Uri', 'N/A')
+
+    # Output config
+    output_config = job.get('OutputDataConfig', {}) or {}
+    output_s3_uri = output_config.get('S3Uri', 'N/A')
+
+    # Data access role
+    data_access_role = job.get('DataAccessRoleArn', 'N/A')
+
+    # Message
+    message = job.get('Message', 'N/A')
+
+    return {
+        'Region': region,
+        'Job ID': job_id,
+        'Job Name': job_name,
+        'Status': job_status,
+        'Language': language_code,
+        'Submitted': submit_time,
+        'Ended': end_time,
+        'Entity Recognizer ARN': entity_recognizer_arn,
+        'Input S3 URI': input_s3_uri,
+        'Output S3 URI': output_s3_uri,
+        'Data Access Role ARN': data_access_role,
+        'Message': message
+    }
+
+
+def _scan_entities_jobs_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect entities detection jobs (limited to 30 most recent) from a single
+    region.
+
+    Region-level failures propagate (see ``_scan_recognizers_region`` docstring
+    for the rationale); malformed individual jobs are skipped and logged.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting entities detection jobs in {region}...")
+    comprehend_client = utils.get_boto3_client('comprehend', region_name=region)
+
+    region_jobs = []
+    paginator = comprehend_client.get_paginator('list_entities_detection_jobs')
+    job_count = 0
+    for page in paginator.paginate(PaginationConfig={'MaxItems': 30}):
+        jobs = page.get('EntitiesDetectionJobPropertiesList', [])
+
+        for job in jobs:
+            try:
+                region_jobs.append(_build_entities_job_row(job, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed entities detection job in {region}: "
+                    f"{job.get('JobId', '<unknown>')}",
+                    e,
+                )
+            finally:
+                job_count += 1
+
+            if job_count >= 30:
+                break
+
+    utils.log_info(f"Collected {len(region_jobs)} entities detection jobs in {region}")
+    return region_jobs
+
+
+def collect_entities_detection_jobs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect entities detection job information across regions, surfacing
+    failures.
+
+    Returns:
+        tuple: ``(jobs, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_entities_jobs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_jobs = [j for result in region_results for j in result]
+    utils.log_info(f"Collected {len(all_jobs)} entities detection jobs total (limited to 30 most recent per region)")
+    return all_jobs, failed_regions
 
 
 def generate_summary(recognizers: list[dict[str, Any]],
@@ -510,11 +684,24 @@ def main():
     # Collect data
     print("\nCollecting Amazon Comprehend data...")
 
-    recognizers = collect_entity_recognizers(regions)
-    classifiers = collect_document_classifiers(regions)
-    endpoints = collect_endpoints(regions)
-    classification_jobs = collect_document_classification_jobs(regions)
-    entities_jobs = collect_entities_detection_jobs(regions)
+    # Each scope is a region-scanned collector that raises on region-level
+    # failure; failures accumulate into one combined list that drives a
+    # single failure marker + exit code below (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    recognizers, failed_recognizers = collect_entity_recognizers(regions)
+    classifiers, failed_classifiers = collect_document_classifiers(regions)
+    endpoints, failed_endpoints = collect_endpoints(regions)
+    classification_jobs, failed_classification_jobs = collect_document_classification_jobs(regions)
+    entities_jobs, failed_entities_jobs = collect_entities_detection_jobs(regions)
+
+    failed_regions = (
+        failed_recognizers
+        + failed_classifiers
+        + failed_endpoints
+        + failed_classification_jobs
+        + failed_entities_jobs
+    )
+
     summary = generate_summary(recognizers, classifiers, endpoints,
                                 classification_jobs, entities_jobs)
 
@@ -553,7 +740,8 @@ def main():
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'comprehend', region_suffix)
@@ -562,8 +750,20 @@ def main():
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
         # Log summary
-    else:
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Amazon Comprehend data found to export")
+
+    # If ANY region failed ANY scope collection, make it loud: write a marker
+    # and exit non-zero, even if some data was exported. A partial export
+    # that looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'comprehend', failed_regions)
+        print(
+            "\nERROR: Amazon Comprehend export completed with failures — data is incomplete. "
+            "See the *-comprehend-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Amazon Comprehend export completed successfully")
 

--- a/scripts/compute_optimizer_export.py
+++ b/scripts/compute_optimizer_export.py
@@ -17,6 +17,7 @@ The data is exported to an Excel file with separate tabs for each recommendation
 import datetime
 import sys
 from pathlib import Path
+from typing import Any, Callable
 
 # Add path to import utils module
 try:
@@ -79,10 +80,59 @@ def check_compute_optimizer_availability(region):
         print(f"Compute Optimizer is not active in {region} (Status: {status})")
         return False
 
-@utils.aws_error_handler("Fetching EC2 instance recommendations", default_return=[])
-def get_ec2_recommendations(region):
+def _build_ec2_recommendation_row(recommendation: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single EC2 instance recommendation export row."""
+    current_instance = recommendation.get('currentInstanceType', 'Unknown')
+    instance_id = recommendation.get('instanceArn', 'Unknown').split('/')[-1]
+
+    # Process recommendation options
+    rec_options = recommendation.get('recommendationOptions', [])
+    if rec_options:
+        top_recommendation = rec_options[0]
+        recommended_type = top_recommendation.get('instanceType', 'Unknown')
+        savings_opportunity = top_recommendation.get('savingsOpportunity', {})
+        savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
+        estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
+        performance_risk = top_recommendation.get('performanceRisk', 'Unknown')
+    else:
+        recommended_type = 'No recommendation'
+        savings_percentage = 0
+        estimated_monthly_savings = 0
+        performance_risk = 'Unknown'
+
+    # Get utilization metrics
+    metrics = recommendation.get('utilizationMetrics', [])
+    cpu_utilization = next((m.get('value') for m in metrics if m.get('name') == 'CPU'), 0)
+    memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'MEMORY'), 0)
+
+    return {
+        'Region': region,
+        'Instance ID': instance_id,
+        'Current Instance Type': current_instance,
+        'Recommended Instance Type': recommended_type,
+        'Finding': recommendation.get('finding', 'Unknown'),
+        'Performance Risk': performance_risk,
+        'CPU Utilization (%)': cpu_utilization,
+        'Memory Utilization (%)': memory_utilization,
+        'Savings Percentage (%)': round(savings_percentage, 2),
+        'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
+        'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
+    }
+
+
+def get_ec2_recommendations(region: str) -> list[dict[str, Any]]:
     """
-    Get EC2 instance recommendations from Compute Optimizer.
+    Get EC2 instance recommendations from Compute Optimizer for a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no recommendations" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed recommendations are skipped (logged) rather than
+    aborting the whole region.
 
     Args:
         region (str): AWS region name
@@ -90,6 +140,10 @@ def get_ec2_recommendations(region):
     Returns:
         list: List of dictionaries containing EC2 recommendations
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Fetching EC2 instance recommendations for region {region}")
     recommendations = []
 
@@ -104,45 +158,11 @@ def get_ec2_recommendations(region):
             params['nextToken'] = next_token
         page = compute_optimizer.get_ec2_instance_recommendations(**params)
         for recommendation in page.get('instanceRecommendations', []):
-            current_instance = recommendation.get('currentInstanceType', 'Unknown')
-            instance_id = recommendation.get('instanceArn', 'Unknown').split('/')[-1]
-
-            # Process recommendation options
-            rec_options = recommendation.get('recommendationOptions', [])
-            if rec_options:
-                top_recommendation = rec_options[0]
-                recommended_type = top_recommendation.get('instanceType', 'Unknown')
-                savings_opportunity = top_recommendation.get('savingsOpportunity', {})
-                savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
-                estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
-                performance_risk = top_recommendation.get('performanceRisk', 'Unknown')
-            else:
-                recommended_type = 'No recommendation'
-                savings_percentage = 0
-                estimated_monthly_savings = 0
-                performance_risk = 'Unknown'
-
-            # Get utilization metrics
-            metrics = recommendation.get('utilizationMetrics', [])
-            cpu_utilization = next((m.get('value') for m in metrics if m.get('name') == 'CPU'), 0)
-            memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'MEMORY'), 0)
-
-            # Create recommendation entry
-            rec_entry = {
-                'Region': region,
-                'Instance ID': instance_id,
-                'Current Instance Type': current_instance,
-                'Recommended Instance Type': recommended_type,
-                'Finding': recommendation.get('finding', 'Unknown'),
-                'Performance Risk': performance_risk,
-                'CPU Utilization (%)': cpu_utilization,
-                'Memory Utilization (%)': memory_utilization,
-                'Savings Percentage (%)': round(savings_percentage, 2),
-                'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
-                'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
-            }
-
-            recommendations.append(rec_entry)
+            try:
+                recommendations.append(_build_ec2_recommendation_row(recommendation, region))
+            except Exception as e:
+                utils.log_error(f"Skipping malformed EC2 recommendation in {region}", e)
+                continue
 
         next_token = page.get('nextToken')
         if not next_token:
@@ -151,10 +171,52 @@ def get_ec2_recommendations(region):
     utils.log_success(f"Found {len(recommendations)} EC2 instance recommendations in {region}")
     return recommendations
 
-@utils.aws_error_handler("Fetching Auto Scaling Group recommendations", default_return=[])
-def get_asg_recommendations(region):
+def _build_asg_recommendation_row(recommendation: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Auto Scaling Group recommendation export row."""
+    asg_name = recommendation.get('autoScalingGroupName', 'Unknown')
+    current_instances = recommendation.get('currentInstanceType', ['Unknown'])
+
+    # Process recommendation options
+    rec_options = recommendation.get('recommendationOptions', [])
+    if rec_options:
+        top_recommendation = rec_options[0]
+        recommended_types = top_recommendation.get('instanceType', ['Unknown'])
+        savings_opportunity = top_recommendation.get('savingsOpportunity', {})
+        savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
+        estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
+    else:
+        recommended_types = ['No recommendation']
+        savings_percentage = 0
+        estimated_monthly_savings = 0
+
+    # Get current configuration
+    current_config = recommendation.get('currentConfiguration', {})
+    min_size = current_config.get('desiredCapacity', 'Unknown')
+    max_size = current_config.get('maxSize', 'Unknown')
+
+    return {
+        'Region': region,
+        'Auto Scaling Group Name': asg_name,
+        'Current Instance Types': ', '.join(current_instances),
+        'Recommended Instance Types': ', '.join(recommended_types),
+        'Desired Capacity': min_size,
+        'Max Size': max_size,
+        'Finding': recommendation.get('finding', 'Unknown'),
+        'Savings Percentage (%)': round(savings_percentage, 2),
+        'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
+        'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
+    }
+
+
+def get_asg_recommendations(region: str) -> list[dict[str, Any]]:
     """
-    Get Auto Scaling Group recommendations from Compute Optimizer.
+    Get Auto Scaling Group recommendations from Compute Optimizer for a
+    single region.
+
+    This is a primary scope collector — see ``get_ec2_recommendations`` for
+    the silent-collection-loss rationale. Region-level failures propagate;
+    individual malformed recommendations are skipped (logged) instead of
+    aborting the whole region.
 
     Args:
         region (str): AWS region name
@@ -162,6 +224,10 @@ def get_asg_recommendations(region):
     Returns:
         list: List of dictionaries containing ASG recommendations
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Fetching Auto Scaling Group recommendations for region {region}")
     recommendations = []
 
@@ -176,42 +242,11 @@ def get_asg_recommendations(region):
             params['nextToken'] = next_token
         page = compute_optimizer.get_auto_scaling_group_recommendations(**params)
         for recommendation in page.get('autoScalingGroupRecommendations', []):
-            asg_name = recommendation.get('autoScalingGroupName', 'Unknown')
-            current_instances = recommendation.get('currentInstanceType', ['Unknown'])
-
-            # Process recommendation options
-            rec_options = recommendation.get('recommendationOptions', [])
-            if rec_options:
-                top_recommendation = rec_options[0]
-                recommended_types = top_recommendation.get('instanceType', ['Unknown'])
-                savings_opportunity = top_recommendation.get('savingsOpportunity', {})
-                savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
-                estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
-            else:
-                recommended_types = ['No recommendation']
-                savings_percentage = 0
-                estimated_monthly_savings = 0
-
-            # Get current configuration
-            current_config = recommendation.get('currentConfiguration', {})
-            min_size = current_config.get('desiredCapacity', 'Unknown')
-            max_size = current_config.get('maxSize', 'Unknown')
-
-            # Create recommendation entry
-            rec_entry = {
-                'Region': region,
-                'Auto Scaling Group Name': asg_name,
-                'Current Instance Types': ', '.join(current_instances),
-                'Recommended Instance Types': ', '.join(recommended_types),
-                'Desired Capacity': min_size,
-                'Max Size': max_size,
-                'Finding': recommendation.get('finding', 'Unknown'),
-                'Savings Percentage (%)': round(savings_percentage, 2),
-                'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
-                'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
-            }
-
-            recommendations.append(rec_entry)
+            try:
+                recommendations.append(_build_asg_recommendation_row(recommendation, region))
+            except Exception as e:
+                utils.log_error(f"Skipping malformed Auto Scaling Group recommendation in {region}", e)
+                continue
 
         next_token = page.get('nextToken')
         if not next_token:
@@ -220,10 +255,69 @@ def get_asg_recommendations(region):
     utils.log_success(f"Found {len(recommendations)} Auto Scaling Group recommendations in {region}")
     return recommendations
 
-@utils.aws_error_handler("Fetching EBS volume recommendations", default_return=[])
-def get_ebs_recommendations(region):
+def _build_ebs_recommendation_row(recommendation: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single EBS volume recommendation export row."""
+    volume_arn = recommendation.get('volumeArn', 'Unknown')
+    volume_id = volume_arn.split('/')[-1]
+    current_config = recommendation.get('currentConfiguration', {})
+    current_volume_type = current_config.get('volumeType', 'Unknown')
+    current_volume_size = current_config.get('volumeSize', 0)
+    current_volume_iops = current_config.get('volumeBaselineIOPS', 0)
+
+    # Process recommendation options
+    rec_options = recommendation.get('volumeRecommendationOptions', [])
+    if rec_options:
+        top_recommendation = rec_options[0]
+        recommended_config = top_recommendation.get('configuration', {})
+        recommended_type = recommended_config.get('volumeType', 'Unknown')
+        recommended_size = recommended_config.get('volumeSize', 0)
+        recommended_iops = recommended_config.get('volumeBaselineIOPS', 0)
+        savings_opportunity = top_recommendation.get('savingsOpportunity', {})
+        savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
+        estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
+    else:
+        recommended_type = 'No recommendation'
+        recommended_size = current_volume_size
+        recommended_iops = current_volume_iops
+        savings_percentage = 0
+        estimated_monthly_savings = 0
+
+    # Get utilization metrics
+    if 'utilizationMetrics' in recommendation:
+        metrics = recommendation.get('utilizationMetrics', [])
+        read_ops_per_second = next((m.get('value') for m in metrics if m.get('name') == 'VolumeReadOpsPerSecond'), 0)
+        write_ops_per_second = next((m.get('value') for m in metrics if m.get('name') == 'VolumeWriteOpsPerSecond'), 0)
+    else:
+        read_ops_per_second = 0
+        write_ops_per_second = 0
+
+    return {
+        'Region': region,
+        'Volume ID': volume_id,
+        'Current Volume Type': current_volume_type,
+        'Current Size (GB)': current_volume_size,
+        'Current IOPS': current_volume_iops,
+        'Recommended Volume Type': recommended_type,
+        'Recommended Size (GB)': recommended_size,
+        'Recommended IOPS': recommended_iops,
+        'Read Ops/Sec': read_ops_per_second,
+        'Write Ops/Sec': write_ops_per_second,
+        'Finding': recommendation.get('finding', 'Unknown'),
+        'Savings Percentage (%)': round(savings_percentage, 2),
+        'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
+        'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
+    }
+
+
+def get_ebs_recommendations(region: str) -> list[dict[str, Any]]:
     """
-    Get EBS volume recommendations from Compute Optimizer.
+    Get EBS volume recommendations from Compute Optimizer for a single
+    region.
+
+    This is a primary scope collector — see ``get_ec2_recommendations`` for
+    the silent-collection-loss rationale. Region-level failures propagate;
+    individual malformed recommendations are skipped (logged) instead of
+    aborting the whole region.
 
     Args:
         region (str): AWS region name
@@ -231,6 +325,10 @@ def get_ebs_recommendations(region):
     Returns:
         list: List of dictionaries containing EBS recommendations
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Fetching EBS volume recommendations for region {region}")
     recommendations = []
 
@@ -245,59 +343,11 @@ def get_ebs_recommendations(region):
             params['nextToken'] = next_token
         page = compute_optimizer.get_ebs_volume_recommendations(**params)
         for recommendation in page.get('volumeRecommendations', []):
-            volume_arn = recommendation.get('volumeArn', 'Unknown')
-            volume_id = volume_arn.split('/')[-1]
-            current_config = recommendation.get('currentConfiguration', {})
-            current_volume_type = current_config.get('volumeType', 'Unknown')
-            current_volume_size = current_config.get('volumeSize', 0)
-            current_volume_iops = current_config.get('volumeBaselineIOPS', 0)
-
-            # Process recommendation options
-            rec_options = recommendation.get('volumeRecommendationOptions', [])
-            if rec_options:
-                top_recommendation = rec_options[0]
-                recommended_config = top_recommendation.get('configuration', {})
-                recommended_type = recommended_config.get('volumeType', 'Unknown')
-                recommended_size = recommended_config.get('volumeSize', 0)
-                recommended_iops = recommended_config.get('volumeBaselineIOPS', 0)
-                savings_opportunity = top_recommendation.get('savingsOpportunity', {})
-                savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
-                estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
-            else:
-                recommended_type = 'No recommendation'
-                recommended_size = current_volume_size
-                recommended_iops = current_volume_iops
-                savings_percentage = 0
-                estimated_monthly_savings = 0
-
-            # Get utilization metrics
-            if 'utilizationMetrics' in recommendation:
-                metrics = recommendation.get('utilizationMetrics', [])
-                read_ops_per_second = next((m.get('value') for m in metrics if m.get('name') == 'VolumeReadOpsPerSecond'), 0)
-                write_ops_per_second = next((m.get('value') for m in metrics if m.get('name') == 'VolumeWriteOpsPerSecond'), 0)
-            else:
-                read_ops_per_second = 0
-                write_ops_per_second = 0
-
-            # Create recommendation entry
-            rec_entry = {
-                'Region': region,
-                'Volume ID': volume_id,
-                'Current Volume Type': current_volume_type,
-                'Current Size (GB)': current_volume_size,
-                'Current IOPS': current_volume_iops,
-                'Recommended Volume Type': recommended_type,
-                'Recommended Size (GB)': recommended_size,
-                'Recommended IOPS': recommended_iops,
-                'Read Ops/Sec': read_ops_per_second,
-                'Write Ops/Sec': write_ops_per_second,
-                'Finding': recommendation.get('finding', 'Unknown'),
-                'Savings Percentage (%)': round(savings_percentage, 2),
-                'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
-                'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
-            }
-
-            recommendations.append(rec_entry)
+            try:
+                recommendations.append(_build_ebs_recommendation_row(recommendation, region))
+            except Exception as e:
+                utils.log_error(f"Skipping malformed EBS volume recommendation in {region}", e)
+                continue
 
         next_token = page.get('nextToken')
         if not next_token:
@@ -306,10 +356,55 @@ def get_ebs_recommendations(region):
     utils.log_success(f"Found {len(recommendations)} EBS volume recommendations in {region}")
     return recommendations
 
-@utils.aws_error_handler("Fetching Lambda function recommendations", default_return=[])
-def get_lambda_recommendations(region):
+def _build_lambda_recommendation_row(recommendation: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Lambda function recommendation export row."""
+    function_arn = recommendation.get('functionArn', 'Unknown')
+    function_name = function_arn.split(':')[-1]
+
+    # Get current configuration
+    current_config = recommendation.get('currentConfiguration', {})
+    current_memory = current_config.get('memorySize', 0)
+
+    # Process recommendation options
+    rec_options = recommendation.get('functionRecommendationOptions', [])
+    if rec_options:
+        top_recommendation = rec_options[0]
+        recommended_config = top_recommendation.get('configuration', {})
+        recommended_memory = recommended_config.get('memorySize', 0)
+        savings_opportunity = top_recommendation.get('savingsOpportunity', {})
+        savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
+        estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
+    else:
+        recommended_memory = current_memory
+        savings_percentage = 0
+        estimated_monthly_savings = 0
+
+    # Get utilization metrics
+    metrics = recommendation.get('utilizationMetrics', [])
+    memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'Memory'), 0)
+
+    return {
+        'Region': region,
+        'Function Name': function_name,
+        'Current Memory (MB)': current_memory,
+        'Recommended Memory (MB)': recommended_memory,
+        'Memory Utilization (%)': memory_utilization,
+        'Finding': recommendation.get('finding', 'Unknown'),
+        'Savings Percentage (%)': round(savings_percentage, 2),
+        'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
+        'Last Invocation Time': recommendation.get('lastRefreshTimestamp', 'Unknown')
+    }
+
+
+def get_lambda_recommendations(region: str) -> list[dict[str, Any]]:
     """
-    Get Lambda function recommendations from Compute Optimizer.
+    Get Lambda function recommendations from Compute Optimizer for a single
+    region.
+
+    This is a primary scope collector — see ``get_ec2_recommendations`` for
+    the silent-collection-loss rationale. Region-level failures propagate;
+    individual malformed recommendations are skipped (logged) instead of
+    aborting the whole region.
 
     Args:
         region (str): AWS region name
@@ -317,6 +412,10 @@ def get_lambda_recommendations(region):
     Returns:
         list: List of dictionaries containing Lambda recommendations
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Fetching Lambda function recommendations for region {region}")
     recommendations = []
 
@@ -327,53 +426,73 @@ def get_lambda_recommendations(region):
 
     for page in paginator.paginate():
         for recommendation in page.get('lambdaFunctionRecommendations', []):
-            function_arn = recommendation.get('functionArn', 'Unknown')
-            function_name = function_arn.split(':')[-1]
-
-            # Get current configuration
-            current_config = recommendation.get('currentConfiguration', {})
-            current_memory = current_config.get('memorySize', 0)
-
-            # Process recommendation options
-            rec_options = recommendation.get('functionRecommendationOptions', [])
-            if rec_options:
-                top_recommendation = rec_options[0]
-                recommended_config = top_recommendation.get('configuration', {})
-                recommended_memory = recommended_config.get('memorySize', 0)
-                savings_opportunity = top_recommendation.get('savingsOpportunity', {})
-                savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
-                estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
-            else:
-                recommended_memory = current_memory
-                savings_percentage = 0
-                estimated_monthly_savings = 0
-
-            # Get utilization metrics
-            metrics = recommendation.get('utilizationMetrics', [])
-            memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'Memory'), 0)
-
-            # Create recommendation entry
-            rec_entry = {
-                'Region': region,
-                'Function Name': function_name,
-                'Current Memory (MB)': current_memory,
-                'Recommended Memory (MB)': recommended_memory,
-                'Memory Utilization (%)': memory_utilization,
-                'Finding': recommendation.get('finding', 'Unknown'),
-                'Savings Percentage (%)': round(savings_percentage, 2),
-                'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
-                'Last Invocation Time': recommendation.get('lastRefreshTimestamp', 'Unknown')
-            }
-
-            recommendations.append(rec_entry)
+            try:
+                recommendations.append(_build_lambda_recommendation_row(recommendation, region))
+            except Exception as e:
+                utils.log_error(f"Skipping malformed Lambda function recommendation in {region}", e)
+                continue
 
     utils.log_success(f"Found {len(recommendations)} Lambda function recommendations in {region}")
     return recommendations
 
-@utils.aws_error_handler("Fetching ECS service recommendations", default_return=[])
-def get_ecs_recommendations(region):
+def _build_ecs_recommendation_row(recommendation: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single ECS service recommendation export row."""
+    service_arn = recommendation.get('serviceArn', 'Unknown')
+    service_name = service_arn.split('/')[-1]
+    cluster_name = service_arn.split('/')[-2]
+
+    # Get current configuration
+    current_config = recommendation.get('currentServiceConfiguration', {})
+    current_cpu = current_config.get('cpu', 'Unknown')
+    current_memory = current_config.get('memory', 'Unknown')
+
+    # Process recommendation options
+    rec_options = recommendation.get('serviceRecommendationOptions', [])
+    if rec_options:
+        top_recommendation = rec_options[0]
+        recommended_config = top_recommendation.get('serviceConfiguration', {})
+        recommended_cpu = recommended_config.get('cpu', 'Unknown')
+        recommended_memory = recommended_config.get('memory', 'Unknown')
+        savings_opportunity = top_recommendation.get('savingsOpportunity', {})
+        savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
+        estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
+    else:
+        recommended_cpu = current_cpu
+        recommended_memory = current_memory
+        savings_percentage = 0
+        estimated_monthly_savings = 0
+
+    # Get utilization metrics
+    metrics = recommendation.get('utilizationMetrics', [])
+    cpu_utilization = next((m.get('value') for m in metrics if m.get('name') == 'CPU'), 0)
+    memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'MEMORY'), 0)
+
+    return {
+        'Region': region,
+        'Cluster Name': cluster_name,
+        'Service Name': service_name,
+        'Current CPU': current_cpu,
+        'Current Memory': current_memory,
+        'Recommended CPU': recommended_cpu,
+        'Recommended Memory': recommended_memory,
+        'CPU Utilization (%)': cpu_utilization,
+        'Memory Utilization (%)': memory_utilization,
+        'Finding': recommendation.get('finding', 'Unknown'),
+        'Savings Percentage (%)': round(savings_percentage, 2),
+        'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
+        'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
+    }
+
+
+def get_ecs_recommendations(region: str) -> list[dict[str, Any]]:
     """
-    Get ECS service recommendations from Compute Optimizer.
+    Get ECS service recommendations from Compute Optimizer for a single
+    region.
+
+    This is a primary scope collector — see ``get_ec2_recommendations`` for
+    the silent-collection-loss rationale. Region-level failures propagate;
+    individual malformed recommendations are skipped (logged) instead of
+    aborting the whole region.
 
     Args:
         region (str): AWS region name
@@ -381,6 +500,10 @@ def get_ecs_recommendations(region):
     Returns:
         list: List of dictionaries containing ECS recommendations
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Fetching ECS service recommendations for region {region}")
     recommendations = []
 
@@ -395,54 +518,11 @@ def get_ecs_recommendations(region):
             params['nextToken'] = next_token
         page = compute_optimizer.get_ecs_service_recommendations(**params)
         for recommendation in page.get('ecsServiceRecommendations', []):
-            service_arn = recommendation.get('serviceArn', 'Unknown')
-            service_name = service_arn.split('/')[-1]
-            cluster_name = service_arn.split('/')[-2]
-
-            # Get current configuration
-            current_config = recommendation.get('currentServiceConfiguration', {})
-            current_cpu = current_config.get('cpu', 'Unknown')
-            current_memory = current_config.get('memory', 'Unknown')
-
-            # Process recommendation options
-            rec_options = recommendation.get('serviceRecommendationOptions', [])
-            if rec_options:
-                top_recommendation = rec_options[0]
-                recommended_config = top_recommendation.get('serviceConfiguration', {})
-                recommended_cpu = recommended_config.get('cpu', 'Unknown')
-                recommended_memory = recommended_config.get('memory', 'Unknown')
-                savings_opportunity = top_recommendation.get('savingsOpportunity', {})
-                savings_percentage = savings_opportunity.get('savingsPercentage', 0) * 100
-                estimated_monthly_savings = savings_opportunity.get('estimatedMonthlySavings', {}).get('value', 0)
-            else:
-                recommended_cpu = current_cpu
-                recommended_memory = current_memory
-                savings_percentage = 0
-                estimated_monthly_savings = 0
-
-            # Get utilization metrics
-            metrics = recommendation.get('utilizationMetrics', [])
-            cpu_utilization = next((m.get('value') for m in metrics if m.get('name') == 'CPU'), 0)
-            memory_utilization = next((m.get('value') for m in metrics if m.get('name') == 'MEMORY'), 0)
-
-            # Create recommendation entry
-            rec_entry = {
-                'Region': region,
-                'Cluster Name': cluster_name,
-                'Service Name': service_name,
-                'Current CPU': current_cpu,
-                'Current Memory': current_memory,
-                'Recommended CPU': recommended_cpu,
-                'Recommended Memory': recommended_memory,
-                'CPU Utilization (%)': cpu_utilization,
-                'Memory Utilization (%)': memory_utilization,
-                'Finding': recommendation.get('finding', 'Unknown'),
-                'Savings Percentage (%)': round(savings_percentage, 2),
-                'Estimated Monthly Savings ($)': round(estimated_monthly_savings, 2),
-                'Reason': recommendation.get('findingReasonCodes', ['Unknown'])[0] if recommendation.get('findingReasonCodes') else 'Unknown'
-            }
-
-            recommendations.append(rec_entry)
+            try:
+                recommendations.append(_build_ecs_recommendation_row(recommendation, region))
+            except Exception as e:
+                utils.log_error(f"Skipping malformed ECS service recommendation in {region}", e)
+                continue
 
         next_token = page.get('nextToken')
         if not next_token:
@@ -450,6 +530,71 @@ def get_ecs_recommendations(region):
 
     utils.log_success(f"Found {len(recommendations)} ECS service recommendations in {region}")
     return recommendations
+
+
+def _scope_collect(
+    label: str,
+    regions: list[str],
+    scan_function: Callable[[str], list[dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Shared scope wrapper: run ``scan_function`` concurrently across
+    ``regions`` and surface failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result. The scope ``label`` is tagged onto each failure's error message
+    (not the region name) so a combined ``failed_regions`` list — built by
+    merging the five recommendation scopes in this file — still reads
+    unambiguously in the failure marker.
+
+    Args:
+        label: Short scope label used in progress output and failure tags
+            (e.g. ``"EC2"``, ``"Lambda"``).
+        regions: List of AWS regions to scan (already filtered to
+            Compute-Optimizer-active regions).
+        scan_function: Per-region collector, e.g. ``get_ec2_recommendations``.
+
+    Returns:
+        tuple: ``(recommendations, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
+    """
+    print(f"\n=== COLLECTING {label.upper()} RECOMMENDATIONS ===")
+    region_results, raw_failed = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=scan_function,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_recs = [rec for result in region_results for rec in result]
+    utils.log_success(f"Total {label} recommendations collected: {len(all_recs)}")
+    failed_regions = [(region, f"[{label}] {err}") for region, err in raw_failed]
+    return all_recs, failed_regions
+
+
+def collect_ec2_recommendations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Scope wrapper: EC2 instance recommendations across regions."""
+    return _scope_collect("EC2", regions, get_ec2_recommendations)
+
+
+def collect_asg_recommendations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Scope wrapper: Auto Scaling Group recommendations across regions."""
+    return _scope_collect("ASG", regions, get_asg_recommendations)
+
+
+def collect_ebs_recommendations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Scope wrapper: EBS volume recommendations across regions."""
+    return _scope_collect("EBS", regions, get_ebs_recommendations)
+
+
+def collect_lambda_recommendations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Scope wrapper: Lambda function recommendations across regions."""
+    return _scope_collect("Lambda", regions, get_lambda_recommendations)
+
+
+def collect_ecs_recommendations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """Scope wrapper: ECS service recommendations across regions."""
+    return _scope_collect("ECS", regions, get_ecs_recommendations)
 
 def export_recommendations_to_excel(all_recommendations, account_name):
     """
@@ -507,12 +652,23 @@ def export_recommendations_to_excel(all_recommendations, account_name):
         print("Error exporting recommendations to Excel.")
         return None
 
-def get_recommendations_for_all_regions():
+def get_recommendations_for_all_regions() -> tuple[dict[str, list], list[tuple[str, str]]]:
     """
     Get Compute Optimizer recommendations for all supported regions.
 
+    Runs each of the five recommendation types (EC2, ASG, EBS, Lambda, ECS)
+    as its own scope collector via ``scan_regions_concurrent(...,
+    collect_failures=True)``, then merges all five scopes' failed regions
+    into a single combined list. This is what lets the caller (``main`` /
+    ``export_recommendations_to_excel``) tell a FAILED collection apart from
+    a genuinely empty account — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``.
+
     Returns:
-        dict: Dictionary containing recommendations for each resource type
+        tuple: ``(all_recommendations, failed_regions)`` where
+        ``all_recommendations`` is a dict keyed by resource type, and
+        ``failed_regions`` is the combined list of ``(region, error_message)``
+        tuples across all five scopes.
     """
     # Dictionary to store recommendations for each resource type
     all_recommendations = {
@@ -527,26 +683,40 @@ def get_recommendations_for_all_regions():
     regions = get_all_regions()
     print(f"Found {len(regions)} AWS regions.")
 
-    # For each region, check if Compute Optimizer is available and get recommendations
+    # Determine which regions have Compute Optimizer active. A region that
+    # is simply not enrolled is not a collection failure, so this gating
+    # step stays outside the failed_regions contract.
+    active_regions = []
     for region in regions:
         print(f"\nChecking Compute Optimizer availability in region: {region}")
-
         if check_compute_optimizer_availability(region):
-            # Get recommendations for each resource type
-            ec2_recommendations = get_ec2_recommendations(region)
-            all_recommendations['EC2'].extend(ec2_recommendations)
+            active_regions.append(region)
 
-            asg_recommendations = get_asg_recommendations(region)
-            all_recommendations['ASG'].extend(asg_recommendations)
+    if not active_regions:
+        print("\nCompute Optimizer is not active in any checked region.")
+        return all_recommendations, []
 
-            ebs_recommendations = get_ebs_recommendations(region)
-            all_recommendations['EBS'].extend(ebs_recommendations)
+    failed_regions: list[tuple[str, str]] = []
 
-            lambda_recommendations = get_lambda_recommendations(region)
-            all_recommendations['Lambda'].extend(lambda_recommendations)
+    ec2_recommendations, ec2_failed = collect_ec2_recommendations(active_regions)
+    all_recommendations['EC2'] = ec2_recommendations
+    failed_regions.extend(ec2_failed)
 
-            ecs_recommendations = get_ecs_recommendations(region)
-            all_recommendations['ECS'].extend(ecs_recommendations)
+    asg_recommendations, asg_failed = collect_asg_recommendations(active_regions)
+    all_recommendations['ASG'] = asg_recommendations
+    failed_regions.extend(asg_failed)
+
+    ebs_recommendations, ebs_failed = collect_ebs_recommendations(active_regions)
+    all_recommendations['EBS'] = ebs_recommendations
+    failed_regions.extend(ebs_failed)
+
+    lambda_recommendations, lambda_failed = collect_lambda_recommendations(active_regions)
+    all_recommendations['Lambda'] = lambda_recommendations
+    failed_regions.extend(lambda_failed)
+
+    ecs_recommendations, ecs_failed = collect_ecs_recommendations(active_regions)
+    all_recommendations['ECS'] = ecs_recommendations
+    failed_regions.extend(ecs_failed)
 
     # Print summary
     print("\n=== RECOMMENDATIONS SUMMARY ===")
@@ -556,7 +726,7 @@ def get_recommendations_for_all_regions():
     print(f"Lambda Function recommendations: {len(all_recommendations['Lambda'])}")
     print(f"ECS Service recommendations: {len(all_recommendations['ECS'])}")
 
-    return all_recommendations
+    return all_recommendations, failed_regions
 
 def main():
     """
@@ -603,12 +773,16 @@ def main():
             print("Please enable Compute Optimizer first, then run this script again.")
             return
 
-        # Get recommendations for all regions
+        # Get recommendations for all regions. Region failures across any of
+        # the five recommendation scopes are collected into failed_regions
+        # rather than silently collapsed into "no recommendations".
         print("\nGetting AWS Compute Optimizer recommendations...")
         utils.log_info("Starting Compute Optimizer recommendations collection")
-        all_recommendations = get_recommendations_for_all_regions()
+        all_recommendations, failed_regions = get_recommendations_for_all_regions()
 
-        # Export recommendations to Excel
+        # Export whatever succeeded — a partial export is required even when
+        # some regions failed (see the silent-collection-failure blast-radius
+        # audit).
         print("\nExporting recommendations to Excel...")
         output_path = export_recommendations_to_excel(all_recommendations, account_name)
 
@@ -616,9 +790,23 @@ def main():
             print("\nExport completed successfully!")
             print(f"Recommendations exported to: {output_path}")
             utils.log_success(f"Compute Optimizer recommendations exported to: {output_path}")
-        else:
+        elif not failed_regions:
+            # Genuinely empty account: every scanned region succeeded (or
+            # none were active) and returned nothing.
             print("\nNo recommendations were exported. Please check if Compute Optimizer is enabled for your account.")
             utils.log_warning("No Compute Optimizer recommendations found")
+
+        # If ANY region failed any of the five recommendation scopes, make it
+        # loud: write a marker and exit non-zero, even if some data was
+        # exported. A partial export that looks complete is exactly the
+        # failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'compute-optimizer', failed_regions)
+            print(
+                "\nERROR: Compute Optimizer export completed with failures — data is incomplete. "
+                "See the *-compute-optimizer-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\nOperation cancelled by user.")

--- a/scripts/connect_export.py
+++ b/scripts/connect_export.py
@@ -28,104 +28,189 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Amazon Connect instances and resources to Excel")
 
+
+def _build_instance_row(instance_summary: dict, region: str) -> dict[str, Any]:
+    """
+    Build a single Connect instance export row from a list_instances entry.
+
+    Extracted so the per-instance processing can be wrapped in try/except by
+    the caller: a malformed instance entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+    """
+    instance_id = instance_summary.get('Id', 'N/A')
+    instance_arn = instance_summary.get('Arn', 'N/A')
+    instance_alias = instance_summary.get('InstanceAlias', 'N/A')
+    created_time = instance_summary.get('CreatedTime', 'N/A')
+    if created_time != 'N/A':
+        created_time = created_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    service_role = instance_summary.get('ServiceRole', 'N/A')
+    instance_status = instance_summary.get('InstanceStatus', 'N/A')
+    inbound_calls_enabled = instance_summary.get('InboundCallsEnabled', False)
+    outbound_calls_enabled = instance_summary.get('OutboundCallsEnabled', False)
+    instance_access_url = instance_summary.get('InstanceAccessUrl', 'N/A')
+
+    return {
+        'Region': region,
+        'Instance ID': instance_id,
+        'Instance Alias': instance_alias,
+        'Status': instance_status,
+        'Inbound Calls Enabled': inbound_calls_enabled,
+        'Outbound Calls Enabled': outbound_calls_enabled,
+        'Access URL': instance_access_url,
+        'Service Role': service_role,
+        'Created': created_time,
+        'ARN': instance_arn
+    }
+
+
 def _scan_instances_region(region: str) -> list[dict[str, Any]]:
-    """Scan Connect instances in a single region."""
+    """
+    Collect Connect instances from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Connect instances" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed instances are skipped (logged) rather than aborting
+    the whole region.
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_instances = []
     connect_client = utils.get_boto3_client('connect', region_name=region)
+    paginator = connect_client.get_paginator('list_instances')
 
-    try:
-        paginator = connect_client.get_paginator('list_instances')
-        for page in paginator.paginate():
-            instances = page.get('InstanceSummaryList', [])
+    for page in paginator.paginate():
+        instances = page.get('InstanceSummaryList', [])
 
-            for instance_summary in instances:
-                instance_id = instance_summary.get('Id', 'N/A')
-                instance_arn = instance_summary.get('Arn', 'N/A')
-                instance_alias = instance_summary.get('InstanceAlias', 'N/A')
-                created_time = instance_summary.get('CreatedTime', 'N/A')
-                if created_time != 'N/A':
-                    created_time = created_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                service_role = instance_summary.get('ServiceRole', 'N/A')
-                instance_status = instance_summary.get('InstanceStatus', 'N/A')
-                inbound_calls_enabled = instance_summary.get('InboundCallsEnabled', False)
-                outbound_calls_enabled = instance_summary.get('OutboundCallsEnabled', False)
-                instance_access_url = instance_summary.get('InstanceAccessUrl', 'N/A')
-
-                regional_instances.append({
-                    'Region': region,
-                    'Instance ID': instance_id,
-                    'Instance Alias': instance_alias,
-                    'Status': instance_status,
-                    'Inbound Calls Enabled': inbound_calls_enabled,
-                    'Outbound Calls Enabled': outbound_calls_enabled,
-                    'Access URL': instance_access_url,
-                    'Service Role': service_role,
-                    'Created': created_time,
-                    'ARN': instance_arn
-                })
-
-    except Exception as e:
-        utils.log_warning(f"Error listing Connect instances in {region}: {str(e)}")
+        for instance_summary in instances:
+            try:
+                regional_instances.append(_build_instance_row(instance_summary, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Connect instance in {region}: "
+                    f"{instance_summary.get('Id', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return regional_instances
 
 
-@utils.aws_error_handler("Collecting Connect instances", default_return=[])
-def collect_instances(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Connect instance information from AWS regions."""
+def collect_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Connect instance information across regions, surfacing failures.
+
+    Uses ``collect_failures=True``: ``_scan_instances_region`` raises on a
+    region-level failure so that failure is recorded and surfaced by the
+    caller, never silently collapsed into "no instances" (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+
+    Returns:
+        tuple: ``(instances, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples for regions whose scan
+        raised.
+    """
     print("\n=== COLLECTING CONNECT INSTANCES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_instances_region)
-    all_instances = [instance for result in results for instance in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_instances_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_instances = [instance for result in region_results for instance in result]
     utils.log_success(f"Total Connect instances collected: {len(all_instances)}")
-    return all_instances
+    return all_instances, failed_regions
 
 
-@utils.aws_error_handler("Collecting queues", default_return=[])
-def collect_queues(instances: list[dict[str, Any]], region: str) -> list[dict[str, Any]]:
-    """Collect queue information for Connect instances."""
+def _scan_queues_region(region: str, instances: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Collect queues for Connect instances in a single region.
+
+    Second top-level scope collector (blast-radius spec notes connect's
+    primary scope has "+2" siblings). Raises on API error so the failure is
+    surfaced via ``scan_regions_concurrent(..., collect_failures=True)``
+    rather than swallowed into an empty result.
+    """
+    if not utils.is_aws_region(region):
+        return []
+
+    region_queues = []
+    connect_client = utils.get_boto3_client('connect', region_name=region)
+
+    for instance in instances:
+        instance_id = instance.get('Instance ID', 'N/A')
+        if instance_id == 'N/A' or instance.get('Region') != region:
+            continue
+
+        paginator = connect_client.get_paginator('list_queues')
+        for page in paginator.paginate(InstanceId=instance_id):
+            queues = page.get('QueueSummaryList', [])
+
+            for queue in queues:
+                queue_id = queue.get('Id', 'N/A')
+                queue_arn = queue.get('Arn', 'N/A')
+                queue_name = queue.get('Name', 'N/A')
+                queue_type = queue.get('QueueType', 'N/A')
+
+                region_queues.append({
+                    'Region': region,
+                    'Instance ID': instance_id,
+                    'Queue ID': queue_id,
+                    'Queue Name': queue_name,
+                    'Queue Type': queue_type,
+                    'Queue ARN': queue_arn
+                })
+
+    return region_queues
+
+
+def collect_queues(
+    instances: list[dict[str, Any]], regions: list[str]
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect queue information for Connect instances across regions,
+    surfacing failures.
+
+    Returns:
+        tuple: ``(queues, failed_regions)``.
+    """
     print("\n=== COLLECTING CONNECT QUEUES ===")
-    all_queues = []
-    connect_client = utils.get_boto3_client('connect', region_name=region)
-
-    for instance in instances:
-        instance_id = instance.get('Instance ID', 'N/A')
-        if instance_id == 'N/A' or instance.get('Region') != region:
-            continue
-
-        try:
-            paginator = connect_client.get_paginator('list_queues')
-            for page in paginator.paginate(InstanceId=instance_id):
-                queues = page.get('QueueSummaryList', [])
-
-                for queue in queues:
-                    queue_id = queue.get('Id', 'N/A')
-                    queue_arn = queue.get('Arn', 'N/A')
-                    queue_name = queue.get('Name', 'N/A')
-                    queue_type = queue.get('QueueType', 'N/A')
-
-                    all_queues.append({
-                        'Region': region,
-                        'Instance ID': instance_id,
-                        'Queue ID': queue_id,
-                        'Queue Name': queue_name,
-                        'Queue Type': queue_type,
-                        'Queue ARN': queue_arn
-                    })
-
-        except Exception as e:
-            utils.log_warning(f"Error listing queues for instance {instance_id}: {str(e)}")
-            continue
-
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=lambda r: _scan_queues_region(r, instances),
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_queues = [queue for result in region_results for queue in result]
     utils.log_success(f"Total queues collected: {len(all_queues)}")
-    return all_queues
+    return all_queues, failed_regions
 
 
-@utils.aws_error_handler("Collecting phone numbers", default_return=[])
-def collect_phone_numbers(instances: list[dict[str, Any]], region: str) -> list[dict[str, Any]]:
-    """Collect phone number information for Connect instances."""
-    print("\n=== COLLECTING PHONE NUMBERS ===")
-    all_numbers = []
+def _scan_phone_numbers_region(region: str, instances: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Collect phone numbers for Connect instances in a single region.
+
+    Third top-level scope collector (blast-radius spec notes connect's
+    primary scope has "+2" siblings). Raises on API error so the failure is
+    surfaced via ``scan_regions_concurrent(..., collect_failures=True)``
+    rather than swallowed into an empty result.
+    """
+    if not utils.is_aws_region(region):
+        return []
+
+    region_numbers = []
     connect_client = utils.get_boto3_client('connect', region_name=region)
 
     for instance in instances:
@@ -133,32 +218,48 @@ def collect_phone_numbers(instances: list[dict[str, Any]], region: str) -> list[
         if instance_id == 'N/A' or instance.get('Region') != region:
             continue
 
-        try:
-            paginator = connect_client.get_paginator('list_phone_numbers_v2')
-            for page in paginator.paginate(TargetArn=instance.get('ARN', '')):
-                numbers = page.get('ListPhoneNumbersSummaryList', [])
+        paginator = connect_client.get_paginator('list_phone_numbers_v2')
+        for page in paginator.paginate(TargetArn=instance.get('ARN', '')):
+            numbers = page.get('ListPhoneNumbersSummaryList', [])
 
-                for number in numbers:
-                    phone_number_id = number.get('PhoneNumberId', 'N/A')
-                    phone_number = number.get('PhoneNumber', 'N/A')
-                    phone_number_type = number.get('PhoneNumberType', 'N/A')
-                    phone_number_country_code = number.get('PhoneNumberCountryCode', 'N/A')
+            for number in numbers:
+                phone_number_id = number.get('PhoneNumberId', 'N/A')
+                phone_number = number.get('PhoneNumber', 'N/A')
+                phone_number_type = number.get('PhoneNumberType', 'N/A')
+                phone_number_country_code = number.get('PhoneNumberCountryCode', 'N/A')
 
-                    all_numbers.append({
-                        'Region': region,
-                        'Instance ID': instance_id,
-                        'Phone Number ID': phone_number_id,
-                        'Phone Number': phone_number,
-                        'Type': phone_number_type,
-                        'Country Code': phone_number_country_code
-                    })
+                region_numbers.append({
+                    'Region': region,
+                    'Instance ID': instance_id,
+                    'Phone Number ID': phone_number_id,
+                    'Phone Number': phone_number,
+                    'Type': phone_number_type,
+                    'Country Code': phone_number_country_code
+                })
 
-        except Exception as e:
-            utils.log_warning(f"Error listing phone numbers for instance {instance_id}: {str(e)}")
-            continue
+    return region_numbers
 
+
+def collect_phone_numbers(
+    instances: list[dict[str, Any]], regions: list[str]
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect phone number information for Connect instances across regions,
+    surfacing failures.
+
+    Returns:
+        tuple: ``(phone_numbers, failed_regions)``.
+    """
+    print("\n=== COLLECTING PHONE NUMBERS ===")
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=lambda r: _scan_phone_numbers_region(r, instances),
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_numbers = [number for result in region_results for number in result]
     utils.log_success(f"Total phone numbers collected: {len(all_numbers)}")
-    return all_numbers
+    return all_numbers, failed_regions
 
 
 def generate_summary(instances: list[dict[str, Any]],
@@ -236,16 +337,19 @@ def main():
     # Collect data
     print("\nCollecting AWS Connect data...")
 
-    instances = collect_instances(regions)
+    # STEP 1: Collect Connect instances (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    instances, instances_failed = collect_instances(regions)
 
-    # Collect queues and phone numbers per region (not concurrent to avoid rate limiting)
-    all_queues = []
-    all_phone_numbers = []
-    for region in regions:
-        queues = collect_queues(instances, region)
-        phone_numbers = collect_phone_numbers(instances, region)
-        all_queues.extend(queues)
-        all_phone_numbers.extend(phone_numbers)
+    # STEP 2 & 3: Collect queues and phone numbers. These are also top-level
+    # region-scanned scope collectors (blast-radius spec: connect +2), so
+    # their failures are surfaced the same way as the primary scope.
+    all_queues, queues_failed = collect_queues(instances, regions)
+    all_phone_numbers, phones_failed = collect_phone_numbers(instances, regions)
+
+    # Combine failures from all top-level scope collectors into one list so a
+    # single marker + exit covers the whole export.
+    failed_regions = instances_failed + queues_failed + phones_failed
 
     summary = generate_summary(instances, all_queues, all_phone_numbers)
 
@@ -274,17 +378,28 @@ def main():
         df_numbers = utils.prepare_dataframe_for_export(df_numbers)
         dataframes['Phone Numbers'] = df_numbers
 
-    # Export to Excel
+    # Export whatever succeeded — a partial export is required even when some
+    # regions failed (see the silent-collection-failure blast-radius audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'connect', region_suffix)
 
         utils.log_info(f"Exporting to {filename}...")
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
-
-        # Log summary
-    else:
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Connect data found to export")
+
+    # If ANY region failed any top-level scope collection, make it loud: write
+    # a marker and exit non-zero, even if some data was exported. A partial
+    # export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'connect', failed_regions)
+        print(
+            "\nERROR: Connect export completed with failures — data is incomplete. "
+            "See the *-connect-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Connect export completed successfully")
 

--- a/scripts/ecr_export.py
+++ b/scripts/ecr_export.py
@@ -46,109 +46,162 @@ except ImportError:
 args = utils.parse_script_args("Export Elastic Container Registry repositories and images to Excel")
 
 
+def _build_repo_row(repo: dict[str, Any], region: str, ecr_client=None) -> dict[str, Any]:
+    """
+    Build a single ECR repository export row from a describe_repositories entry.
+
+    Extracted so the per-repository processing can be wrapped in try/except by
+    the caller: a malformed repository entry is logged and skipped rather than
+    discarding the whole region's results.
+
+    Args:
+        repo: A single repository entry from describe_repositories.
+        region: AWS region name.
+        ecr_client: Optional pre-built ECR client (reused across repos in a
+            region to avoid recreating one per row). Created on demand if
+            not supplied.
+
+    Returns:
+        dict: The assembled repository row.
+    """
+    repository_name = repo.get('repositoryName', '')
+    print(f"  Processing repository: {repository_name}")
+
+    # Basic information
+    repository_arn = repo.get('repositoryArn', '')
+    repository_uri = repo.get('repositoryUri', '')
+    registry_id = repo.get('registryId', '')
+
+    # Creation date
+    created_at = repo.get('createdAt', '')
+    if created_at:
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
+
+    # Image tag mutability
+    image_tag_mutability = repo.get('imageTagMutability', 'MUTABLE')
+
+    # Image scanning configuration
+    image_scanning_config = repo.get('imageScanningConfiguration', {})
+    scan_on_push = image_scanning_config.get('scanOnPush', False)
+
+    # Encryption configuration
+    encryption_config = repo.get('encryptionConfiguration', {})
+    encryption_type = encryption_config.get('encryptionType', 'AES256')
+    kms_key = encryption_config.get('kmsKey', 'N/A')
+
+    # Get image count (paginated — maxResults=1000 was silently capping).
+    # Per-field enrichment: gracefully degrades to 'Unknown' rather than
+    # failing the whole repository row.
+    image_count: Any
+    try:
+        image_count = 0
+        client = ecr_client if ecr_client is not None else utils.get_boto3_client('ecr', region_name=region)
+        image_paginator = client.get_paginator('describe_images')
+        for img_page in image_paginator.paginate(repositoryName=repository_name):
+            image_count += len(img_page.get('imageDetails', []))
+    except Exception:
+        image_count = 'Unknown'
+
+    return {
+        'Region': region,
+        'Repository Name': repository_name,
+        'Repository URI': repository_uri,
+        'Registry ID': registry_id,
+        'Image Count': image_count,
+        'Image Tag Mutability': image_tag_mutability,
+        'Scan on Push': scan_on_push,
+        'Encryption Type': encryption_type,
+        'KMS Key': kms_key,
+        'Created At': created_at,
+        'Repository ARN': repository_arn
+    }
+
+
 def scan_ecr_repositories_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan ECR repositories in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no ECR repositories" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed repositories are skipped (logged) rather than
+    aborting the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with ECR repository information from this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    ecr_client = utils.get_boto3_client('ecr', region_name=region)
+
+    # Get ECR repositories
+    paginator = ecr_client.get_paginator('describe_repositories')
     regional_repos = []
+    repo_count = 0
 
-    try:
-        ecr_client = utils.get_boto3_client('ecr', region_name=region)
+    for page in paginator.paginate():
+        repositories = page.get('repositories', [])
+        repo_count += len(repositories)
 
-        # Get ECR repositories
-        paginator = ecr_client.get_paginator('describe_repositories')
-        repo_count = 0
+        for repo in repositories:
+            try:
+                regional_repos.append(_build_repo_row(repo, region, ecr_client))
+            except Exception as e:
+                # One malformed repository is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed ECR repository in {region}: "
+                    f"{repo.get('repositoryName', '<unknown>')}",
+                    e,
+                )
+                continue
 
-        for page in paginator.paginate():
-            repositories = page.get('repositories', [])
-            repo_count += len(repositories)
-
-            for repo in repositories:
-                repository_name = repo.get('repositoryName', '')
-                print(f"  Processing repository: {repository_name}")
-
-                # Basic information
-                repository_arn = repo.get('repositoryArn', '')
-                repository_uri = repo.get('repositoryUri', '')
-                registry_id = repo.get('registryId', '')
-
-                # Creation date
-                created_at = repo.get('createdAt', '')
-                if created_at:
-                    created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
-
-                # Image tag mutability
-                image_tag_mutability = repo.get('imageTagMutability', 'MUTABLE')
-
-                # Image scanning configuration
-                image_scanning_config = repo.get('imageScanningConfiguration', {})
-                scan_on_push = image_scanning_config.get('scanOnPush', False)
-
-                # Encryption configuration
-                encryption_config = repo.get('encryptionConfiguration', {})
-                encryption_type = encryption_config.get('encryptionType', 'AES256')
-                kms_key = encryption_config.get('kmsKey', 'N/A')
-
-                # Get image count (paginated — maxResults=1000 was silently capping)
-                try:
-                    image_count = 0
-                    image_paginator = ecr_client.get_paginator('describe_images')
-                    for img_page in image_paginator.paginate(repositoryName=repository_name):
-                        image_count += len(img_page.get('imageDetails', []))
-                except Exception:
-                    image_count = 'Unknown'
-
-                regional_repos.append({
-                    'Region': region,
-                    'Repository Name': repository_name,
-                    'Repository URI': repository_uri,
-                    'Registry ID': registry_id,
-                    'Image Count': image_count,
-                    'Image Tag Mutability': image_tag_mutability,
-                    'Scan on Push': scan_on_push,
-                    'Encryption Type': encryption_type,
-                    'KMS Key': kms_key,
-                    'Created At': created_at,
-                    'Repository ARN': repository_arn
-                })
-
-        utils.log_info(f"Found {repo_count} ECR repositories in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for ECR repositories", e)
-
+    utils.log_info(f"Found {repo_count} ECR repositories in {region}")
     return regional_repos
 
 
-@utils.aws_error_handler("Collecting ECR repositories", default_return=[])
-def collect_ecr_repositories(regions: list[str]) -> list[dict[str, Any]]:
+def collect_ecr_repositories(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect ECR repository information from AWS regions using concurrent scanning.
+    Collect ECR repository information from AWS regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with ECR repository information
+        tuple: ``(repos, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING ECR REPOSITORIES ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    all_repos = []
-    for region_repos in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_ecr_repositories_in_region,
-    ):
-        all_repos.extend(region_repos)
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_repos = [repo for result in region_results for repo in result]
 
     utils.log_success(f"Total ECR repositories collected: {len(all_repos)}")
-    return all_repos
+    return all_repos, failed_regions
 
 
 def scan_ecr_images_in_region(region: str) -> list[dict[str, Any]]:
@@ -379,58 +432,75 @@ def export_ecr_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect ECR repositories
-    repos = collect_ecr_repositories(regions)
+    # STEP 1: Collect ECR repositories (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    repos, failed_regions = collect_ecr_repositories(regions)
     if repos:
         data_frames['ECR Repositories'] = pd.DataFrame(repos)
 
-    # STEP 2: Collect images
+    # STEP 2: Collect images (enrichment — degrades gracefully; a region-level
+    # failure here does not fail the whole export).
     images = collect_ecr_images(regions)
     if images:
         data_frames['Images'] = pd.DataFrame(images)
 
-    # STEP 3: Collect lifecycle policies
+    # STEP 3: Collect lifecycle policies (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     policies = collect_lifecycle_policies(regions)
     if policies:
         data_frames['Lifecycle Policies'] = pd.DataFrame(policies)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius
+    # audit).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'ecr',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("ECR data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No ECR data was collected. Nothing to export.")
         print("\nNo ECR repositories found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'ecr',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("ECR data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the ECR Repositories scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data (from this
+    # scope or the enrichment sheets) was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ecr', failed_regions)
+        print(
+            "\nERROR: ECR export completed with failures — data is incomplete. "
+            "See the *-ecr-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -46,406 +46,491 @@ except ImportError:
 args = utils.parse_script_args("Export EC2 Image Builder pipelines and recipes to Excel")
 
 
-@utils.aws_error_handler("Collecting Image Builder pipelines", default_return=[])
-def collect_image_pipelines(regions: list[str]) -> list[dict[str, Any]]:
+def _build_pipeline_row(imagebuilder: Any, pipeline_arn: str, region: str) -> dict[str, Any]:
     """
-    Collect Image Builder pipeline information from AWS regions.
+    Build a single Image Builder pipeline export row.
 
-    Args:
-        regions: List of AWS regions to scan
+    Fetches the pipeline's full details (the list API only returns ARNs) and
+    assembles the export row. Left to raise on failure so the caller can log
+    and skip just this one pipeline without discarding the rest of the
+    region's results.
+    """
+    pipeline_response = imagebuilder.get_image_pipeline(imagePipelineArn=pipeline_arn)
+    pipeline = pipeline_response.get('imagePipeline', {})
+
+    name = pipeline.get('name', '')
+    description = pipeline.get('description', 'N/A')
+    status = pipeline.get('status', '')
+
+    # Image recipe or container recipe
+    image_recipe_arn = pipeline.get('imageRecipeArn', 'N/A')
+    container_recipe_arn = pipeline.get('containerRecipeArn', 'N/A')
+
+    recipe_type = 'AMI' if image_recipe_arn != 'N/A' else 'Container'
+    recipe_arn = image_recipe_arn if recipe_type == 'AMI' else container_recipe_arn
+
+    # Infrastructure configuration
+    infrastructure_config_arn = pipeline.get('infrastructureConfigurationArn', 'N/A')
+
+    # Distribution configuration
+    distribution_config_arn = pipeline.get('distributionConfigurationArn', 'N/A')
+
+    # Schedule
+    schedule = pipeline.get('schedule', {})
+    schedule_expression = schedule.get('scheduleExpression', 'N/A')
+    pipeline_execution_start_condition = schedule.get('pipelineExecutionStartCondition', 'N/A')
+
+    # Enhanced image metadata
+    enhanced_metadata_enabled = pipeline.get('enhancedImageMetadataEnabled', False)
+
+    # Image tests
+    image_tests_config = pipeline.get('imageTestsConfiguration', {})
+    tests_enabled = image_tests_config.get('imageTestsEnabled', False)
+    timeout_minutes = image_tests_config.get('timeoutMinutes', 0)
+
+    # Date created
+    date_created = pipeline.get('dateCreated', 'N/A')
+
+    # Tags
+    tags = pipeline.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Pipeline Name': name,
+        'Status': status,
+        'Recipe Type': recipe_type,
+        'Schedule Expression': schedule_expression,
+        'Start Condition': pipeline_execution_start_condition,
+        'Tests Enabled': tests_enabled,
+        'Test Timeout (min)': timeout_minutes,
+        'Enhanced Metadata': enhanced_metadata_enabled,
+        'Infrastructure Config ARN': infrastructure_config_arn,
+        'Distribution Config ARN': distribution_config_arn,
+        'Recipe ARN': recipe_arn,
+        'Date Created': date_created,
+        'Description': description,
+        'Tags': tags_str,
+        'Pipeline ARN': pipeline_arn
+    }
+
+
+def _scan_pipelines_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Image Builder pipelines from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: a region-level API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no pipelines" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/unreachable pipelines are skipped (logged) rather
+    than aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
+
+    # Get image pipelines (paginated)
+    pipeline_arns = []
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = imagebuilder.list_image_pipelines(**params)
+        pipeline_arns.extend([p.get('arn') for p in page.get('imagePipelineList', []) if p.get('arn')])
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
+    print(f"  Found {len(pipeline_arns)} pipelines")
+
+    region_pipelines = []
+    for pipeline_arn in pipeline_arns:
+        try:
+            region_pipelines.append(_build_pipeline_row(imagebuilder, pipeline_arn, region))
+        except Exception as e:
+            # One malformed/unreachable pipeline is skipped, not fatal to the region.
+            utils.log_error(f"Skipping Image Builder pipeline in {region}: {pipeline_arn}", e)
+            continue
+
+    return region_pipelines
+
+
+def collect_image_pipelines(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Image Builder pipeline information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with pipeline information
+        tuple: ``(pipelines, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING IMAGE BUILDER PIPELINES ===")
-    all_pipelines = []
 
-    for region in regions:
-        if not utils.is_aws_region(region):
-            utils.log_error(f"Skipping invalid AWS region: {region}")
-            continue
-
-        print(f"\nProcessing region: {region}")
-
-        try:
-            imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
-
-            # Get image pipelines (paginated)
-            pipeline_arns = []
-            next_token = None
-            while True:
-                params = {}
-                params['maxResults'] = 100
-                if next_token:
-                    params['nextToken'] = next_token
-                page = imagebuilder.list_image_pipelines(**params)
-                pipeline_arns.extend([p['arn'] for p in page.get('imagePipelineList', [])])
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
-
-            print(f"  Found {len(pipeline_arns)} pipelines")
-
-            for pipeline_arn in pipeline_arns:
-                try:
-                    # Get pipeline details
-                    pipeline_response = imagebuilder.get_image_pipeline(imagePipelineArn=pipeline_arn)
-                    pipeline = pipeline_response.get('imagePipeline', {})
-
-                    name = pipeline.get('name', '')
-                    description = pipeline.get('description', 'N/A')
-                    status = pipeline.get('status', '')
-
-                    # Image recipe or container recipe
-                    image_recipe_arn = pipeline.get('imageRecipeArn', 'N/A')
-                    container_recipe_arn = pipeline.get('containerRecipeArn', 'N/A')
-
-                    recipe_type = 'AMI' if image_recipe_arn != 'N/A' else 'Container'
-                    recipe_arn = image_recipe_arn if recipe_type == 'AMI' else container_recipe_arn
-
-                    # Infrastructure configuration
-                    infrastructure_config_arn = pipeline.get('infrastructureConfigurationArn', 'N/A')
-
-                    # Distribution configuration
-                    distribution_config_arn = pipeline.get('distributionConfigurationArn', 'N/A')
-
-                    # Schedule
-                    schedule = pipeline.get('schedule', {})
-                    schedule_expression = schedule.get('scheduleExpression', 'N/A')
-                    pipeline_execution_start_condition = schedule.get('pipelineExecutionStartCondition', 'N/A')
-
-                    # Enhanced image metadata
-                    enhanced_metadata_enabled = pipeline.get('enhancedImageMetadataEnabled', False)
-
-                    # Image tests
-                    image_tests_config = pipeline.get('imageTestsConfiguration', {})
-                    tests_enabled = image_tests_config.get('imageTestsEnabled', False)
-                    timeout_minutes = image_tests_config.get('timeoutMinutes', 0)
-
-                    # Date created
-                    date_created = pipeline.get('dateCreated', 'N/A')
-
-                    # Tags
-                    tags = pipeline.get('tags', {})
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-                    all_pipelines.append({
-                        'Region': region,
-                        'Pipeline Name': name,
-                        'Status': status,
-                        'Recipe Type': recipe_type,
-                        'Schedule Expression': schedule_expression,
-                        'Start Condition': pipeline_execution_start_condition,
-                        'Tests Enabled': tests_enabled,
-                        'Test Timeout (min)': timeout_minutes,
-                        'Enhanced Metadata': enhanced_metadata_enabled,
-                        'Infrastructure Config ARN': infrastructure_config_arn,
-                        'Distribution Config ARN': distribution_config_arn,
-                        'Recipe ARN': recipe_arn,
-                        'Date Created': date_created,
-                        'Description': description,
-                        'Tags': tags_str,
-                        'Pipeline ARN': pipeline_arn
-                    })
-
-                except Exception as e:
-                    utils.log_error(f"Error getting pipeline details for {pipeline_arn}", e)
-
-        except Exception as e:
-            utils.log_error(f"Error processing region {region} for pipelines", e)
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_pipelines_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_pipelines = [p for result in region_results for p in result]
 
     utils.log_success(f"Total pipelines collected: {len(all_pipelines)}")
-    return all_pipelines
+    return all_pipelines, failed_regions
 
 
-@utils.aws_error_handler("Collecting image recipes", default_return=[])
-def collect_image_recipes(regions: list[str]) -> list[dict[str, Any]]:
+def _build_recipe_row(imagebuilder: Any, recipe_arn: str, region: str) -> dict[str, Any]:
+    """Build a single Image Builder image recipe export row (fetches details)."""
+    recipe_response = imagebuilder.get_image_recipe(imageRecipeArn=recipe_arn)
+    recipe = recipe_response.get('imageRecipe', {})
+
+    name = recipe.get('name', '')
+    version = recipe.get('version', '')
+    description = recipe.get('description', 'N/A')
+    platform = recipe.get('platform', '')
+
+    # Parent image
+    parent_image = recipe.get('parentImage', 'N/A')
+
+    # Block device mappings
+    block_device_mappings = recipe.get('blockDeviceMappings', [])
+    volume_count = len(block_device_mappings)
+
+    # Components
+    components = recipe.get('components', [])
+    component_count = len(components)
+
+    # Working directory
+    working_directory = recipe.get('workingDirectory', 'N/A')
+
+    # Date created
+    date_created = recipe.get('dateCreated', 'N/A')
+
+    # Tags
+    tags = recipe.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Recipe Name': name,
+        'Version': version,
+        'Platform': platform,
+        'Parent Image': parent_image,
+        'Component Count': component_count,
+        'Volume Count': volume_count,
+        'Working Directory': working_directory,
+        'Date Created': date_created,
+        'Description': description,
+        'Tags': tags_str,
+        'Recipe ARN': recipe_arn
+    }
+
+
+def _scan_recipes_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect Image Builder image recipe information from AWS regions.
+    Collect Image Builder image recipes from a single region.
 
-    Args:
-        regions: List of AWS regions to scan
+    Primary scope collector — deliberately does NOT swallow region-level
+    errors; see ``_scan_pipelines_region`` for the rationale. Individual
+    malformed/unreachable recipes are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
+
+    # Get image recipes
+    recipe_arns = []
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = imagebuilder.list_image_recipes(**params)
+        recipe_arns.extend([r.get('arn') for r in page.get('imageRecipeSummaryList', []) if r.get('arn')])
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
+    region_recipes = []
+    for recipe_arn in recipe_arns:
+        try:
+            region_recipes.append(_build_recipe_row(imagebuilder, recipe_arn, region))
+        except Exception as e:
+            utils.log_error(f"Skipping Image Builder recipe in {region}: {recipe_arn}", e)
+            continue
+
+    return region_recipes
+
+
+def collect_image_recipes(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Image Builder image recipe information across regions, surfacing failures.
 
     Returns:
-        list: List of dictionaries with image recipe information
+        tuple: ``(recipes, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING IMAGE RECIPES ===")
-    all_recipes = []
 
-    for region in regions:
-        if not utils.is_aws_region(region):
-            continue
-
-        print(f"\nProcessing region: {region}")
-
-        try:
-            imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
-
-            # Get image recipes
-            recipe_arns = []
-            next_token = None
-            while True:
-                params = {}
-                params['maxResults'] = 100
-                if next_token:
-                    params['nextToken'] = next_token
-                page = imagebuilder.list_image_recipes(**params)
-                recipe_arns.extend([r['arn'] for r in page.get('imageRecipeSummaryList', [])])
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
-
-            for recipe_arn in recipe_arns:
-                try:
-                    # Get recipe details
-                    recipe_response = imagebuilder.get_image_recipe(imageRecipeArn=recipe_arn)
-                    recipe = recipe_response.get('imageRecipe', {})
-
-                    name = recipe.get('name', '')
-                    version = recipe.get('version', '')
-                    description = recipe.get('description', 'N/A')
-                    platform = recipe.get('platform', '')
-
-                    # Parent image
-                    parent_image = recipe.get('parentImage', 'N/A')
-
-                    # Block device mappings
-                    block_device_mappings = recipe.get('blockDeviceMappings', [])
-                    volume_count = len(block_device_mappings)
-
-                    # Components
-                    components = recipe.get('components', [])
-                    component_count = len(components)
-
-                    # Working directory
-                    working_directory = recipe.get('workingDirectory', 'N/A')
-
-                    # Date created
-                    date_created = recipe.get('dateCreated', 'N/A')
-
-                    # Tags
-                    tags = recipe.get('tags', {})
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-                    all_recipes.append({
-                        'Region': region,
-                        'Recipe Name': name,
-                        'Version': version,
-                        'Platform': platform,
-                        'Parent Image': parent_image,
-                        'Component Count': component_count,
-                        'Volume Count': volume_count,
-                        'Working Directory': working_directory,
-                        'Date Created': date_created,
-                        'Description': description,
-                        'Tags': tags_str,
-                        'Recipe ARN': recipe_arn
-                    })
-
-                except Exception as e:
-                    utils.log_error(f"Error getting recipe details for {recipe_arn}", e)
-
-        except Exception as e:
-            utils.log_error(f"Error collecting recipes in region {region}", e)
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_recipes_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_recipes = [r for result in region_results for r in result]
 
     utils.log_success(f"Total image recipes collected: {len(all_recipes)}")
-    return all_recipes
+    return all_recipes, failed_regions
 
 
-@utils.aws_error_handler("Collecting components", default_return=[])
-def collect_components(regions: list[str]) -> list[dict[str, Any]]:
+def _build_component_row(imagebuilder: Any, component_arn: str, region: str) -> dict[str, Any]:
+    """Build a single Image Builder component export row (fetches details)."""
+    component_response = imagebuilder.get_component(componentBuildVersionArn=component_arn)
+    component = component_response.get('component', {})
+
+    name = component.get('name', '')
+    version = component.get('version', '')
+    description = component.get('description', 'N/A')
+    component_type = component.get('type', '')
+    platform = component.get('platform', '')
+
+    # Supported OS versions
+    supported_os_versions = component.get('supportedOsVersions', [])
+    os_versions_str = ', '.join(supported_os_versions) if supported_os_versions else 'All'
+
+    # Change description
+    change_description = component.get('changeDescription', 'N/A')
+
+    # Date created
+    date_created = component.get('dateCreated', 'N/A')
+
+    # Tags
+    tags = component.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Component Name': name,
+        'Version': version,
+        'Type': component_type,
+        'Platform': platform,
+        'Supported OS Versions': os_versions_str,
+        'Date Created': date_created,
+        'Change Description': change_description,
+        'Description': description,
+        'Tags': tags_str,
+        'Component ARN': component_arn
+    }
+
+
+def _scan_components_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect Image Builder component information from AWS regions.
+    Collect Image Builder components from a single region.
 
-    Args:
-        regions: List of AWS regions to scan
+    Primary scope collector — deliberately does NOT swallow region-level
+    errors; see ``_scan_pipelines_region`` for the rationale. Individual
+    malformed/unreachable components are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
+
+    # Get components (owned by account)
+    component_arns = []
+    next_token = None
+    while True:
+        params = {'owner': 'Self'}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = imagebuilder.list_components(**params)
+        component_arns.extend([c.get('arn') for c in page.get('componentVersionList', []) if c.get('arn')])
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
+    region_components = []
+    for component_arn in component_arns:
+        try:
+            region_components.append(_build_component_row(imagebuilder, component_arn, region))
+        except Exception as e:
+            utils.log_error(f"Skipping Image Builder component in {region}: {component_arn}", e)
+            continue
+
+    return region_components
+
+
+def collect_components(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Image Builder component information across regions, surfacing failures.
 
     Returns:
-        list: List of dictionaries with component information
+        tuple: ``(components, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING COMPONENTS ===")
-    all_components = []
 
-    for region in regions:
-        if not utils.is_aws_region(region):
-            continue
-
-        print(f"\nProcessing region: {region}")
-
-        try:
-            imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
-
-            # Get components (owned by account)
-            component_arns = []
-            next_token = None
-            while True:
-                params = {'owner': 'Self'}
-                params['maxResults'] = 100
-                if next_token:
-                    params['nextToken'] = next_token
-                page = imagebuilder.list_components(**params)
-                component_arns.extend([c['arn'] for c in page.get('componentVersionList', [])])
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
-
-            for component_arn in component_arns:
-                try:
-                    # Get component details
-                    component_response = imagebuilder.get_component(componentBuildVersionArn=component_arn)
-                    component = component_response.get('component', {})
-
-                    name = component.get('name', '')
-                    version = component.get('version', '')
-                    description = component.get('description', 'N/A')
-                    component_type = component.get('type', '')
-                    platform = component.get('platform', '')
-
-                    # Supported OS versions
-                    supported_os_versions = component.get('supportedOsVersions', [])
-                    os_versions_str = ', '.join(supported_os_versions) if supported_os_versions else 'All'
-
-                    # Change description
-                    change_description = component.get('changeDescription', 'N/A')
-
-                    # Date created
-                    date_created = component.get('dateCreated', 'N/A')
-
-                    # Tags
-                    tags = component.get('tags', {})
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-                    all_components.append({
-                        'Region': region,
-                        'Component Name': name,
-                        'Version': version,
-                        'Type': component_type,
-                        'Platform': platform,
-                        'Supported OS Versions': os_versions_str,
-                        'Date Created': date_created,
-                        'Change Description': change_description,
-                        'Description': description,
-                        'Tags': tags_str,
-                        'Component ARN': component_arn
-                    })
-
-                except Exception as e:
-                    utils.log_error(f"Error getting component details for {component_arn}", e)
-
-        except Exception as e:
-            utils.log_error(f"Error collecting components in region {region}", e)
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_components_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_components = [c for result in region_results for c in result]
 
     utils.log_success(f"Total components collected: {len(all_components)}")
-    return all_components
+    return all_components, failed_regions
 
 
-@utils.aws_error_handler("Collecting infrastructure configurations", default_return=[])
-def collect_infrastructure_configurations(regions: list[str]) -> list[dict[str, Any]]:
+def _build_infra_config_row(imagebuilder: Any, config_arn: str, region: str) -> dict[str, Any]:
+    """Build a single Image Builder infrastructure configuration export row (fetches details)."""
+    config_response = imagebuilder.get_infrastructure_configuration(
+        infrastructureConfigurationArn=config_arn
+    )
+    config = config_response.get('infrastructureConfiguration', {})
+
+    name = config.get('name', '')
+    description = config.get('description', 'N/A')
+
+    # Instance types
+    instance_types = config.get('instanceTypes', [])
+    instance_types_str = ', '.join(instance_types) if instance_types else 'N/A'
+
+    # Instance profile name
+    instance_profile_name = config.get('instanceProfileName', 'N/A')
+
+    # Security group IDs
+    security_group_ids = config.get('securityGroupIds', [])
+    sg_count = len(security_group_ids)
+
+    # Subnet ID
+    subnet_id = config.get('subnetId', 'N/A')
+
+    # Terminate on failure
+    terminate_on_failure = config.get('terminateInstanceOnFailure', False)
+
+    # SNS topic ARN
+    sns_topic_arn = config.get('snsTopicArn', 'N/A')
+
+    # Key pair
+    key_pair = config.get('keyPair', 'N/A')
+
+    # Resource tags
+    resource_tags = config.get('resourceTags', {})
+    resource_tags_str = ', '.join([f"{k}={v}" for k, v in resource_tags.items()]) if resource_tags else 'N/A'
+
+    # Date created
+    date_created = config.get('dateCreated', 'N/A')
+
+    # Tags
+    tags = config.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Config Name': name,
+        'Instance Types': instance_types_str,
+        'Instance Profile': instance_profile_name,
+        'Subnet ID': subnet_id,
+        'Security Group Count': sg_count,
+        'Key Pair': key_pair,
+        'Terminate on Failure': terminate_on_failure,
+        'SNS Topic ARN': sns_topic_arn,
+        'Resource Tags': resource_tags_str,
+        'Date Created': date_created,
+        'Description': description,
+        'Tags': tags_str,
+        'Config ARN': config_arn
+    }
+
+
+def _scan_infra_configs_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect Image Builder infrastructure configuration information from AWS regions.
+    Collect Image Builder infrastructure configurations from a single region.
 
-    Args:
-        regions: List of AWS regions to scan
-
-    Returns:
-        list: List of dictionaries with infrastructure configuration information
+    Primary scope collector — deliberately does NOT swallow region-level
+    errors; see ``_scan_pipelines_region`` for the rationale. Individual
+    malformed/unreachable configurations are skipped (logged) rather than
+    aborting the whole region.
     """
-    print("\n=== COLLECTING INFRASTRUCTURE CONFIGURATIONS ===")
-    all_configs = []
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-    for region in regions:
-        if not utils.is_aws_region(region):
+    print(f"\nProcessing region: {region}")
+
+    imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
+
+    # Get infrastructure configurations
+    config_arns = []
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = imagebuilder.list_infrastructure_configurations(**params)
+        config_arns.extend([c.get('arn') for c in page.get('infrastructureConfigurationSummaryList', []) if c.get('arn')])
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
+    region_configs = []
+    for config_arn in config_arns:
+        try:
+            region_configs.append(_build_infra_config_row(imagebuilder, config_arn, region))
+        except Exception as e:
+            utils.log_error(f"Skipping Image Builder infrastructure config in {region}: {config_arn}", e)
             continue
 
-        print(f"\nProcessing region: {region}")
+    return region_configs
 
-        try:
-            imagebuilder = utils.get_boto3_client('imagebuilder', region_name=region)
 
-            # Get infrastructure configurations
-            config_arns = []
-            next_token = None
-            while True:
-                params = {}
-                params['maxResults'] = 100
-                if next_token:
-                    params['nextToken'] = next_token
-                page = imagebuilder.list_infrastructure_configurations(**params)
-                config_arns.extend([c['arn'] for c in page.get('infrastructureConfigurationSummaryList', [])])
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
+def collect_infrastructure_configurations(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Image Builder infrastructure configuration information across
+    regions, surfacing failures.
 
-            for config_arn in config_arns:
-                try:
-                    # Get configuration details
-                    config_response = imagebuilder.get_infrastructure_configuration(
-                        infrastructureConfigurationArn=config_arn
-                    )
-                    config = config_response.get('infrastructureConfiguration', {})
+    Returns:
+        tuple: ``(configs, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    print("\n=== COLLECTING INFRASTRUCTURE CONFIGURATIONS ===")
 
-                    name = config.get('name', '')
-                    description = config.get('description', 'N/A')
-
-                    # Instance types
-                    instance_types = config.get('instanceTypes', [])
-                    instance_types_str = ', '.join(instance_types) if instance_types else 'N/A'
-
-                    # Instance profile name
-                    instance_profile_name = config.get('instanceProfileName', 'N/A')
-
-                    # Security group IDs
-                    security_group_ids = config.get('securityGroupIds', [])
-                    sg_count = len(security_group_ids)
-
-                    # Subnet ID
-                    subnet_id = config.get('subnetId', 'N/A')
-
-                    # Terminate on failure
-                    terminate_on_failure = config.get('terminateInstanceOnFailure', False)
-
-                    # SNS topic ARN
-                    sns_topic_arn = config.get('snsTopicArn', 'N/A')
-
-                    # Key pair
-                    key_pair = config.get('keyPair', 'N/A')
-
-                    # Resource tags
-                    resource_tags = config.get('resourceTags', {})
-                    resource_tags_str = ', '.join([f"{k}={v}" for k, v in resource_tags.items()]) if resource_tags else 'N/A'
-
-                    # Date created
-                    date_created = config.get('dateCreated', 'N/A')
-
-                    # Tags
-                    tags = config.get('tags', {})
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-                    all_configs.append({
-                        'Region': region,
-                        'Config Name': name,
-                        'Instance Types': instance_types_str,
-                        'Instance Profile': instance_profile_name,
-                        'Subnet ID': subnet_id,
-                        'Security Group Count': sg_count,
-                        'Key Pair': key_pair,
-                        'Terminate on Failure': terminate_on_failure,
-                        'SNS Topic ARN': sns_topic_arn,
-                        'Resource Tags': resource_tags_str,
-                        'Date Created': date_created,
-                        'Description': description,
-                        'Tags': tags_str,
-                        'Config ARN': config_arn
-                    })
-
-                except Exception as e:
-                    utils.log_error(f"Error getting infrastructure config details for {config_arn}", e)
-
-        except Exception as e:
-            utils.log_error(f"Error collecting infrastructure configs in region {region}", e)
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_infra_configs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_configs = [c for result in region_results for c in result]
 
     utils.log_success(f"Total infrastructure configurations collected: {len(all_configs)}")
-    return all_configs
+    return all_configs, failed_regions
 
 
 def export_image_builder_data(account_id: str, account_name: str):
@@ -465,63 +550,91 @@ def export_image_builder_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect pipelines
-    pipelines = collect_image_pipelines(regions)
+    # Every top-level region-scanned collector below is a "scope": each
+    # raises per-region on API/permission failure (via
+    # scan_regions_concurrent(..., collect_failures=True)) instead of
+    # swallowing it into an empty result. Their (region, error) failures are
+    # accumulated into ONE combined list that drives a single failure marker
+    # + non-zero exit at the end of this function. Per-field enrichment
+    # within each row builder stays graceful (missing fields default via
+    # .get()).
+    all_failed_regions: list[tuple[str, str]] = []
+
+    # STEP 1: Collect pipelines (scope)
+    pipelines, pipeline_failed_regions = collect_image_pipelines(regions)
+    all_failed_regions.extend(pipeline_failed_regions)
     if pipelines:
         data_frames['Image Pipelines'] = pd.DataFrame(pipelines)
 
-    # STEP 2: Collect image recipes
-    recipes = collect_image_recipes(regions)
+    # STEP 2: Collect image recipes (scope)
+    recipes, recipe_failed_regions = collect_image_recipes(regions)
+    all_failed_regions.extend(recipe_failed_regions)
     if recipes:
         data_frames['Image Recipes'] = pd.DataFrame(recipes)
 
-    # STEP 3: Collect components
-    components = collect_components(regions)
+    # STEP 3: Collect components (scope)
+    components, component_failed_regions = collect_components(regions)
+    all_failed_regions.extend(component_failed_regions)
     if components:
         data_frames['Components'] = pd.DataFrame(components)
 
-    # STEP 4: Collect infrastructure configurations
-    infra_configs = collect_infrastructure_configurations(regions)
+    # STEP 4: Collect infrastructure configurations (scope)
+    infra_configs, infra_config_failed_regions = collect_infrastructure_configurations(regions)
+    all_failed_regions.extend(infra_config_failed_regions)
     if infra_configs:
         data_frames['Infrastructure Configurations'] = pd.DataFrame(infra_configs)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some scopes/regions failed (see the silent-collection-failure
+    # blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'image-builder',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("EC2 Image Builder data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not all_failed_regions:
+        # Genuinely empty account: every scope's regions succeeded and
+        # returned nothing.
         utils.log_warning("No EC2 Image Builder data was collected. Nothing to export.")
         print("\nNo EC2 Image Builder resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'image-builder',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("EC2 Image Builder data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY scope's region collection failed, make it loud: write a marker
+    # and exit non-zero, even if some data was exported. A partial export
+    # that looks complete is exactly the failure mode this guards against.
+    if all_failed_regions:
+        utils.report_collection_failures(account_name, 'image-builder', all_failed_regions)
+        print(
+            "\nERROR: EC2 Image Builder export completed with failures — data is incomplete. "
+            "See the *-image-builder-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/ssm_fleet_export.py
+++ b/scripts/ssm_fleet_export.py
@@ -44,289 +44,360 @@ except ImportError:
 args = utils.parse_script_args("Export Systems Manager fleet and patch data to Excel")
 
 
+def _build_instance_row(instance: dict, region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single SSM managed instance.
+
+    Extracted so the per-instance processing can be wrapped in try/except by
+    the caller: a malformed instance entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+    """
+    instance_id = instance.get('InstanceId', 'N/A')
+
+    # Instance details
+    ping_status = instance.get('PingStatus', 'Unknown')
+    last_ping_time = instance.get('LastPingDateTime', '')
+    if last_ping_time:
+        last_ping_time = last_ping_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_ping_time, datetime.datetime) else str(last_ping_time)
+
+    # Platform
+    platform_type = instance.get('PlatformType', 'N/A')
+    platform_name = instance.get('PlatformName', 'N/A')
+    platform_version = instance.get('PlatformVersion', 'N/A')
+
+    # Agent version
+    agent_version = instance.get('AgentVersion', 'N/A')
+
+    # IP address
+    ip_address = instance.get('IPAddress', 'N/A')
+
+    # Computer name
+    computer_name = instance.get('ComputerName', 'N/A')
+
+    # Association status
+    association_status = instance.get('AssociationStatus', 'Unknown')
+
+    # Last successful association
+    last_association = instance.get('LastSuccessfulAssociationExecutionDate', '')
+    if last_association:
+        last_association = last_association.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_association, datetime.datetime) else str(last_association)
+
+    # Last association execution
+    last_assoc_exec = instance.get('LastAssociationExecutionDate', '')
+    if last_assoc_exec:
+        last_assoc_exec = last_assoc_exec.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_assoc_exec, datetime.datetime) else str(last_assoc_exec)
+
+    # Activation ID (for on-prem instances)
+    activation_id = instance.get('ActivationId', 'N/A')
+
+    # IAM role
+    iam_role = instance.get('IamRole', 'N/A')
+
+    # Registration date
+    registration_date = instance.get('RegistrationDate', '')
+    if registration_date:
+        registration_date = registration_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(registration_date, datetime.datetime) else str(registration_date)
+
+    return {
+        'Region': region,
+        'Instance ID': instance_id,
+        'Ping Status': ping_status,
+        'Last Ping': last_ping_time if last_ping_time else 'Never',
+        'Platform Type': platform_type,
+        'Platform Name': platform_name,
+        'Platform Version': platform_version,
+        'Agent Version': agent_version,
+        'IP Address': ip_address,
+        'Computer Name': computer_name,
+        'Association Status': association_status,
+        'Last Successful Association': last_association if last_association else 'N/A',
+        'Last Association Execution': last_assoc_exec if last_assoc_exec else 'N/A',
+        'Activation ID': activation_id,
+        'IAM Role': iam_role,
+        'Registration Date': registration_date if registration_date else 'N/A'
+    }
+
+
 def _scan_managed_instances_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for SSM managed instances."""
-    instances_data = []
+    """
+    Collect SSM managed instances from a single region.
 
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no managed instances" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed instances are skipped (logged) rather than aborting
+    the whole region.
+    """
     if not utils.is_aws_region(region):
-        return instances_data
+        return []
 
-    try:
-        ssm_client = utils.get_boto3_client('ssm', region_name=region)
+    instances_data = []
+    ssm_client = utils.get_boto3_client('ssm', region_name=region)
 
-        paginator = ssm_client.get_paginator('describe_instance_information')
-        for page in paginator.paginate():
-            instances = page.get('InstanceInformationList', [])
+    paginator = ssm_client.get_paginator('describe_instance_information')
+    for page in paginator.paginate():
+        instances = page.get('InstanceInformationList', [])
 
-            for instance in instances:
-                instance_id = instance.get('InstanceId', 'N/A')
-
-                # Instance details
-                ping_status = instance.get('PingStatus', 'Unknown')
-                last_ping_time = instance.get('LastPingDateTime', '')
-                if last_ping_time:
-                    last_ping_time = last_ping_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_ping_time, datetime.datetime) else str(last_ping_time)
-
-                # Platform
-                platform_type = instance.get('PlatformType', 'N/A')
-                platform_name = instance.get('PlatformName', 'N/A')
-                platform_version = instance.get('PlatformVersion', 'N/A')
-
-                # Agent version
-                agent_version = instance.get('AgentVersion', 'N/A')
-
-                # IP address
-                ip_address = instance.get('IPAddress', 'N/A')
-
-                # Computer name
-                computer_name = instance.get('ComputerName', 'N/A')
-
-                # Association status
-                association_status = instance.get('AssociationStatus', 'Unknown')
-
-                # Last successful association
-                last_association = instance.get('LastSuccessfulAssociationExecutionDate', '')
-                if last_association:
-                    last_association = last_association.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_association, datetime.datetime) else str(last_association)
-
-                # Last association execution
-                last_assoc_exec = instance.get('LastAssociationExecutionDate', '')
-                if last_assoc_exec:
-                    last_assoc_exec = last_assoc_exec.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_assoc_exec, datetime.datetime) else str(last_assoc_exec)
-
-                # Activation ID (for on-prem instances)
-                activation_id = instance.get('ActivationId', 'N/A')
-
-                # IAM role
-                iam_role = instance.get('IamRole', 'N/A')
-
-                # Registration date
-                registration_date = instance.get('RegistrationDate', '')
-                if registration_date:
-                    registration_date = registration_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(registration_date, datetime.datetime) else str(registration_date)
-
-                instances_data.append({
-                    'Region': region,
-                    'Instance ID': instance_id,
-                    'Ping Status': ping_status,
-                    'Last Ping': last_ping_time if last_ping_time else 'Never',
-                    'Platform Type': platform_type,
-                    'Platform Name': platform_name,
-                    'Platform Version': platform_version,
-                    'Agent Version': agent_version,
-                    'IP Address': ip_address,
-                    'Computer Name': computer_name,
-                    'Association Status': association_status,
-                    'Last Successful Association': last_association if last_association else 'N/A',
-                    'Last Association Execution': last_assoc_exec if last_assoc_exec else 'N/A',
-                    'Activation ID': activation_id,
-                    'IAM Role': iam_role,
-                    'Registration Date': registration_date if registration_date else 'N/A'
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting managed instances in {region}", e)
+        for instance in instances:
+            try:
+                instances_data.append(_build_instance_row(instance, region))
+            except Exception as e:
+                # One malformed instance is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed SSM managed instance in {region}: "
+                    f"{instance.get('InstanceId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return instances_data
 
 
-@utils.aws_error_handler("Collecting SSM managed instances", default_return=[])
-def collect_managed_instances(regions: list[str]) -> list[dict[str, Any]]:
+def collect_managed_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect SSM managed instance information from AWS regions.
+    Collect SSM managed instance information across regions, surfacing failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Primary scope. Uses ``collect_failures=True`` so a region whose collection
+    errors is reported as a failed scope rather than silently collapsed into
+    an empty result.
 
     Returns:
-        list: List of dictionaries with managed instance information
+        tuple: ``(instances, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING SSM MANAGED INSTANCES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_managed_instances_region)
-    all_instances = [instance for result in results for instance in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_managed_instances_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_instances = [instance for result in region_results for instance in result]
     utils.log_success(f"Total SSM managed instances collected: {len(all_instances)}")
-    return all_instances
+    return all_instances, failed_regions
+
+
+def _build_compliance_row(item: dict, region: str, instance_id: str) -> dict[str, Any]:
+    """Build the export row for a single SSM patch compliance item."""
+    compliance_type = item.get('ComplianceType', 'N/A')
+    status = item.get('Status', 'UNKNOWN')
+    severity = item.get('Severity', 'UNSPECIFIED')
+
+    # Execution summary
+    execution_summary = item.get('ExecutionSummary', {})
+    execution_time = execution_summary.get('ExecutionTime', '')
+    if execution_time:
+        execution_time = execution_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(execution_time, datetime.datetime) else str(execution_time)
+
+    # Details
+    details = item.get('Details', {})
+    patch_group = details.get('PatchGroup', 'N/A')
+    installed_count = details.get('InstalledCount', '0')
+    installed_other_count = details.get('InstalledOtherCount', '0')
+    missing_count = details.get('MissingCount', '0')
+    failed_count = details.get('FailedCount', '0')
+    not_applicable_count = details.get('NotApplicableCount', '0')
+
+    return {
+        'Region': region,
+        'Instance ID': instance_id,
+        'Compliance Type': compliance_type,
+        'Status': status,
+        'Severity': severity,
+        'Patch Group': patch_group,
+        'Installed Patches': installed_count,
+        'Installed Other': installed_other_count,
+        'Missing Patches': missing_count,
+        'Failed Patches': failed_count,
+        'Not Applicable': not_applicable_count,
+        'Execution Time': execution_time if execution_time else 'N/A'
+    }
 
 
 def _scan_patch_compliance_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for SSM patch compliance."""
+    """
+    Collect SSM patch compliance from a single region.
+
+    Region-scanned scope collector — its (region, error) results accumulate
+    into the combined ``failed_regions`` list alongside managed instances and
+    parameters (see the blast-radius audit referenced above). A region-level
+    API failure (e.g. ``describe_instance_information`` throttled or denied)
+    propagates rather than being swallowed into an empty list.
+
+    A per-instance ``list_compliance_items`` lookup failing is left graceful
+    (best-effort enrichment): many instances legitimately have no compliance
+    data attached, and one instance's lookup failure must not discard the
+    whole region.
+    """
     compliance_data = []
 
     if not utils.is_aws_region(region):
         return compliance_data
 
-    try:
-        ssm_client = utils.get_boto3_client('ssm', region_name=region)
+    ssm_client = utils.get_boto3_client('ssm', region_name=region)
 
-        # Get instances first
-        instances_paginator = ssm_client.get_paginator('describe_instance_information')
-        instances = []
-        for inst_page in instances_paginator.paginate():
-            instances.extend(inst_page.get('InstanceInformationList', []))
+    # Get instances first
+    instances_paginator = ssm_client.get_paginator('describe_instance_information')
+    instances = []
+    for inst_page in instances_paginator.paginate():
+        instances.extend(inst_page.get('InstanceInformationList', []))
 
-        for instance in instances:
-            instance_id = instance.get('InstanceId', '')
+    for instance in instances:
+        instance_id = instance.get('InstanceId', '')
 
-            try:
-                # Get patch compliance for this instance
-                compliance_response = ssm_client.list_compliance_items(
-                    ResourceIds=[instance_id],
-                    Filters=[
-                        {
-                            'Key': 'ComplianceType',
-                            'Values': ['Patch'],
-                            'Type': 'EQUAL'
-                        }
-                    ]
-                )
+        try:
+            # Get patch compliance for this instance
+            compliance_response = ssm_client.list_compliance_items(
+                ResourceIds=[instance_id],
+                Filters=[
+                    {
+                        'Key': 'ComplianceType',
+                        'Values': ['Patch'],
+                        'Type': 'EQUAL'
+                    }
+                ]
+            )
 
-                compliance_items = compliance_response.get('ComplianceItems', [])
+            compliance_items = compliance_response.get('ComplianceItems', [])
 
-                if compliance_items:
-                    for item in compliance_items:
-                        compliance_type = item.get('ComplianceType', 'N/A')
-                        status = item.get('Status', 'UNKNOWN')
-                        severity = item.get('Severity', 'UNSPECIFIED')
+            for item in compliance_items:
+                try:
+                    compliance_data.append(_build_compliance_row(item, region, instance_id))
+                except Exception as e:
+                    utils.log_error(
+                        f"Skipping malformed compliance item in {region} for {instance_id}", e
+                    )
+                    continue
 
-                        # Execution summary
-                        execution_summary = item.get('ExecutionSummary', {})
-                        execution_time = execution_summary.get('ExecutionTime', '')
-                        if execution_time:
-                            execution_time = execution_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(execution_time, datetime.datetime) else str(execution_time)
-
-                        # Details
-                        details = item.get('Details', {})
-                        patch_group = details.get('PatchGroup', 'N/A')
-                        installed_count = details.get('InstalledCount', '0')
-                        installed_other_count = details.get('InstalledOtherCount', '0')
-                        missing_count = details.get('MissingCount', '0')
-                        failed_count = details.get('FailedCount', '0')
-                        not_applicable_count = details.get('NotApplicableCount', '0')
-
-                        compliance_data.append({
-                            'Region': region,
-                            'Instance ID': instance_id,
-                            'Compliance Type': compliance_type,
-                            'Status': status,
-                            'Severity': severity,
-                            'Patch Group': patch_group,
-                            'Installed Patches': installed_count,
-                            'Installed Other': installed_other_count,
-                            'Missing Patches': missing_count,
-                            'Failed Patches': failed_count,
-                            'Not Applicable': not_applicable_count,
-                            'Execution Time': execution_time if execution_time else 'N/A'
-                        })
-
-            except Exception:
-                # Some instances may not have compliance data
-                pass
-
-    except Exception as e:
-        utils.log_error(f"Error collecting patch compliance in {region}", e)
+        except Exception:
+            # Some instances may not have compliance data - best-effort enrichment.
+            pass
 
     return compliance_data
 
 
-@utils.aws_error_handler("Collecting SSM patch compliance", default_return=[])
-def collect_patch_compliance(regions: list[str]) -> list[dict[str, Any]]:
+def collect_patch_compliance(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect SSM patch compliance information from AWS regions.
-
-    Args:
-        regions: List of AWS regions to scan
+    Collect SSM patch compliance information across regions, surfacing failures.
 
     Returns:
-        list: List of dictionaries with patch compliance information
+        tuple: ``(compliance_items, failed_regions)``.
     """
     print("\n=== COLLECTING SSM PATCH COMPLIANCE ===")
-    results = utils.scan_regions_concurrent(regions, _scan_patch_compliance_region)
-    all_compliance = [item for result in results for item in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_patch_compliance_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_compliance = [item for result in region_results for item in result]
     utils.log_success(f"Total patch compliance items collected: {len(all_compliance)}")
-    return all_compliance
+    return all_compliance, failed_regions
+
+
+def _build_parameter_row(parameter: dict, region: str) -> dict[str, Any]:
+    """Build the export row for a single SSM parameter."""
+    param_name = parameter.get('Name', 'N/A')
+
+    # Parameter details
+    param_type = parameter.get('Type', 'String')
+    description = parameter.get('Description', 'N/A')
+
+    # Key ID (for SecureString)
+    key_id = parameter.get('KeyId', 'N/A')
+
+    # Last modified
+    last_modified = parameter.get('LastModifiedDate', '')
+    if last_modified:
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified, datetime.datetime) else str(last_modified)
+
+    # Last modified user
+    last_modified_user = parameter.get('LastModifiedUser', 'N/A')
+
+    # Version
+    version = parameter.get('Version', 1)
+
+    # Tier
+    tier = parameter.get('Tier', 'Standard')
+
+    # Policies
+    policies = parameter.get('Policies', [])
+    has_policies = 'Yes' if policies else 'No'
+
+    # Data type
+    data_type = parameter.get('DataType', 'text')
+
+    return {
+        'Region': region,
+        'Parameter Name': param_name,
+        'Parameter Type': param_type,
+        'Tier': tier,
+        'Data Type': data_type,
+        'Description': description,
+        'KMS Key ID': key_id,
+        'Last Modified': last_modified if last_modified else 'N/A',
+        'Last Modified User': last_modified_user,
+        'Version': version,
+        'Has Policies': has_policies
+    }
 
 
 def _scan_ssm_parameters_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for SSM parameters."""
+    """
+    Collect SSM Parameter Store parameters from a single region.
+
+    Region-scanned scope collector — its (region, error) results accumulate
+    into the combined ``failed_regions`` list alongside managed instances and
+    patch compliance. Propagates region-level API errors rather than
+    swallowing them into an empty list.
+    """
     parameters_data = []
 
     if not utils.is_aws_region(region):
         return parameters_data
 
-    try:
-        ssm_client = utils.get_boto3_client('ssm', region_name=region)
+    ssm_client = utils.get_boto3_client('ssm', region_name=region)
 
-        paginator = ssm_client.get_paginator('describe_parameters')
-        for page in paginator.paginate():
-            parameters = page.get('Parameters', [])
+    paginator = ssm_client.get_paginator('describe_parameters')
+    for page in paginator.paginate():
+        parameters = page.get('Parameters', [])
 
-            for parameter in parameters:
-                param_name = parameter.get('Name', 'N/A')
-
-                # Parameter details
-                param_type = parameter.get('Type', 'String')
-                description = parameter.get('Description', 'N/A')
-
-                # Key ID (for SecureString)
-                key_id = parameter.get('KeyId', 'N/A')
-
-                # Last modified
-                last_modified = parameter.get('LastModifiedDate', '')
-                if last_modified:
-                    last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified, datetime.datetime) else str(last_modified)
-
-                # Last modified user
-                last_modified_user = parameter.get('LastModifiedUser', 'N/A')
-
-                # Version
-                version = parameter.get('Version', 1)
-
-                # Tier
-                tier = parameter.get('Tier', 'Standard')
-
-                # Policies
-                policies = parameter.get('Policies', [])
-                has_policies = 'Yes' if policies else 'No'
-
-                # Data type
-                data_type = parameter.get('DataType', 'text')
-
-                parameters_data.append({
-                    'Region': region,
-                    'Parameter Name': param_name,
-                    'Parameter Type': param_type,
-                    'Tier': tier,
-                    'Data Type': data_type,
-                    'Description': description,
-                    'KMS Key ID': key_id,
-                    'Last Modified': last_modified if last_modified else 'N/A',
-                    'Last Modified User': last_modified_user,
-                    'Version': version,
-                    'Has Policies': has_policies
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting SSM parameters in {region}", e)
+        for parameter in parameters:
+            try:
+                parameters_data.append(_build_parameter_row(parameter, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed SSM parameter in {region}: "
+                    f"{parameter.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return parameters_data
 
 
-@utils.aws_error_handler("Collecting SSM parameters", default_return=[])
-def collect_ssm_parameters(regions: list[str]) -> list[dict[str, Any]]:
+def collect_ssm_parameters(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect SSM Parameter Store parameters from AWS regions.
-
-    Args:
-        regions: List of AWS regions to scan
+    Collect SSM Parameter Store parameters across regions, surfacing failures.
 
     Returns:
-        list: List of dictionaries with parameter information
+        tuple: ``(parameters, failed_regions)``.
     """
     print("\n=== COLLECTING SSM PARAMETERS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_ssm_parameters_region)
-    all_parameters = [parameter for result in results for parameter in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_ssm_parameters_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_parameters = [parameter for result in region_results for parameter in result]
     utils.log_success(f"Total SSM parameters collected: {len(all_parameters)}")
-    return all_parameters
+    return all_parameters, failed_regions
 
 
 def export_ssm_fleet_data(account_id: str, account_name: str):
@@ -346,19 +417,26 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
 
     # Dictionary to hold all DataFrames for export
     data_frames = {}
+    # Accumulates (region, error_message) tuples across all three
+    # region-scanned scope collectors so a single marker + exit covers
+    # every scope that failed (see blast-radius audit).
+    failed_regions: list = []
 
-    # STEP 1: Collect managed instances
-    instances = collect_managed_instances(regions)
+    # STEP 1: Collect managed instances (primary scope)
+    instances, failed_1 = collect_managed_instances(regions)
+    failed_regions.extend(failed_1)
     if instances:
         data_frames['Managed Instances'] = pd.DataFrame(instances)
 
     # STEP 2: Collect patch compliance
-    compliance = collect_patch_compliance(regions)
+    compliance, failed_2 = collect_patch_compliance(regions)
+    failed_regions.extend(failed_2)
     if compliance:
         data_frames['Patch Compliance'] = pd.DataFrame(compliance)
 
     # STEP 3: Collect parameters
-    parameters = collect_ssm_parameters(regions)
+    parameters, failed_3 = collect_ssm_parameters(regions)
+    failed_regions.extend(failed_3)
     if parameters:
         data_frames['SSM Parameters'] = pd.DataFrame(parameters)
 
@@ -371,8 +449,8 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
         total_parameters = len(parameters)
 
         # Instance status
-        online_instances = sum(1 for i in instances if i['Ping Status'] == 'Online')
-        offline_instances = sum(1 for i in instances if i['Ping Status'] != 'Online')
+        online_instances = sum(1 for i in instances if i.get('Ping Status') == 'Online')
+        offline_instances = sum(1 for i in instances if i.get('Ping Status') != 'Online')
 
         # Platform types
         platform_counts = {}
@@ -381,13 +459,13 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
             platform_counts[platform] = platform_counts.get(platform, 0) + 1
 
         # Compliance status
-        compliant_instances = sum(1 for c in compliance if c['Status'] == 'COMPLIANT')
-        non_compliant_instances = sum(1 for c in compliance if c['Status'] == 'NON_COMPLIANT')
+        compliant_instances = sum(1 for c in compliance if c.get('Status') == 'COMPLIANT')
+        non_compliant_instances = sum(1 for c in compliance if c.get('Status') == 'NON_COMPLIANT')
 
         # Parameter types
-        secure_params = sum(1 for p in parameters if p['Parameter Type'] == 'SecureString')
-        string_params = sum(1 for p in parameters if p['Parameter Type'] == 'String')
-        stringlist_params = sum(1 for p in parameters if p['Parameter Type'] == 'StringList')
+        secure_params = sum(1 for p in parameters if p.get('Parameter Type') == 'SecureString')
+        string_params = sum(1 for p in parameters if p.get('Parameter Type') == 'String')
+        stringlist_params = sum(1 for p in parameters if p.get('Parameter Type') == 'StringList')
 
         summary_data.append({'Metric': 'Total Managed Instances', 'Value': total_instances})
         summary_data.append({'Metric': 'Online Instances', 'Value': online_instances})
@@ -406,43 +484,56 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'ssm-fleet',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("SSM Fleet data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded across every scope
+        # and returned nothing.
         utils.log_warning("No SSM Fleet data was collected. Nothing to export.")
         print("\nNo SSM Fleet resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'ssm-fleet',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("SSM Fleet data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed ANY of the three scope collections, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ssm-fleet', failed_regions)
+        print(
+            "\nERROR: SSM Fleet export completed with failures — data is incomplete. "
+            "See the *-ssm-fleet-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/tests/test_exporters/test_ami_export.py
+++ b/tests/test_exporters/test_ami_export.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ami_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ami_export  # noqa: E402
+from ami_export import collect_amis_in_region  # noqa: E402
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_ami(ec2_client, name):
+    """Launch a minimal instance and register/create an AMI named ``name``."""
+    reservation = ec2_client.run_instances(
+        ImageId="ami-12345678",
+        MinCount=1,
+        MaxCount=1,
+        InstanceType="t2.micro",
+    )
+    instance_id = reservation["Instances"][0]["InstanceId"]
+    response = ec2_client.create_image(
+        InstanceId=instance_id,
+        Name=name,
+        Description="test AMI",
+    )
+    return response["ImageId"]
+
+
+class TestCollectAmisInRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_amis(self):
+        client = boto3.client("ec2", region_name=REGION)
+        _create_ami(client, "web-ami")
+
+        rows = collect_amis_in_region(REGION, ACCOUNT_ID)
+
+        names = {row["AMI Name"] for row in rows}
+        assert "web-ami" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ec2", region_name=REGION)  # region exists, no AMIs
+
+        rows = collect_amis_in_region(REGION, ACCOUNT_ID)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One AMI that fails to process must not discard the whole region."""
+        client = boto3.client("ec2", region_name=REGION)
+        _create_ami(client, "good-ami")
+        _create_ami(client, "bad-ami")
+
+        original = ami_export._build_ami_row
+
+        def raise_for_bad(ami, region):
+            if ami.get("Name") == "bad-ami":
+                raise KeyError("SomeUnexpectedField")
+            return original(ami, region)
+
+        monkeypatch.setattr(ami_export, "_build_ami_row", raise_for_bad)
+
+        rows = collect_amis_in_region(REGION, ACCOUNT_ID)
+
+        names = {row["AMI Name"] for row in rows}
+        assert "good-ami" in names, "healthy AMI was lost when a sibling failed"
+        assert "bad-ami" not in names, "malformed AMI should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeImages",
+            )
+
+        monkeypatch.setattr(ami_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_amis_in_region(REGION, ACCOUNT_ID)
+
+    @mock_aws
+    def test_collect_amis_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region, account_id):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeImages",
+            )
+
+        monkeypatch.setattr(ami_export, "collect_amis_in_region", boom)
+
+        amis, failed_regions = ami_export.collect_amis([REGION], ACCOUNT_ID)
+
+        assert amis == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_autoscaling_export.py
+++ b/tests/test_exporters/test_autoscaling_export.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for autoscaling_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import autoscaling_export  # noqa: E402
+from autoscaling_export import _scan_asgs_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_asg(client, name):
+    """Create a launch configuration + Auto Scaling Group named ``name``."""
+    client.create_launch_configuration(
+        LaunchConfigurationName=f"{name}-lc",
+        ImageId="ami-12345678",
+        InstanceType="t3.micro",
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        LaunchConfigurationName=f"{name}-lc",
+        MinSize=0,
+        MaxSize=1,
+        DesiredCapacity=0,
+        AvailabilityZones=[f"{REGION}a"],
+    )
+
+
+class TestScanAsgsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_asgs(self):
+        client = boto3.client("autoscaling", region_name=REGION)
+        _create_asg(client, "web-asg")
+
+        rows = _scan_asgs_region(REGION)
+
+        names = {row["ASG Name"] for row in rows}
+        assert "web-asg" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("autoscaling", region_name=REGION)  # region exists, no ASGs
+
+        rows = _scan_asgs_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One ASG that fails to process must not discard the whole region."""
+        client = boto3.client("autoscaling", region_name=REGION)
+        _create_asg(client, "good-asg")
+        _create_asg(client, "bad-asg")
+
+        original = autoscaling_export._build_asg_row
+
+        def raise_for_bad(asg, region):
+            if asg.get("AutoScalingGroupName") == "bad-asg":
+                raise KeyError("SomeUnexpectedField")
+            return original(asg, region)
+
+        monkeypatch.setattr(autoscaling_export, "_build_asg_row", raise_for_bad)
+
+        rows = _scan_asgs_region(REGION)
+
+        names = {row["ASG Name"] for row in rows}
+        assert "good-asg" in names, "healthy ASG was lost when a sibling failed"
+        assert "bad-asg" not in names, "malformed ASG should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeAutoScalingGroups",
+            )
+
+        monkeypatch.setattr(autoscaling_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_asgs_region(REGION)
+
+    @mock_aws
+    def test_collect_autoscaling_groups_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeAutoScalingGroups",
+            )
+
+        monkeypatch.setattr(autoscaling_export, "_scan_asgs_region", boom)
+
+        asgs, failed_regions = autoscaling_export.collect_autoscaling_groups([REGION])
+
+        assert asgs == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_comprehend_export.py
+++ b/tests/test_exporters/test_comprehend_export.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Tests for comprehend_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2A) against the ENTITY
+RECOGNIZERS scope. See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's Comprehend support does not cover list_entity_recognizers /
+create_entity_recognizer, so all three regression cases here use monkeypatch
+to fake the boto3 client/paginator rather than moto's @mock_aws — no real
+AWS resources are created or contacted.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import comprehend_export  # noqa: E402
+from comprehend_export import _scan_recognizers_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Fake paginator that yields a single page with the given recognizers."""
+
+    def __init__(self, recognizers):
+        self._recognizers = recognizers
+
+    def paginate(self, **kwargs):
+        yield {"EntityRecognizerPropertiesList": self._recognizers}
+
+
+class _FakeComprehendClient:
+    """Fake Comprehend client exposing only what list_entity_recognizers needs."""
+
+    def __init__(self, recognizers):
+        self._recognizers = recognizers
+
+    def get_paginator(self, operation_name):
+        assert operation_name == "list_entity_recognizers"
+        return _FakePaginator(self._recognizers)
+
+
+def _fake_recognizer(name, language_code="en"):
+    """Build a minimal fake EntityRecognizerPropertiesList entry."""
+    return {
+        "EntityRecognizerArn": f"arn:aws:comprehend:{REGION}:123456789012:entity-recognizer/{name}",
+        "LanguageCode": language_code,
+        "Status": "TRAINED",
+    }
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One recognizer that fails to process must not discard the whole region."""
+        good = _fake_recognizer("good-recognizer")
+        bad = _fake_recognizer("bad-recognizer")
+
+        fake_client = _FakeComprehendClient([good, bad])
+        monkeypatch.setattr(
+            comprehend_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        original = comprehend_export._build_recognizer_row
+
+        def raise_for_bad(recognizer, region):
+            if recognizer.get("EntityRecognizerArn", "").endswith("bad-recognizer"):
+                raise KeyError("SomeUnexpectedField")
+            return original(recognizer, region)
+
+        monkeypatch.setattr(comprehend_export, "_build_recognizer_row", raise_for_bad)
+
+        rows = _scan_recognizers_region(REGION)
+
+        names = {row["Recognizer Name"] for row in rows}
+        assert "good-recognizer" in names, "healthy recognizer was lost when a sibling failed"
+        assert "bad-recognizer" not in names, "malformed recognizer should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListEntityRecognizers",
+            )
+
+        monkeypatch.setattr(comprehend_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_recognizers_region(REGION)
+
+    def test_collect_entity_recognizers_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListEntityRecognizers",
+            )
+
+        monkeypatch.setattr(comprehend_export, "_scan_recognizers_region", boom)
+
+        recognizers, failed_regions = comprehend_export.collect_entity_recognizers([REGION])
+
+        assert recognizers == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_compute_optimizer_export.py
+++ b/tests/test_exporters/test_compute_optimizer_export.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Tests for compute_optimizer_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2a / compute). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+moto has no AWS Compute Optimizer support, so unlike the autoscaling/lambda
+regression suites (which use @mock_aws against real moto-backed resources),
+all three cases here monkeypatch a fake compute-optimizer client or the
+collector functions directly. No real AWS resources are involved.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import compute_optimizer_export  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+
+    Exercised against the EC2 recommendations scope
+    (get_ec2_recommendations / _build_ec2_recommendation_row /
+    collect_ec2_recommendations) as the representative of this file's five
+    identically-shaped scope collectors.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One recommendation that fails to process must not discard the
+        whole region's results."""
+        good_item = {
+            "instanceArn": "arn:aws:ec2:us-east-1:123456789012:instance/i-good",
+            "currentInstanceType": "t3.micro",
+            "finding": "Overprovisioned",
+            "recommendationOptions": [],
+            "utilizationMetrics": [],
+        }
+        bad_item = {
+            "instanceArn": "arn:aws:ec2:us-east-1:123456789012:instance/i-bad",
+        }
+
+        class FakeComputeOptimizerClient:
+            def get_ec2_instance_recommendations(self, **kwargs):
+                return {"instanceRecommendations": [good_item, bad_item]}
+
+        monkeypatch.setattr(
+            compute_optimizer_export.utils,
+            "get_boto3_client",
+            lambda service, region_name=None: FakeComputeOptimizerClient(),
+        )
+
+        original = compute_optimizer_export._build_ec2_recommendation_row
+
+        def raise_for_bad(recommendation, region):
+            if recommendation is bad_item:
+                raise KeyError("SomeUnexpectedField")
+            return original(recommendation, region)
+
+        monkeypatch.setattr(
+            compute_optimizer_export, "_build_ec2_recommendation_row", raise_for_bad
+        )
+
+        rows = compute_optimizer_export.get_ec2_recommendations(REGION)
+
+        instance_ids = {row["Instance ID"] for row in rows}
+        assert "i-good" in instance_ids, "healthy recommendation was lost when a sibling failed"
+        assert "i-bad" not in instance_ids, "malformed recommendation should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record
+        a FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "GetEc2InstanceRecommendations",
+            )
+
+        monkeypatch.setattr(compute_optimizer_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            compute_optimizer_export.get_ec2_recommendations(REGION)
+
+    def test_collect_ec2_recommendations_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker and
+        exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "GetEc2InstanceRecommendations",
+            )
+
+        monkeypatch.setattr(compute_optimizer_export, "get_ec2_recommendations", boom)
+
+        recs, failed_regions = compute_optimizer_export.collect_ec2_recommendations([REGION])
+
+        assert recs == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_connect_export.py
+++ b/tests/test_exporters/test_connect_export.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for connect_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2a). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+moto's Amazon Connect support covers create_instance/list_instances, so the
+malformed-item and happy-path cases exercise real moto resources. moto does
+not implement list_queues/list_phone_numbers_v2 in a way that's practical to
+seed with real data for this regression suite, so the queues/phone-number
+raise-and-surface cases (b)/(c) are exercised purely via monkeypatch, with no
+real AWS/moto resources involved.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import connect_export  # noqa: E402
+from connect_export import _scan_instances_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_instance(client, alias):
+    """Create a Connect instance named ``alias``."""
+    return client.create_instance(
+        IdentityManagementType="CONNECT_MANAGED",
+        InstanceAlias=alias,
+        InboundCallsEnabled=True,
+        OutboundCallsEnabled=True,
+    )
+
+
+class TestScanInstancesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_instances(self):
+        client = boto3.client("connect", region_name=REGION)
+        _create_instance(client, "web-instance")
+
+        rows = _scan_instances_region(REGION)
+
+        aliases = {row["Instance Alias"] for row in rows}
+        assert "web-instance" in aliases
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("connect", region_name=REGION)  # region exists, no instances
+
+        rows = _scan_instances_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One instance that fails to process must not discard the whole region."""
+        client = boto3.client("connect", region_name=REGION)
+        _create_instance(client, "good-instance")
+        _create_instance(client, "bad-instance")
+
+        original = connect_export._build_instance_row
+
+        def raise_for_bad(instance_summary, region):
+            if instance_summary.get("InstanceAlias") == "bad-instance":
+                raise KeyError("SomeUnexpectedField")
+            return original(instance_summary, region)
+
+        monkeypatch.setattr(connect_export, "_build_instance_row", raise_for_bad)
+
+        rows = _scan_instances_region(REGION)
+
+        aliases = {row["Instance Alias"] for row in rows}
+        assert "good-instance" in aliases, "healthy instance was lost when a sibling failed"
+        assert "bad-instance" not in aliases, "malformed instance should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListInstances",
+            )
+
+        monkeypatch.setattr(connect_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_instances_region(REGION)
+
+    @mock_aws
+    def test_collect_instances_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListInstances",
+            )
+
+        monkeypatch.setattr(connect_export, "_scan_instances_region", boom)
+
+        instances, failed_regions = connect_export.collect_instances([REGION])
+
+        assert instances == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_scan_queues_region_raises_not_empty(self, monkeypatch):
+        """
+        The queues scope collector (blast-radius "+2" sibling of the primary
+        scope) must also propagate region-level API failures rather than
+        swallowing them into an empty list. Exercised purely via monkeypatch —
+        no real moto/AWS resources involved.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListQueues",
+            )
+
+        monkeypatch.setattr(connect_export.utils, "get_boto3_client", boom)
+
+        instances = [{"Region": REGION, "Instance ID": "fake-instance-id", "ARN": "fake-arn"}]
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            connect_export._scan_queues_region(REGION, instances)
+
+    def test_collect_queues_surfaces_failed_regions(self, monkeypatch):
+        """
+        collect_queues must surface failed regions via collect_failures rather
+        than dropping them. Exercised purely via monkeypatch — no real
+        moto/AWS resources involved.
+        """
+
+        def boom(region, instances):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListQueues",
+            )
+
+        monkeypatch.setattr(connect_export, "_scan_queues_region", boom)
+
+        queues, failed_regions = connect_export.collect_queues([], [REGION])
+
+        assert queues == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_scan_phone_numbers_region_raises_not_empty(self, monkeypatch):
+        """
+        The phone-numbers scope collector (blast-radius "+2" sibling of the
+        primary scope) must also propagate region-level API failures rather
+        than swallowing them into an empty list. Exercised purely via
+        monkeypatch — no real moto/AWS resources involved.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListPhoneNumbersV2",
+            )
+
+        monkeypatch.setattr(connect_export.utils, "get_boto3_client", boom)
+
+        instances = [{"Region": REGION, "Instance ID": "fake-instance-id", "ARN": "fake-arn"}]
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            connect_export._scan_phone_numbers_region(REGION, instances)
+
+    def test_collect_phone_numbers_surfaces_failed_regions(self, monkeypatch):
+        """
+        collect_phone_numbers must surface failed regions via
+        collect_failures rather than dropping them. Exercised purely via
+        monkeypatch — no real moto/AWS resources involved.
+        """
+
+        def boom(region, instances):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListPhoneNumbersV2",
+            )
+
+        monkeypatch.setattr(connect_export, "_scan_phone_numbers_region", boom)
+
+        numbers, failed_regions = connect_export.collect_phone_numbers([], [REGION])
+
+        assert numbers == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_ecr_export.py
+++ b/tests/test_exporters/test_ecr_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ecr_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2a). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ecr_export  # noqa: E402
+from ecr_export import scan_ecr_repositories_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_repo(client, name):
+    """Create an ECR repository named ``name``."""
+    client.create_repository(repositoryName=name)
+
+
+class TestScanEcrRepositoriesInRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_repositories(self):
+        client = boto3.client("ecr", region_name=REGION)
+        _create_repo(client, "web-repo")
+
+        rows = scan_ecr_repositories_in_region(REGION)
+
+        names = {row["Repository Name"] for row in rows}
+        assert "web-repo" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ecr", region_name=REGION)  # region exists, no repos
+
+        rows = scan_ecr_repositories_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One repository that fails to process must not discard the whole region."""
+        client = boto3.client("ecr", region_name=REGION)
+        _create_repo(client, "good-repo")
+        _create_repo(client, "bad-repo")
+
+        original = ecr_export._build_repo_row
+
+        def raise_for_bad(repo, region, ecr_client=None):
+            if repo.get("repositoryName") == "bad-repo":
+                raise KeyError("SomeUnexpectedField")
+            return original(repo, region, ecr_client)
+
+        monkeypatch.setattr(ecr_export, "_build_repo_row", raise_for_bad)
+
+        rows = scan_ecr_repositories_in_region(REGION)
+
+        names = {row["Repository Name"] for row in rows}
+        assert "good-repo" in names, "healthy repository was lost when a sibling failed"
+        assert "bad-repo" not in names, "malformed repository should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeRepositories",
+            )
+
+        monkeypatch.setattr(ecr_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_ecr_repositories_in_region(REGION)
+
+    @mock_aws
+    def test_collect_ecr_repositories_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeRepositories",
+            )
+
+        monkeypatch.setattr(ecr_export, "scan_ecr_repositories_in_region", boom)
+
+        repos, failed_regions = ecr_export.collect_ecr_repositories([REGION])
+
+        assert repos == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_image_builder_export.py
+++ b/tests/test_exporters/test_image_builder_export.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Tests for image_builder_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2a) applied to the
+PIPELINES scope. See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+NOTE: moto (5.1.21, at the time this test was written) does not implement an
+EC2 Image Builder backend, so this file cannot use ``@mock_aws`` against a
+simulated ``imagebuilder`` service the way the RDS/Lambda/Auto Scaling
+regression suites do. Instead, ``utils.get_boto3_client`` is monkeypatched to
+return either a raising stub (region-level failure case) or a minimal fake
+client object exposing just the ``list_image_pipelines`` /
+``get_image_pipeline`` surface the collector calls (malformed-item case).
+This still exercises the real control flow in
+``_scan_pipelines_region`` / ``_build_pipeline_row`` / ``collect_image_pipelines``
+without touching real AWS or requiring a moto backend.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import image_builder_export  # noqa: E402
+from image_builder_export import _scan_pipelines_region  # noqa: E402
+
+REGION = "us-east-1"
+GOOD_ARN = f"arn:aws:imagebuilder:{REGION}:123456789012:image-pipeline/good-pipeline"
+BAD_ARN = f"arn:aws:imagebuilder:{REGION}:123456789012:image-pipeline/bad-pipeline"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakeImageBuilderClient:
+    """
+    Minimal stand-in for the boto3 ``imagebuilder`` client, exposing only the
+    two calls ``_scan_pipelines_region`` / ``_build_pipeline_row`` use:
+    ``list_image_pipelines`` and ``get_image_pipeline``. One pipeline
+    (``BAD_ARN``) raises when its details are fetched, to exercise the
+    per-item skip-not-fatal path.
+    """
+
+    def list_image_pipelines(self, **kwargs):
+        return {
+            "imagePipelineList": [
+                {"arn": GOOD_ARN},
+                {"arn": BAD_ARN},
+            ]
+        }
+
+    def get_image_pipeline(self, **kwargs):
+        pipeline_arn = kwargs.get("imagePipelineArn")
+        if pipeline_arn == BAD_ARN:
+            raise KeyError("SomeUnexpectedField")
+        return {
+            "imagePipeline": {
+                "name": "good-pipeline",
+                "status": "ENABLED",
+                "imageRecipeArn": f"arn:aws:imagebuilder:{REGION}:123456789012:image-recipe/good-recipe/1.0.0",
+                "infrastructureConfigurationArn": "N/A",
+                "distributionConfigurationArn": "N/A",
+                "schedule": {},
+                "enhancedImageMetadataEnabled": True,
+                "imageTestsConfiguration": {},
+                "dateCreated": "2026-01-01T00:00:00.000Z",
+                "description": "test pipeline",
+                "tags": {},
+            }
+        }
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit applied to the Image Builder
+    pipelines scope: a collection error must never be swallowed into an
+    empty result indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One pipeline that fails to fetch details must not discard the whole region."""
+        monkeypatch.setattr(
+            image_builder_export.utils,
+            "get_boto3_client",
+            lambda service, region_name=None: _FakeImageBuilderClient(),
+        )
+
+        rows = _scan_pipelines_region(REGION)
+
+        names = {row["Pipeline Name"] for row in rows}
+        assert "good-pipeline" in names, "healthy pipeline was lost when a sibling failed"
+        assert len(rows) == 1, "malformed pipeline should have been skipped, not included"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListImagePipelines",
+            )
+
+        monkeypatch.setattr(image_builder_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_pipelines_region(REGION)
+
+    def test_collect_image_pipelines_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListImagePipelines",
+            )
+
+        monkeypatch.setattr(image_builder_export, "_scan_pipelines_region", boom)
+
+        pipelines, failed_regions = image_builder_export.collect_image_pipelines([REGION])
+
+        assert pipelines == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_invalid_region_is_skipped_not_scanned(self):
+        """An invalid region string is skipped locally, not sent to AWS."""
+        rows = _scan_pipelines_region("not-a-region")
+        assert rows == []

--- a/tests/test_exporters/test_ssm_fleet_export.py
+++ b/tests/test_exporters/test_ssm_fleet_export.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ssm_fleet_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto 5.1.21 does not implement SSM's ``describe_instance_information``
+or ``list_compliance_items`` (both raise "action has not been implemented"),
+so the managed-instances and patch-compliance scope tests fake the SSM
+client / scan functions via ``monkeypatch`` instead of relying on
+``@mock_aws`` state. ``describe_parameters`` IS implemented by moto, so the
+parameters scope also gets one real ``@mock_aws`` happy-path test.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ssm_fleet_export  # noqa: E402
+from ssm_fleet_export import _scan_managed_instances_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in yielding pre-built pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeSSMClient:
+    """
+    Minimal SSM client stand-in for ``describe_instance_information``.
+
+    moto does not implement this action, so the managed-instances scope is
+    exercised against this fake instead of ``@mock_aws``.
+    """
+
+    def __init__(self, instances=None):
+        self._instances = instances or []
+
+    def get_paginator(self, operation_name):
+        assert operation_name == 'describe_instance_information'
+        return _FakePaginator([{'InstanceInformationList': self._instances}])
+
+
+def _instance(instance_id, ping_status='Online'):
+    return {
+        'InstanceId': instance_id,
+        'PingStatus': ping_status,
+        'PlatformType': 'Linux',
+    }
+
+
+class TestScanManagedInstancesRegion:
+    """Happy-path collection."""
+
+    def test_collects_instances(self, monkeypatch):
+        fake_client = _FakeSSMClient(instances=[_instance('i-good')])
+        monkeypatch.setattr(ssm_fleet_export.utils, 'get_boto3_client', lambda *a, **kw: fake_client)
+
+        rows = _scan_managed_instances_region(REGION)
+
+        ids = {row['Instance ID'] for row in rows}
+        assert 'i-good' in ids
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _FakeSSMClient(instances=[])
+        monkeypatch.setattr(ssm_fleet_export.utils, 'get_boto3_client', lambda *a, **kw: fake_client)
+
+        rows = _scan_managed_instances_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+
+    ssm_fleet_export has three region-scanned scope collectors (managed
+    instances, patch compliance, parameters) whose failures must all
+    accumulate into one combined ``failed_regions`` list.
+    """
+
+    # -- Primary scope: managed instances -----------------------------------
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One instance that fails to process must not discard the whole region."""
+        fake_client = _FakeSSMClient(instances=[_instance('good-i'), _instance('bad-i')])
+        monkeypatch.setattr(ssm_fleet_export.utils, 'get_boto3_client', lambda *a, **kw: fake_client)
+
+        original = ssm_fleet_export._build_instance_row
+
+        def raise_for_bad(instance, region):
+            if instance.get('InstanceId') == 'bad-i':
+                raise KeyError('SomeUnexpectedField')
+            return original(instance, region)
+
+        monkeypatch.setattr(ssm_fleet_export, '_build_instance_row', raise_for_bad)
+
+        rows = _scan_managed_instances_region(REGION)
+
+        ids = {row['Instance ID'] for row in rows}
+        assert 'good-i' in ids, "healthy instance was lost when a sibling failed"
+        assert 'bad-i' not in ids, "malformed instance should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeInstanceInformation",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_managed_instances_region(REGION)
+
+    def test_collect_managed_instances_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeInstanceInformation",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export, "_scan_managed_instances_region", boom)
+
+        instances, failed_regions = ssm_fleet_export.collect_managed_instances([REGION])
+
+        assert instances == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    # -- Second scope: patch compliance --------------------------------------
+
+    def test_scan_patch_compliance_region_api_failure_raises(self, monkeypatch):
+        """
+        A failure while listing instances (the region-level API call) must
+        propagate. Per-instance list_compliance_items lookups stay
+        best-effort (see docstring on _scan_patch_compliance_region).
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeInstanceInformation",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            ssm_fleet_export._scan_patch_compliance_region(REGION)
+
+    def test_collect_patch_compliance_surfaces_failed_regions(self, monkeypatch):
+        """The patch-compliance scope must also surface region failures."""
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeInstanceInformation",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export, "_scan_patch_compliance_region", boom)
+
+        compliance, failed_regions = ssm_fleet_export.collect_patch_compliance([REGION])
+
+        assert compliance == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    # -- Third scope: parameters ---------------------------------------------
+
+    @mock_aws
+    def test_scan_ssm_parameters_region_collects_real_moto_parameters(self):
+        """Happy path: describe_parameters IS implemented by moto."""
+        client = boto3.client("ssm", region_name=REGION)
+        client.put_parameter(Name="/app/config", Value="v1", Type="String")
+
+        rows = ssm_fleet_export._scan_ssm_parameters_region(REGION)
+
+        names = {row["Parameter Name"] for row in rows}
+        assert "/app/config" in names
+
+    def test_scan_ssm_parameters_region_api_failure_raises(self, monkeypatch):
+        """Parameters scope: a region-level API failure must propagate."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeParameters",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            ssm_fleet_export._scan_ssm_parameters_region(REGION)
+
+    def test_collect_ssm_parameters_surfaces_failed_regions(self, monkeypatch):
+        """The parameters scope must also surface region failures."""
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeParameters",
+            )
+
+        monkeypatch.setattr(ssm_fleet_export, "_scan_ssm_parameters_region", boom)
+
+        parameters, failed_regions = ssm_fleet_export.collect_ssm_parameters([REGION])
+
+        assert parameters == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -54,6 +54,19 @@ _EXCLUDED = {
     "governance_resources.py",
     "output_archive.py",
     "services_in_use_export.py",
+    # image_builder and ssm_fleet: moto does not implement their PRIMARY
+    # collection APIs — imagebuilder:ListImagePipelines raises ClientError 404
+    # "Not yet implemented" and ssm:DescribeInstanceInformation raises
+    # NotImplementedError. With the Tier-2 silent-collection-failure fix, a
+    # primary-scope collection error is (correctly) surfaced as a failed scope
+    # -> FAILED marker -> sys.exit(1), so these cannot exit 0 against an empty
+    # mocked environment. The scripts are correct in production (the APIs exist
+    # there); adding an availability-probe skip would reintroduce silent loss on
+    # a real throttle/deny. Behavior is covered by the dedicated regression
+    # suites: tests/test_exporters/test_image_builder_export.py and
+    # test_ssm_fleet_export.py.
+    "image_builder_export.py",
+    "ssm_fleet_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233 (blast-radius follow-up to #231/#232). Second phase of the phased rollout — **Batch A: compute & containers (8 exporters)** — onto the shared plumbing landed in #234.

## What
Converts each exporter's PRIMARY scope collector(s) onto the shared failure-surfacing contract, matching the Tier-1 pattern:
1. Scope collector **raises** on error (removed `@utils.aws_error_handler(default_return=...)` / broad region-level swallow) so `scan_regions_concurrent(collect_failures=True)` records the failed scope.
2. Per-item row building extracted to a `_build_*_row()` helper and guarded (`try/except + continue`) — one malformed item is skipped, not fatal; hard subscripts converted to `.get()`.
3. export/main exports whatever succeeded (**partial export**), distinguishes genuine-empty (`elif not failed_regions`) from failure, and on any failed scope calls `utils.report_collection_failures(account_name, '<slug>', failed_regions)` + prints an error + `sys.exit(1)`.

| Exporter | Scopes fixed | Slug |
|---|---|---|
| autoscaling | 1 (ASGs) | `autoscaling` |
| ami | 1 | `ami` |
| ecr | 1 (repos) | `ecr` |
| image_builder | 4 | `image-builder` |
| ssm_fleet | 3 | `ssm-fleet` |
| connect | 3 | `connect` |
| comprehend | 5 | `comprehend` |
| compute_optimizer | 5 | `compute-optimizer` |

Multi-scope exporters merge all scopes' `failed_regions` into one list driving a single marker + exit. Enrichment/probe helpers keep degrading gracefully.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite (malformed-item-skipped; scope API failure raises-not-empty; wrapper surfaces failed_regions). Where moto lacks the service (imagebuilder, comprehend, compute-optimizer, parts of connect/ssm), the raise/surface cases use monkeypatch — noted in each test's docstring. **Batch-A suites: 44 passed. Full suite green. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusion (please note)
`image_builder_export` and `ssm_fleet_export` are added to the smoke test's `_EXCLUDED` set. moto does not implement their primary APIs (`imagebuilder:ListImagePipelines` → ClientError 404 "Not yet implemented"; `ssm:DescribeInstanceInformation` → `NotImplementedError`), so with the correct fail-loud behavior they exit 1 against an empty mocked env. Adding an availability-probe skip would **reintroduce silent loss** on a real throttle/deny, so it is deliberately avoided; the dedicated regression suites cover both. compute_optimizer survives smoke via its pre-existing enrollment-availability probe; the moto-mockable exporters (ami/ecr/connect/comprehend) return empty and pass normally.

## Scope notes / follow-ups (tracked in #233)
- `ecr`: the images + lifecycle-policy sheets remain enrichment (graceful) — PARTIAL-class, same treatment Tier-1 gave lambda's enrichment sheets. Follow-up.
- Remaining Tier-2 batches: **B** data & storage, **C** security & identity, **D** networking, **E** messaging/cost/governance. Tier-3 (48 PARTIAL) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)