### PR TITLE
Silent collection failure: Tier-2b (data & storage exporters)

### DIFF
--- a/scripts/bedrock_export.py
+++ b/scripts/bedrock_export.py
@@ -28,391 +28,591 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Bedrock models and usage to Excel")
 
-@utils.aws_error_handler("Collecting Bedrock foundation models", default_return=[])
-def collect_foundation_models(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect available Bedrock foundation models from AWS regions."""
-    all_models = []
 
-    for region in regions:
-        utils.log_info(f"Collecting foundation models in {region}...")
-        bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+def _build_foundation_model_row(model: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build the export row for a single Bedrock foundation model."""
+    model_id = model.get('modelId', 'N/A')
+    model_arn = model.get('modelArn', 'N/A')
+    model_name = model.get('modelName', 'N/A')
+    provider_name = model.get('providerName', 'N/A')
 
+    # Input/output modalities
+    input_modalities = model.get('inputModalities', [])
+    output_modalities = model.get('outputModalities', [])
+    input_str = ', '.join(input_modalities) if input_modalities else 'N/A'
+    output_str = ', '.join(output_modalities) if output_modalities else 'N/A'
+
+    # Response streaming
+    response_streaming = model.get('responseStreamingSupported', False)
+
+    # Customization supported
+    customization_supported = model.get('customizationsSupported', [])
+    customization_str = ', '.join(customization_supported) if customization_supported else 'None'
+
+    # Inference types
+    inference_types = model.get('inferenceTypesSupported', [])
+    inference_str = ', '.join(inference_types) if inference_types else 'N/A'
+
+    # Model lifecycle status
+    model_lifecycle = model.get('modelLifecycle', {}) or {}
+    lifecycle_status = model_lifecycle.get('status', 'N/A')
+
+    return {
+        'Region': region,
+        'Model ID': model_id,
+        'Model Name': model_name,
+        'Provider': provider_name,
+        'ARN': model_arn,
+        'Lifecycle Status': lifecycle_status,
+        'Input Modalities': input_str,
+        'Output Modalities': output_str,
+        'Response Streaming': response_streaming,
+        'Customization Supported': customization_str,
+        'Inference Types': inference_str
+    }
+
+
+def _scan_foundation_models_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Bedrock foundation models from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no foundation models" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed models are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting foundation models in {region}...")
+    bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+
+    # list_foundation_models is not paginated (no token) — single call.
+    response = bedrock_client.list_foundation_models()
+    models = response.get('modelSummaries', [])
+
+    region_models = []
+    for model in models:
         try:
-            # list_foundation_models is not paginated (no token) — single call.
-            response = bedrock_client.list_foundation_models()
-            models = response.get('modelSummaries', [])
-
-            for model in models:
-                model_id = model.get('modelId', 'N/A')
-                model_arn = model.get('modelArn', 'N/A')
-                model_name = model.get('modelName', 'N/A')
-                provider_name = model.get('providerName', 'N/A')
-
-                # Input/output modalities
-                input_modalities = model.get('inputModalities', [])
-                output_modalities = model.get('outputModalities', [])
-                input_str = ', '.join(input_modalities) if input_modalities else 'N/A'
-                output_str = ', '.join(output_modalities) if output_modalities else 'N/A'
-
-                # Response streaming
-                response_streaming = model.get('responseStreamingSupported', False)
-
-                # Customization supported
-                customization_supported = model.get('customizationsSupported', [])
-                customization_str = ', '.join(customization_supported) if customization_supported else 'None'
-
-                # Inference types
-                inference_types = model.get('inferenceTypesSupported', [])
-                inference_str = ', '.join(inference_types) if inference_types else 'N/A'
-
-                # Model lifecycle status
-                model_lifecycle = model.get('modelLifecycle', {})
-                lifecycle_status = model_lifecycle.get('status', 'N/A')
-
-                all_models.append({
-                    'Region': region,
-                    'Model ID': model_id,
-                    'Model Name': model_name,
-                    'Provider': provider_name,
-                    'ARN': model_arn,
-                    'Lifecycle Status': lifecycle_status,
-                    'Input Modalities': input_str,
-                    'Output Modalities': output_str,
-                    'Response Streaming': response_streaming,
-                    'Customization Supported': customization_str,
-                    'Inference Types': inference_str
-                })
-
+            region_models.append(_build_foundation_model_row(model, region))
         except Exception as e:
-            utils.log_warning(f"Error listing foundation models in {region}: {str(e)}")
+            utils.log_error(
+                f"Skipping malformed foundation model in {region}: "
+                f"{model.get('modelId', '<unknown>')}",
+                e,
+            )
             continue
 
+    utils.log_info(f"Collected {len(region_models)} foundation models in {region}")
+    return region_models
+
+
+def collect_foundation_models(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock foundation model information across regions, surfacing
+    failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(models, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_foundation_models_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_models = [m for result in region_results for m in result]
     utils.log_info(f"Collected {len(all_models)} foundation models")
-    return all_models
+    return all_models, failed_regions
 
 
-@utils.aws_error_handler("Collecting Bedrock custom models", default_return=[])
-def collect_custom_models(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Bedrock custom (fine-tuned) models."""
-    all_custom_models = []
+def _build_custom_model_row(model: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build the export row for a single Bedrock custom (fine-tuned) model."""
+    model_arn = model.get('modelArn', 'N/A')
+    model_name = model.get('modelName', 'N/A')
+    base_model_arn = model.get('baseModelArn', 'N/A')
 
-    for region in regions:
-        utils.log_info(f"Collecting custom models in {region}...")
-        bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+    creation_time = model.get('creationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
 
-        try:
-            paginator = bedrock_client.get_paginator('list_custom_models')
-            for page in paginator.paginate():
-                models = page.get('modelSummaries', [])
+    # Extract base model name from ARN
+    base_model_name = 'N/A'
+    if base_model_arn != 'N/A' and '/' in base_model_arn:
+        base_model_name = base_model_arn.split('/')[-1]
 
-                for model in models:
-                    model_arn = model.get('modelArn', 'N/A')
-                    model_name = model.get('modelName', 'N/A')
-                    base_model_arn = model.get('baseModelArn', 'N/A')
+    customization_type = model.get('customizationType', 'N/A')
 
-                    creation_time = model.get('creationTime', 'N/A')
-                    if creation_time != 'N/A':
-                        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Extract base model name from ARN
-                    base_model_name = 'N/A'
-                    if base_model_arn != 'N/A' and '/' in base_model_arn:
-                        base_model_name = base_model_arn.split('/')[-1]
-
-                    # Customization type
-                    customization_type = model.get('customizationType', 'N/A')
-
-                    all_custom_models.append({
-                        'Region': region,
-                        'Model Name': model_name,
-                        'Model ARN': model_arn,
-                        'Base Model': base_model_name,
-                        'Base Model ARN': base_model_arn,
-                        'Customization Type': customization_type,
-                        'Created': creation_time
-                    })
-
-        except Exception as e:
-            utils.log_warning(f"Error listing custom models in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_custom_models)} custom models")
-    return all_custom_models
+    return {
+        'Region': region,
+        'Model Name': model_name,
+        'Model ARN': model_arn,
+        'Base Model': base_model_name,
+        'Base Model ARN': base_model_arn,
+        'Customization Type': customization_type,
+        'Created': creation_time
+    }
 
 
-@utils.aws_error_handler("Collecting Bedrock model invocation logging", default_return=[])
-def collect_model_invocation_logging(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Bedrock model invocation logging configurations."""
-    all_logging_configs = []
+def _scan_custom_models_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Bedrock custom models from a single region.
 
-    for region in regions:
-        utils.log_info(f"Collecting model invocation logging config in {region}...")
-        bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+    Primary scope collector — raises on genuine API error so the caller can
+    record the region as failed rather than empty. Individual malformed
+    models are skipped (logged).
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-        try:
-            response = bedrock_client.get_model_invocation_logging_configuration()
-            logging_config = response.get('loggingConfig', {})
+    utils.log_info(f"Collecting custom models in {region}...")
+    bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
 
-            if logging_config:
-                # CloudWatch Logs
-                cloudwatch_config = logging_config.get('cloudWatchConfig', {})
-                cloudwatch_enabled = cloudwatch_config.get('logGroupName') is not None
-                cloudwatch_log_group = cloudwatch_config.get('logGroupName', 'N/A')
-                cloudwatch_role = cloudwatch_config.get('roleArn', 'N/A')
-
-                # S3
-                s3_config = logging_config.get('s3Config', {})
-                s3_enabled = s3_config.get('bucketName') is not None
-                s3_bucket = s3_config.get('bucketName', 'N/A')
-                s3_prefix = s3_config.get('keyPrefix', 'N/A')
-
-                # Text data delivery
-                text_data_delivery = logging_config.get('textDataDeliveryEnabled', False)
-                image_data_delivery = logging_config.get('imageDataDeliveryEnabled', False)
-                embedding_data_delivery = logging_config.get('embeddingDataDeliveryEnabled', False)
-
-                all_logging_configs.append({
-                    'Region': region,
-                    'CloudWatch Enabled': cloudwatch_enabled,
-                    'CloudWatch Log Group': cloudwatch_log_group,
-                    'CloudWatch Role ARN': cloudwatch_role,
-                    'S3 Enabled': s3_enabled,
-                    'S3 Bucket': s3_bucket,
-                    'S3 Key Prefix': s3_prefix,
-                    'Text Data Delivery': text_data_delivery,
-                    'Image Data Delivery': image_data_delivery,
-                    'Embedding Data Delivery': embedding_data_delivery
-                })
-
-        except Exception as e:
-            utils.log_warning(f"Error getting model invocation logging config in {region}: {str(e)}")
-            continue
-
-    utils.log_info(f"Collected {len(all_logging_configs)} logging configurations")
-    return all_logging_configs
-
-
-@utils.aws_error_handler("Collecting Bedrock guardrails", default_return=[])
-def collect_guardrails(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Bedrock guardrails for responsible AI."""
-    all_guardrails = []
-
-    for region in regions:
-        utils.log_info(f"Collecting guardrails in {region}...")
-        bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
-
-        try:
-            # list_guardrails is absent in older botocore and unpaginated in newer —
-            # probe for the operation, then page manually via nextToken.
-            if 'list_guardrails' not in bedrock_client.meta.service_model.operation_names:
-                utils.log_info(f"Bedrock guardrails API unavailable in this SDK ({region}); skipping.")
+    region_custom_models = []
+    paginator = bedrock_client.get_paginator('list_custom_models')
+    for page in paginator.paginate():
+        models = page.get('modelSummaries', [])
+        for model in models:
+            try:
+                region_custom_models.append(_build_custom_model_row(model, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed custom model in {region}: "
+                    f"{model.get('modelArn', '<unknown>')}",
+                    e,
+                )
                 continue
 
-            next_token = None
-            while True:
-                params: dict[str, Any] = {'maxResults': 100}
-                if next_token:
-                    params['nextToken'] = next_token
-                page = bedrock_client.list_guardrails(**params)
-                guardrails = page.get('guardrails', [])
+    utils.log_info(f"Collected {len(region_custom_models)} custom models in {region}")
+    return region_custom_models
 
-                for guardrail in guardrails:
-                    guardrail_id = guardrail.get('id', 'N/A')
-                    guardrail_arn = guardrail.get('arn', 'N/A')
-                    guardrail_name = guardrail.get('name', 'N/A')
-                    description = guardrail.get('description', 'N/A')
-                    version = guardrail.get('version', 'N/A')
-                    status = guardrail.get('status', 'N/A')
 
-                    created_at = guardrail.get('createdAt', 'N/A')
-                    if created_at != 'N/A':
-                        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+def collect_custom_models(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock custom model information across regions, surfacing
+    failures via ``collect_failures=True``.
 
-                    updated_at = guardrail.get('updatedAt', 'N/A')
-                    if updated_at != 'N/A':
-                        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
+    Returns:
+        tuple: ``(models, failed_regions)``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_custom_models_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_custom_models = [m for result in region_results for m in result]
+    utils.log_info(f"Collected {len(all_custom_models)} custom models")
+    return all_custom_models, failed_regions
 
-                    all_guardrails.append({
-                        'Region': region,
-                        'Guardrail Name': guardrail_name,
-                        'Guardrail ID': guardrail_id,
-                        'ARN': guardrail_arn,
-                        'Version': version,
-                        'Status': status,
-                        'Description': description,
-                        'Created': created_at,
-                        'Updated': updated_at
-                    })
 
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
+def _build_logging_config_row(logging_config: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build the export row for a single region's model invocation logging config."""
+    cloudwatch_config = logging_config.get('cloudWatchConfig', {}) or {}
+    cloudwatch_enabled = cloudwatch_config.get('logGroupName') is not None
+    cloudwatch_log_group = cloudwatch_config.get('logGroupName', 'N/A')
+    cloudwatch_role = cloudwatch_config.get('roleArn', 'N/A')
 
-        except Exception as e:
-            utils.log_warning(f"Error listing guardrails in {region}: {str(e)}")
-            continue
+    s3_config = logging_config.get('s3Config', {}) or {}
+    s3_enabled = s3_config.get('bucketName') is not None
+    s3_bucket = s3_config.get('bucketName', 'N/A')
+    s3_prefix = s3_config.get('keyPrefix', 'N/A')
 
+    text_data_delivery = logging_config.get('textDataDeliveryEnabled', False)
+    image_data_delivery = logging_config.get('imageDataDeliveryEnabled', False)
+    embedding_data_delivery = logging_config.get('embeddingDataDeliveryEnabled', False)
+
+    return {
+        'Region': region,
+        'CloudWatch Enabled': cloudwatch_enabled,
+        'CloudWatch Log Group': cloudwatch_log_group,
+        'CloudWatch Role ARN': cloudwatch_role,
+        'S3 Enabled': s3_enabled,
+        'S3 Bucket': s3_bucket,
+        'S3 Key Prefix': s3_prefix,
+        'Text Data Delivery': text_data_delivery,
+        'Image Data Delivery': image_data_delivery,
+        'Embedding Data Delivery': embedding_data_delivery
+    }
+
+
+def _scan_model_invocation_logging_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect the Bedrock model invocation logging configuration for a single
+    region.
+
+    Primary scope collector — raises on genuine API error so the caller can
+    record the region as failed rather than empty.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting model invocation logging config in {region}...")
+    bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+
+    response = bedrock_client.get_model_invocation_logging_configuration()
+    logging_config = response.get('loggingConfig', {})
+
+    if not logging_config:
+        return []
+
+    try:
+        return [_build_logging_config_row(logging_config, region)]
+    except Exception as e:
+        utils.log_error(f"Skipping malformed logging config in {region}", e)
+        return []
+
+
+def collect_model_invocation_logging(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock model invocation logging configurations across regions,
+    surfacing failures via ``collect_failures=True``.
+
+    Returns:
+        tuple: ``(logging_configs, failed_regions)``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_model_invocation_logging_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_logging_configs = [c for result in region_results for c in result]
+    utils.log_info(f"Collected {len(all_logging_configs)} logging configurations")
+    return all_logging_configs, failed_regions
+
+
+def _build_guardrail_row(guardrail: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build the export row for a single Bedrock guardrail."""
+    guardrail_id = guardrail.get('id', 'N/A')
+    guardrail_arn = guardrail.get('arn', 'N/A')
+    guardrail_name = guardrail.get('name', 'N/A')
+    description = guardrail.get('description', 'N/A')
+    version = guardrail.get('version', 'N/A')
+    status = guardrail.get('status', 'N/A')
+
+    created_at = guardrail.get('createdAt', 'N/A')
+    if created_at != 'N/A':
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    updated_at = guardrail.get('updatedAt', 'N/A')
+    if updated_at != 'N/A':
+        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    return {
+        'Region': region,
+        'Guardrail Name': guardrail_name,
+        'Guardrail ID': guardrail_id,
+        'ARN': guardrail_arn,
+        'Version': version,
+        'Status': status,
+        'Description': description,
+        'Created': created_at,
+        'Updated': updated_at
+    }
+
+
+def _scan_guardrails_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Bedrock guardrails from a single region.
+
+    Primary scope collector — raises on genuine API error so the caller can
+    record the region as failed rather than empty. The exception is the
+    op-availability probe below: ``list_guardrails`` is absent at the
+    botocore floor in some environments (see Issue #224). A missing
+    operation is a graceful skip, NOT a failed region — only errors raised
+    by an actually-present operation propagate as failures.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting guardrails in {region}...")
+    bedrock_client = utils.get_boto3_client('bedrock', region_name=region)
+
+    # list_guardrails is absent in older botocore and unpaginated in newer —
+    # probe for the operation, then page manually via nextToken. A missing
+    # operation is a graceful skip, not a collection failure.
+    if 'list_guardrails' not in bedrock_client.meta.service_model.operation_names:
+        utils.log_info(f"Bedrock guardrails API unavailable in this SDK ({region}); skipping.")
+        return []
+
+    region_guardrails = []
+    next_token = None
+    while True:
+        params: dict[str, Any] = {'maxResults': 100}
+        if next_token:
+            params['nextToken'] = next_token
+        page = bedrock_client.list_guardrails(**params)
+        guardrails = page.get('guardrails', [])
+
+        for guardrail in guardrails:
+            try:
+                region_guardrails.append(_build_guardrail_row(guardrail, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed guardrail in {region}: "
+                    f"{guardrail.get('id', '<unknown>')}",
+                    e,
+                )
+                continue
+
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
+
+    utils.log_info(f"Collected {len(region_guardrails)} guardrails in {region}")
+    return region_guardrails
+
+
+def collect_guardrails(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock guardrail information across regions, surfacing failures
+    via ``collect_failures=True``. The op-availability probe (missing
+    ``list_guardrails`` operation) is a graceful per-region skip and never
+    contributes to ``failed_regions``.
+
+    Returns:
+        tuple: ``(guardrails, failed_regions)``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_guardrails_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_guardrails = [g for result in region_results for g in result]
     utils.log_info(f"Collected {len(all_guardrails)} guardrails")
-    return all_guardrails
+    return all_guardrails, failed_regions
 
 
-@utils.aws_error_handler("Collecting Bedrock knowledge bases", default_return=[])
-def collect_knowledge_bases(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Bedrock knowledge bases for RAG applications."""
-    all_knowledge_bases = []
+def _build_kb_row(kb: dict[str, Any], region: str, bedrock_agent_client) -> dict[str, Any]:
+    """
+    Build the export row for a single Bedrock knowledge base.
 
-    for region in regions:
-        utils.log_info(f"Collecting knowledge bases in {region}...")
-        bedrock_agent_client = utils.get_boto3_client('bedrock-agent', region_name=region)
+    Fetches enrichment details via ``get_knowledge_base``; that call is
+    best-effort (a single knowledge base's detail lookup failing should not
+    discard the base from the export) so it degrades to basic info on error
+    rather than raising.
+    """
+    kb_id = kb.get('knowledgeBaseId', 'N/A')
+    kb_name = kb.get('name', 'N/A')
+    description = kb.get('description', 'N/A')
+    status = kb.get('status', 'N/A')
 
-        try:
-            paginator = bedrock_agent_client.get_paginator('list_knowledge_bases')
-            for page in paginator.paginate():
-                knowledge_bases = page.get('knowledgeBaseSummaries', [])
+    created_at = kb.get('createdAt', 'N/A')
+    if created_at != 'N/A':
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                for kb in knowledge_bases:
-                    kb_id = kb.get('knowledgeBaseId', 'N/A')
-                    kb_name = kb.get('name', 'N/A')
-                    description = kb.get('description', 'N/A')
-                    status = kb.get('status', 'N/A')
+    updated_at = kb.get('updatedAt', 'N/A')
+    if updated_at != 'N/A':
+        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                    created_at = kb.get('createdAt', 'N/A')
-                    if created_at != 'N/A':
-                        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+    kb_arn = 'N/A'
+    role_arn = 'N/A'
+    storage_type = 'N/A'
 
-                    updated_at = kb.get('updatedAt', 'N/A')
-                    if updated_at != 'N/A':
-                        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        kb_details = bedrock_agent_client.get_knowledge_base(knowledgeBaseId=kb_id)
+        kb_data = kb_details.get('knowledgeBase', {})
 
-                    # Get additional details
-                    try:
-                        kb_details = bedrock_agent_client.get_knowledge_base(
-                            knowledgeBaseId=kb_id
-                        )
-                        kb_data = kb_details.get('knowledgeBase', {})
+        kb_arn = kb_data.get('knowledgeBaseArn', 'N/A')
+        role_arn = kb_data.get('roleArn', 'N/A')
 
-                        kb_arn = kb_data.get('knowledgeBaseArn', 'N/A')
-                        role_arn = kb_data.get('roleArn', 'N/A')
+        storage_config = kb_data.get('storageConfiguration', {})
+        storage_type = storage_config.get('type', 'N/A')
+    except Exception as e:
+        utils.log_warning(f"Could not get details for knowledge base {kb_id}: {str(e)}")
 
-                        # Storage configuration
-                        storage_config = kb_data.get('storageConfiguration', {})
-                        storage_type = storage_config.get('type', 'N/A')
+    return {
+        'Region': region,
+        'Knowledge Base Name': kb_name,
+        'Knowledge Base ID': kb_id,
+        'ARN': kb_arn,
+        'Status': status,
+        'Description': description,
+        'Storage Type': storage_type,
+        'Role ARN': role_arn,
+        'Created': created_at,
+        'Updated': updated_at
+    }
 
-                        all_knowledge_bases.append({
-                            'Region': region,
-                            'Knowledge Base Name': kb_name,
-                            'Knowledge Base ID': kb_id,
-                            'ARN': kb_arn,
-                            'Status': status,
-                            'Description': description,
-                            'Storage Type': storage_type,
-                            'Role ARN': role_arn,
-                            'Created': created_at,
-                            'Updated': updated_at
-                        })
 
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for knowledge base {kb_id}: {str(e)}")
-                        # Add basic info
-                        all_knowledge_bases.append({
-                            'Region': region,
-                            'Knowledge Base Name': kb_name,
-                            'Knowledge Base ID': kb_id,
-                            'ARN': 'N/A',
-                            'Status': status,
-                            'Description': description,
-                            'Storage Type': 'N/A',
-                            'Role ARN': 'N/A',
-                            'Created': created_at,
-                            'Updated': updated_at
-                        })
+def _scan_knowledge_bases_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Bedrock knowledge bases from a single region.
 
-        except Exception as e:
-            utils.log_warning(f"Error listing knowledge bases in {region}: {str(e)}")
-            continue
+    Primary scope collector — raises on genuine API error from the
+    ``list_knowledge_bases`` listing call so the caller can record the region
+    as failed rather than empty. Per-knowledge-base detail enrichment
+    (``get_knowledge_base``) degrades gracefully inside ``_build_kb_row`` and
+    does not fail the region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
+    utils.log_info(f"Collecting knowledge bases in {region}...")
+    bedrock_agent_client = utils.get_boto3_client('bedrock-agent', region_name=region)
+
+    region_knowledge_bases = []
+    paginator = bedrock_agent_client.get_paginator('list_knowledge_bases')
+    for page in paginator.paginate():
+        knowledge_bases = page.get('knowledgeBaseSummaries', [])
+        for kb in knowledge_bases:
+            try:
+                region_knowledge_bases.append(_build_kb_row(kb, region, bedrock_agent_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed knowledge base in {region}: "
+                    f"{kb.get('knowledgeBaseId', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_knowledge_bases)} knowledge bases in {region}")
+    return region_knowledge_bases
+
+
+def collect_knowledge_bases(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock knowledge base information across regions, surfacing
+    failures via ``collect_failures=True``.
+
+    Returns:
+        tuple: ``(knowledge_bases, failed_regions)``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_knowledge_bases_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_knowledge_bases = [kb for result in region_results for kb in result]
     utils.log_info(f"Collected {len(all_knowledge_bases)} knowledge bases")
-    return all_knowledge_bases
+    return all_knowledge_bases, failed_regions
 
 
-@utils.aws_error_handler("Collecting Bedrock agents", default_return=[])
-def collect_agents(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Bedrock agents for task automation."""
-    all_agents = []
+def _build_agent_row(agent: dict[str, Any], region: str, bedrock_agent_client) -> dict[str, Any]:
+    """
+    Build the export row for a single Bedrock agent.
 
-    for region in regions:
-        utils.log_info(f"Collecting agents in {region}...")
-        bedrock_agent_client = utils.get_boto3_client('bedrock-agent', region_name=region)
+    Fetches enrichment details via ``get_agent``; that call is best-effort (a
+    single agent's detail lookup failing should not discard the agent from
+    the export) so it degrades to basic info on error rather than raising.
+    """
+    agent_id = agent.get('agentId', 'N/A')
+    agent_name = agent.get('agentName', 'N/A')
+    agent_status = agent.get('agentStatus', 'N/A')
+    description = agent.get('description', 'N/A')
+    latest_agent_version = agent.get('latestAgentVersion', 'N/A')
 
-        try:
-            paginator = bedrock_agent_client.get_paginator('list_agents')
-            for page in paginator.paginate():
-                agents = page.get('agentSummaries', [])
+    created_at = agent.get('createdAt', 'N/A')
+    if created_at != 'N/A':
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                for agent in agents:
-                    agent_id = agent.get('agentId', 'N/A')
-                    agent_name = agent.get('agentName', 'N/A')
-                    agent_status = agent.get('agentStatus', 'N/A')
-                    description = agent.get('description', 'N/A')
-                    latest_agent_version = agent.get('latestAgentVersion', 'N/A')
+    updated_at = agent.get('updatedAt', 'N/A')
+    if updated_at != 'N/A':
+        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                    created_at = agent.get('createdAt', 'N/A')
-                    if created_at != 'N/A':
-                        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+    agent_arn = 'N/A'
+    agent_resource_role_arn = 'N/A'
+    foundation_model = 'N/A'
+    idle_session_ttl = 'N/A'
 
-                    updated_at = agent.get('updatedAt', 'N/A')
-                    if updated_at != 'N/A':
-                        updated_at = updated_at.strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        agent_details = bedrock_agent_client.get_agent(agentId=agent_id)
+        agent_data = agent_details.get('agent', {})
 
-                    # Get additional details
-                    try:
-                        agent_details = bedrock_agent_client.get_agent(agentId=agent_id)
-                        agent_data = agent_details.get('agent', {})
+        agent_arn = agent_data.get('agentArn', 'N/A')
+        agent_resource_role_arn = agent_data.get('agentResourceRoleArn', 'N/A')
+        foundation_model = agent_data.get('foundationModel', 'N/A')
+        idle_session_ttl = agent_data.get('idleSessionTTLInSeconds', 'N/A')
+    except Exception as e:
+        utils.log_warning(f"Could not get details for agent {agent_id}: {str(e)}")
 
-                        agent_arn = agent_data.get('agentArn', 'N/A')
-                        agent_resource_role_arn = agent_data.get('agentResourceRoleArn', 'N/A')
-                        foundation_model = agent_data.get('foundationModel', 'N/A')
-                        idle_session_ttl = agent_data.get('idleSessionTTLInSeconds', 'N/A')
+    return {
+        'Region': region,
+        'Agent Name': agent_name,
+        'Agent ID': agent_id,
+        'ARN': agent_arn,
+        'Status': agent_status,
+        'Latest Version': latest_agent_version,
+        'Foundation Model': foundation_model,
+        'Description': description,
+        'Role ARN': agent_resource_role_arn,
+        'Idle Session TTL (seconds)': idle_session_ttl,
+        'Created': created_at,
+        'Updated': updated_at
+    }
 
-                        all_agents.append({
-                            'Region': region,
-                            'Agent Name': agent_name,
-                            'Agent ID': agent_id,
-                            'ARN': agent_arn,
-                            'Status': agent_status,
-                            'Latest Version': latest_agent_version,
-                            'Foundation Model': foundation_model,
-                            'Description': description,
-                            'Role ARN': agent_resource_role_arn,
-                            'Idle Session TTL (seconds)': idle_session_ttl,
-                            'Created': created_at,
-                            'Updated': updated_at
-                        })
 
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for agent {agent_id}: {str(e)}")
-                        # Add basic info
-                        all_agents.append({
-                            'Region': region,
-                            'Agent Name': agent_name,
-                            'Agent ID': agent_id,
-                            'ARN': 'N/A',
-                            'Status': agent_status,
-                            'Latest Version': latest_agent_version,
-                            'Foundation Model': 'N/A',
-                            'Description': description,
-                            'Role ARN': 'N/A',
-                            'Idle Session TTL (seconds)': 'N/A',
-                            'Created': created_at,
-                            'Updated': updated_at
-                        })
+def _scan_agents_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Bedrock agents from a single region.
 
-        except Exception as e:
-            utils.log_warning(f"Error listing agents in {region}: {str(e)}")
-            continue
+    Primary scope collector — raises on genuine API error from the
+    ``list_agents`` listing call so the caller can record the region as
+    failed rather than empty. Per-agent detail enrichment (``get_agent``)
+    degrades gracefully inside ``_build_agent_row`` and does not fail the
+    region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
+    utils.log_info(f"Collecting agents in {region}...")
+    bedrock_agent_client = utils.get_boto3_client('bedrock-agent', region_name=region)
+
+    region_agents = []
+    paginator = bedrock_agent_client.get_paginator('list_agents')
+    for page in paginator.paginate():
+        agents = page.get('agentSummaries', [])
+        for agent in agents:
+            try:
+                region_agents.append(_build_agent_row(agent, region, bedrock_agent_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed agent in {region}: "
+                    f"{agent.get('agentId', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_agents)} agents in {region}")
+    return region_agents
+
+
+def collect_agents(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Bedrock agent information across regions, surfacing failures via
+    ``collect_failures=True``.
+
+    Returns:
+        tuple: ``(agents, failed_regions)``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_agents_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_agents = [a for result in region_results for a in result]
     utils.log_info(f"Collected {len(all_agents)} agents")
-    return all_agents
+    return all_agents, failed_regions
 
 
 def generate_summary(foundation_models: list[dict[str, Any]],
@@ -529,14 +729,30 @@ def main():
     # Collect data
     print("\nCollecting Amazon Bedrock data...")
 
-    foundation_models = collect_foundation_models(regions)
-    custom_models = collect_custom_models(regions)
-    logging_configs = collect_model_invocation_logging(regions)
-    guardrails = collect_guardrails(regions)
-    knowledge_bases = collect_knowledge_bases(regions)
-    agents = collect_agents(regions)
+    # Each scope collector surfaces its own (region, error) failures; region
+    # failures must propagate as failed scopes, never collapse into "empty"
+    # (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    # The guardrails op-availability probe (missing operation) is a graceful
+    # skip and never contributes to its failed_regions list.
+    foundation_models, failed_fm = collect_foundation_models(regions)
+    custom_models, failed_cm = collect_custom_models(regions)
+    logging_configs, failed_log = collect_model_invocation_logging(regions)
+    guardrails, failed_gr = collect_guardrails(regions)
+    knowledge_bases, failed_kb = collect_knowledge_bases(regions)
+    agents, failed_ag = collect_agents(regions)
     summary = generate_summary(foundation_models, custom_models, logging_configs,
                                 guardrails, knowledge_bases, agents)
+
+    # Merge every scope's failed regions into one combined list, tagged with
+    # the scope that failed, so a single marker + exit covers all of them.
+    failed_regions = (
+        [(f"foundation_models/{region}", err) for region, err in failed_fm]
+        + [(f"custom_models/{region}", err) for region, err in failed_cm]
+        + [(f"model_invocation_logging/{region}", err) for region, err in failed_log]
+        + [(f"guardrails/{region}", err) for region, err in failed_gr]
+        + [(f"knowledge_bases/{region}", err) for region, err in failed_kb]
+        + [(f"agents/{region}", err) for region, err in failed_ag]
+    )
 
     # Create DataFrames
     utils.log_info("Creating DataFrames...")
@@ -578,7 +794,9 @@ def main():
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius
+    # audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'bedrock', region_suffix)
@@ -586,11 +804,23 @@ def main():
         utils.log_info(f"Exporting to {filename}...")
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
-        # Log summary
-    else:
+        utils.log_success("Amazon Bedrock export completed successfully")
+    elif not failed_regions:
+        # Genuinely empty account: every scope/region succeeded and returned
+        # nothing.
         utils.log_warning("No Amazon Bedrock data found to export")
 
-    utils.log_success("Amazon Bedrock export completed successfully")
+    # If ANY scope failed collection in ANY region, make it loud: write a
+    # marker and exit non-zero, even if some data was exported. A partial
+    # export that looks complete is exactly the failure mode this guards
+    # against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'bedrock', failed_regions)
+        print(
+            "\nERROR: Bedrock export completed with failures — data is incomplete. "
+            "See the *-bedrock-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/datasync_export.py
+++ b/scripts/datasync_export.py
@@ -79,96 +79,165 @@ def determine_location_type(location_arn: str) -> str:
     # Type is not directly in ARN, need to use describe operations
     return "Unknown"
 
-@utils.aws_error_handler("Collecting DataSync tasks", default_return=[])
+def _build_task_row(item: str, region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single DataSync task.
+
+    ``item`` is the task ARN (from ``list_tasks``); this issues the
+    ``describe_task`` call and assembles the row. Extracted so the caller can
+    wrap each task in try/except: a task that fails to describe or process is
+    logged and skipped rather than discarding the whole region's results.
+    Every field is read with ``.get()`` and a safe default for the same
+    reason.
+
+    Args:
+        item: DataSync task ARN.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled task row.
+    """
+    task_arn = item
+    datasync = utils.get_boto3_client('datasync', region_name=region)
+
+    # Get detailed task information
+    task_details = datasync.describe_task(TaskArn=task_arn)
+
+    # Extract task name from tags
+    task_name = 'N/A'
+    for tag in task_details.get('Tags', []):
+        if tag.get('Key') == 'Name':
+            task_name = tag.get('Value', 'N/A')
+            break
+
+    # Parse schedule if present
+    schedule = task_details.get('Schedule', {}) or {}
+    schedule_expression = schedule.get('ScheduleExpression', 'None')
+
+    # Parse options
+    options = task_details.get('Options', {}) or {}
+
+    # Get filter rules
+    includes = task_details.get('Includes', [])
+    excludes = task_details.get('Excludes', [])
+    filter_summary = f"Includes: {len(includes)}, Excludes: {len(excludes)}"
+
+    return {
+        'Task Name': task_name,
+        'Task ARN': task_arn,
+        'Status': task_details.get('Status', 'N/A'),
+        'Source Location ARN': task_details.get('SourceLocationArn', 'N/A'),
+        'Destination Location ARN': task_details.get('DestinationLocationArn', 'N/A'),
+        'Schedule': schedule_expression,
+        'CloudWatch Log Group': task_details.get('CloudWatchLogGroupArn', 'N/A'),
+        'Current Status': task_details.get('CurrentTaskExecutionArn', 'N/A'),
+        'Creation Time': task_details.get('CreationTime', 'N/A'),
+        'Verify Mode': options.get('VerifyMode', 'N/A'),
+        'Overwrite Mode': options.get('OverwriteMode', 'N/A'),
+        'Atime': options.get('Atime', 'N/A'),
+        'Mtime': options.get('Mtime', 'N/A'),
+        'UID': options.get('Uid', 'N/A'),
+        'GID': options.get('Gid', 'N/A'),
+        'Preserve Deleted Files': options.get('PreserveDeletedFiles', 'N/A'),
+        'Filter Rules': filter_summary,
+        'Region': region
+    }
+
+
 def collect_datasync_tasks(region: str) -> list[dict[str, Any]]:
     """
     Collect all DataSync tasks in a region.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that the caller cannot distinguish from a genuinely empty
+    region, producing silent data loss (no file written). Region-level
+    failures are allowed to raise so ``scan_regions_concurrent`` can record
+    the region as FAILED rather than empty. Per-task errors are contained
+    internally (logged and skipped) via ``_build_task_row``.
 
     Args:
         region: AWS region name
 
     Returns:
         List of task dictionaries with detailed information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     datasync = utils.get_boto3_client('datasync', region_name=region)
     tasks_data = []
 
-    try:
-        # List all tasks with pagination
-        paginator = datasync.get_paginator('list_tasks')
+    # List all tasks with pagination
+    paginator = datasync.get_paginator('list_tasks')
 
-        # Count tasks first
-        task_arns = []
-        for page in paginator.paginate():
-            task_arns.extend([task['TaskArn'] for task in page.get('Tasks', [])])
+    task_arns = []
+    for page in paginator.paginate():
+        task_arns.extend([task.get('TaskArn') for task in page.get('Tasks', []) if task.get('TaskArn')])
 
-        total_tasks = len(task_arns)
-        if total_tasks == 0:
-            utils.log_info(f"No DataSync tasks found in {region}")
-            return tasks_data
+    total_tasks = len(task_arns)
+    if total_tasks == 0:
+        utils.log_info(f"No DataSync tasks found in {region}")
+        return tasks_data
 
-        utils.log_info(f"Found {total_tasks} DataSync tasks in {region}")
+    utils.log_info(f"Found {total_tasks} DataSync tasks in {region}")
 
-        # Process each task
-        for idx, task_arn in enumerate(task_arns, 1):
-            progress = (idx / total_tasks) * 100
-            utils.log_info(f"[{progress:.1f}%] Processing task {idx}/{total_tasks} in {region}")
+    # Process each task. One malformed/failed task must not sink the region,
+    # so each is built inside try/except; failures are logged and skipped.
+    skipped = 0
+    for idx, task_arn in enumerate(task_arns, 1):
+        progress = (idx / total_tasks) * 100
+        utils.log_info(f"[{progress:.1f}%] Processing task {idx}/{total_tasks} in {region}")
 
-            try:
-                # Get detailed task information
-                task_details = datasync.describe_task(TaskArn=task_arn)
+        try:
+            tasks_data.append(_build_task_row(task_arn, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_warning(f"Skipping task {task_arn} in {region} due to a processing error: {e}")
+            continue
 
-                # Extract task name from tags
-                task_name = 'N/A'
-                if 'Tags' in task_details:
-                    for tag in task_details['Tags']:
-                        if tag['Key'] == 'Name':
-                            task_name = tag['Value']
-                            break
-
-                # Parse schedule if present
-                schedule = task_details.get('Schedule', {})
-                schedule_expression = schedule.get('ScheduleExpression', 'None')
-
-                # Parse options
-                options = task_details.get('Options', {})
-
-                # Get filter rules
-                includes = task_details.get('Includes', [])
-                excludes = task_details.get('Excludes', [])
-                filter_summary = f"Includes: {len(includes)}, Excludes: {len(excludes)}"
-
-                task_data = {
-                    'Task Name': task_name,
-                    'Task ARN': task_arn,
-                    'Status': task_details.get('Status', 'N/A'),
-                    'Source Location ARN': task_details.get('SourceLocationArn', 'N/A'),
-                    'Destination Location ARN': task_details.get('DestinationLocationArn', 'N/A'),
-                    'Schedule': schedule_expression,
-                    'CloudWatch Log Group': task_details.get('CloudWatchLogGroupArn', 'N/A'),
-                    'Current Status': task_details.get('CurrentTaskExecutionArn', 'N/A'),
-                    'Creation Time': task_details.get('CreationTime', 'N/A'),
-                    'Verify Mode': options.get('VerifyMode', 'N/A'),
-                    'Overwrite Mode': options.get('OverwriteMode', 'N/A'),
-                    'Atime': options.get('Atime', 'N/A'),
-                    'Mtime': options.get('Mtime', 'N/A'),
-                    'UID': options.get('Uid', 'N/A'),
-                    'GID': options.get('Gid', 'N/A'),
-                    'Preserve Deleted Files': options.get('PreserveDeletedFiles', 'N/A'),
-                    'Filter Rules': filter_summary,
-                    'Region': region
-                }
-
-                tasks_data.append(task_data)
-
-            except Exception as e:
-                utils.log_warning(f"Error processing task {task_arn} in {region}: {e}")
-                continue
-
-    except Exception as e:
-        utils.log_error(f"Error listing tasks in {region}", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_tasks} DataSync task(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining tasks were still collected."
+        )
 
     return tasks_data
+
+
+def collect_datasync_tasks_all_regions(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect DataSync tasks across regions, surfacing failures.
+
+    Uses ``collect_failures=True``: ``collect_datasync_tasks`` raises on a
+    region-level failure so that failure is recorded and surfaced by the
+    caller, never silently collapsed into "no tasks" (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: (tasks, failed_regions) where failed_regions is a list of
+            (region, error_message) tuples for regions whose scan raised.
+    """
+    print("\n=== COLLECTING DATASYNC TASKS ===")
+
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=collect_datasync_tasks,
+        show_progress=True,
+        collect_failures=True,
+    )
+
+    all_tasks = [task for result in region_results for task in result]
+
+    utils.log_success(f"Total DataSync tasks collected: {len(all_tasks)}")
+    return all_tasks, failed_regions
 
 @utils.aws_error_handler("Collecting DataSync locations", default_return=[])
 def collect_datasync_locations(region: str) -> list[dict[str, Any]]:
@@ -624,8 +693,13 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
 
     utils.log_info(f"Scanning {len(regions)} region(s): {', '.join(regions)}")
 
-    # Collect data from all regions
-    all_tasks = []
+    # Collect tasks (primary scope — region failures must propagate as
+    # failed_regions, never collapse into "empty"). See
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md.
+    all_tasks, failed_regions = collect_datasync_tasks_all_regions(regions)
+
+    # Collect locations, agents, and executions (enrichment — degrades
+    # gracefully; a region-level failure here does not fail the whole export).
     all_locations = []
     all_agents = []
     all_executions = []
@@ -633,10 +707,6 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     for region in regions:
         utils.log_info(f"Processing region: {region}")
         utils.log_section(f"DataSync data collection - {region}")
-
-        # Collect tasks
-        tasks = collect_datasync_tasks(region)
-        all_tasks.extend(tasks)
 
         # Collect locations
         locations = collect_datasync_locations(region)
@@ -647,15 +717,10 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
         all_agents.extend(agents)
 
         # Collect executions for tasks in this region
-        task_arns = [t['Task ARN'] for t in tasks]
-        if task_arns:
-            executions = collect_task_executions(region, task_arns)
+        region_task_arns = [t['Task ARN'] for t in all_tasks if t.get('Region') == region]
+        if region_task_arns:
+            executions = collect_task_executions(region, region_task_arns)
             all_executions.extend(executions)
-
-    # Check if we have any data
-    if not all_tasks and not all_locations and not all_agents:
-        utils.log_warning("No DataSync resources found in any region. Exiting...")
-        return
 
     utils.log_success("Collection complete:")
     utils.log_info(f"  Tasks: {len(all_tasks)}")
@@ -663,68 +728,87 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.log_info(f"  Agents: {len(all_agents)}")
     utils.log_info(f"  Executions (30 days): {len(all_executions)}")
 
-    # Create DataFrames
-    utils.log_info("Preparing data for export...")
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see .collab/audit/07.16.2026-...).
+    if all_tasks or all_locations or all_agents:
+        # Create DataFrames
+        utils.log_info("Preparing data for export...")
 
-    dataframes = {}
+        dataframes = {}
 
-    # Summary sheet
-    summary_data = create_summary_data(all_tasks, all_locations, all_agents, all_executions)
-    summary_df = pd.DataFrame(summary_data)
-    dataframes['Summary'] = utils.prepare_dataframe_for_export(summary_df)
+        # Summary sheet
+        summary_data = create_summary_data(all_tasks, all_locations, all_agents, all_executions)
+        summary_df = pd.DataFrame(summary_data)
+        dataframes['Summary'] = utils.prepare_dataframe_for_export(summary_df)
 
-    # Tasks sheet
-    if all_tasks:
-        tasks_df = pd.DataFrame(all_tasks)
-        dataframes['Tasks'] = utils.prepare_dataframe_for_export(tasks_df)
+        # Tasks sheet
+        if all_tasks:
+            tasks_df = pd.DataFrame(all_tasks)
+            dataframes['Tasks'] = utils.prepare_dataframe_for_export(tasks_df)
 
-    # Locations sheet
-    if all_locations:
-        locations_df = pd.DataFrame(all_locations)
-        dataframes['Locations'] = utils.prepare_dataframe_for_export(locations_df)
+        # Locations sheet
+        if all_locations:
+            locations_df = pd.DataFrame(all_locations)
+            dataframes['Locations'] = utils.prepare_dataframe_for_export(locations_df)
 
-    # Agents sheet
-    if all_agents:
-        agents_df = pd.DataFrame(all_agents)
-        dataframes['Agents'] = utils.prepare_dataframe_for_export(agents_df)
+        # Agents sheet
+        if all_agents:
+            agents_df = pd.DataFrame(all_agents)
+            dataframes['Agents'] = utils.prepare_dataframe_for_export(agents_df)
 
-    # Recent Executions sheet
-    if all_executions:
-        executions_df = pd.DataFrame(all_executions)
-        dataframes['Recent Executions'] = utils.prepare_dataframe_for_export(executions_df)
+        # Recent Executions sheet
+        if all_executions:
+            executions_df = pd.DataFrame(all_executions)
+            dataframes['Recent Executions'] = utils.prepare_dataframe_for_export(executions_df)
 
-    # Active Tasks sheet (AVAILABLE status)
-    active_tasks = [t for t in all_tasks if t.get('Status') == 'AVAILABLE']
-    if active_tasks:
-        active_tasks_df = pd.DataFrame(active_tasks)
-        dataframes['Active Tasks'] = utils.prepare_dataframe_for_export(active_tasks_df)
+        # Active Tasks sheet (AVAILABLE status)
+        active_tasks = [t for t in all_tasks if t.get('Status') == 'AVAILABLE']
+        if active_tasks:
+            active_tasks_df = pd.DataFrame(active_tasks)
+            dataframes['Active Tasks'] = utils.prepare_dataframe_for_export(active_tasks_df)
 
-    # Failed Executions sheet
-    failed_executions = [e for e in all_executions if e.get('Status') == 'ERROR']
-    if failed_executions:
-        failed_df = pd.DataFrame(failed_executions)
-        dataframes['Failed Executions'] = utils.prepare_dataframe_for_export(failed_df)
+        # Failed Executions sheet
+        failed_executions = [e for e in all_executions if e.get('Status') == 'ERROR']
+        if failed_executions:
+            failed_df = pd.DataFrame(failed_executions)
+            dataframes['Failed Executions'] = utils.prepare_dataframe_for_export(failed_df)
 
-    # Generate filename
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    filename = utils.create_export_filename(
-        account_name,
-        "datasync",
-        "all",
-        current_date
-    )
+        # Generate filename
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        filename = utils.create_export_filename(
+            account_name,
+            "datasync",
+            "all",
+            current_date
+        )
 
-    # Export to Excel
-    output_path = utils.save_multiple_dataframes_to_excel(dataframes, filename)
+        # Export to Excel
+        output_path = utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
-    if output_path:
-        utils.log_success("AWS DataSync data exported successfully!")
-        utils.log_success(f"File location: {output_path}")
-        utils.log_info(f"Export contains data from {len(regions)} region(s)")
-        utils.log_info(f"Total sheets: {len(dataframes)}")
-        print("\nScript execution completed.")
-    else:
-        utils.log_error("Error exporting data. Please check the logs.")
+        if output_path:
+            utils.log_success("AWS DataSync data exported successfully!")
+            utils.log_success(f"File location: {output_path}")
+            utils.log_info(f"Export contains data from {len(regions)} region(s)")
+            utils.log_info(f"Total sheets: {len(dataframes)}")
+            print("\nScript execution completed.")
+        else:
+            utils.log_error("Error exporting data. Please check the logs.")
+            sys.exit(1)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
+        utils.log_warning("No DataSync resources found in any region. Exiting...")
+        print("\nNo DataSync resources found in the selected region(s).")
+
+    # If ANY region failed the Tasks scope collection, make it loud: write a
+    # marker and exit non-zero, even if some data (from this scope or the
+    # enrichment sheets) was exported. A partial export that looks complete
+    # is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'datasync', failed_regions)
+        print(
+            "\nERROR: DataSync export completed with failures — data is incomplete. "
+            "See the *-datasync-FAILED-*.txt marker in the output directory."
+        )
         sys.exit(1)
 
 

--- a/scripts/dynamodb_export.py
+++ b/scripts/dynamodb_export.py
@@ -45,164 +45,182 @@ except ImportError:
 args = utils.parse_script_args("Export DynamoDB tables and capacity to Excel")
 
 
-def scan_dynamodb_tables_in_region(region: str) -> list[dict[str, Any]]:
+def _scan_dynamodb_tables_region(region: str) -> list[dict[str, Any]]:
     """
-    Scan DynamoDB tables in a single region.
+    Collect DynamoDB tables from a single region.
 
-    Args:
-        region: AWS region to scan
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no DynamoDB tables" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
-    Returns:
-        list: List of dictionaries with table information from this region
+    Individual malformed tables are skipped (logged) rather than aborting the
+    whole region.
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    dynamodb_client = utils.get_boto3_client('dynamodb', region_name=region)
+
+    # List tables
+    paginator = dynamodb_client.get_paginator('list_tables')
+    table_names = []
+    for page in paginator.paginate():
+        table_names.extend(page.get('TableNames', []))
+
     regional_tables = []
+    for table_name in table_names:
+        print(f"  Processing table: {table_name}")
 
-    try:
-        dynamodb_client = utils.get_boto3_client('dynamodb', region_name=region)
+        try:
+            table_response = dynamodb_client.describe_table(TableName=table_name)
+            table = table_response.get('Table', {})
+            regional_tables.append(_build_table_row(dynamodb_client, table, region))
+        except Exception as e:
+            # One malformed table is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed DynamoDB table in {region}: {table_name}",
+                e,
+            )
+            continue
 
-        # List tables
-        paginator = dynamodb_client.get_paginator('list_tables')
-        for page in paginator.paginate():
-            table_names = page.get('TableNames', [])
-
-            for table_name in table_names:
-                print(f"  Processing table: {table_name}")
-
-                try:
-                    # Get table details
-                    table_response = dynamodb_client.describe_table(TableName=table_name)
-                    table = table_response.get('Table', {})
-
-                    # Basic info
-                    table_arn = table.get('TableArn', 'N/A')
-                    table_status = table.get('TableStatus', 'UNKNOWN')
-                    creation_date = table.get('CreationDateTime', '')
-                    if creation_date:
-                        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
-
-                    # Item count and size
-                    item_count = table.get('ItemCount', 0)
-                    table_size_bytes = table.get('TableSizeBytes', 0)
-                    table_size_mb = round(table_size_bytes / (1024 * 1024), 2)
-
-                    # Billing mode
-                    billing_mode_summary = table.get('BillingModeSummary', {})
-                    billing_mode = billing_mode_summary.get('BillingMode', 'PROVISIONED')
-
-                    # Provisioned throughput
-                    provisioned_throughput = table.get('ProvisionedThroughput', {})
-                    read_capacity = provisioned_throughput.get('ReadCapacityUnits', 0)
-                    write_capacity = provisioned_throughput.get('WriteCapacityUnits', 0)
-
-                    # Key schema
-                    key_schema = table.get('KeySchema', [])
-                    partition_key = 'N/A'
-                    sort_key = 'N/A'
-                    for key in key_schema:
-                        if key.get('KeyType') == 'HASH':
-                            partition_key = key.get('AttributeName', 'N/A')
-                        elif key.get('KeyType') == 'RANGE':
-                            sort_key = key.get('AttributeName', 'N/A')
-
-                    # Global Secondary Indexes
-                    gsi_list = table.get('GlobalSecondaryIndexes', [])
-                    gsi_count = len(gsi_list)
-
-                    # Local Secondary Indexes
-                    lsi_list = table.get('LocalSecondaryIndexes', [])
-                    lsi_count = len(lsi_list)
-
-                    # Stream specification
-                    stream_spec = table.get('StreamSpecification', {})
-                    stream_enabled = stream_spec.get('StreamEnabled', False)
-                    stream_view_type = stream_spec.get('StreamViewType', 'N/A') if stream_enabled else 'N/A'
-
-                    # SSE (encryption)
-                    sse_description = table.get('SSEDescription', {})
-                    sse_status = sse_description.get('Status', 'DISABLED')
-                    sse_type = sse_description.get('SSEType', 'N/A') if sse_status == 'ENABLED' else 'N/A'
-                    kms_key_arn = sse_description.get('KMSMasterKeyArn', 'N/A') if sse_type == 'KMS' else 'N/A'
-
-                    # Point-in-time recovery
-                    try:
-                        pitr_response = dynamodb_client.describe_continuous_backups(TableName=table_name)
-                        continuous_backups = pitr_response.get('ContinuousBackupsDescription', {})
-                        pitr_status = continuous_backups.get('PointInTimeRecoveryDescription', {}).get('PointInTimeRecoveryStatus', 'DISABLED')
-                    except Exception:
-                        pitr_status = 'UNKNOWN'
-
-                    # Table class
-                    table_class_summary = table.get('TableClassSummary', {})
-                    table_class = table_class_summary.get('TableClass', 'STANDARD')
-
-                    # Tags
-                    try:
-                        tags_response = dynamodb_client.list_tags_of_resource(ResourceArn=table_arn)
-                        tags = tags_response.get('Tags', [])
-                        tags_str = ', '.join([f"{t['Key']}={t['Value']}" for t in tags]) if tags else 'None'
-                    except Exception:
-                        tags_str = 'Error retrieving'
-
-                    regional_tables.append({
-                        'Region': region,
-                        'Table Name': table_name,
-                        'Status': table_status,
-                        'Billing Mode': billing_mode,
-                        'Read Capacity': read_capacity if billing_mode == 'PROVISIONED' else 'On-Demand',
-                        'Write Capacity': write_capacity if billing_mode == 'PROVISIONED' else 'On-Demand',
-                        'Item Count': item_count,
-                        'Table Size (MB)': table_size_mb,
-                        'Partition Key': partition_key,
-                        'Sort Key': sort_key if sort_key != 'N/A' else 'None',
-                        'GSI Count': gsi_count,
-                        'LSI Count': lsi_count,
-                        'Stream Enabled': stream_enabled,
-                        'Stream View Type': stream_view_type,
-                        'Encryption Status': sse_status,
-                        'Encryption Type': sse_type,
-                        'KMS Key ARN': kms_key_arn,
-                        'PITR Status': pitr_status,
-                        'Table Class': table_class,
-                        'Created Date': creation_date if creation_date else 'N/A',
-                        'Tags': tags_str,
-                        'Table ARN': table_arn
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for table {table_name}: {e}")
-
-        utils.log_info(f"Found {len(regional_tables)} DynamoDB tables in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for DynamoDB tables", e)
-
+    print(f"  Found {len(regional_tables)} DynamoDB tables")
+    utils.log_info(f"Found {len(regional_tables)} DynamoDB tables in {region}")
     return regional_tables
 
 
-@utils.aws_error_handler("Collecting DynamoDB tables", default_return=[])
-def collect_dynamodb_tables(regions: list[str]) -> list[dict[str, Any]]:
-    """
-    Collect DynamoDB table information from AWS regions using concurrent scanning.
+def _build_table_row(client, table: dict, region: str) -> dict[str, Any]:
+    """Build a single DynamoDB table export row from a describe_table response."""
+    table_name = table.get('TableName', 'N/A')
 
-    Args:
-        regions: List of AWS regions to scan
+    # Basic info
+    table_arn = table.get('TableArn', 'N/A')
+    table_status = table.get('TableStatus', 'UNKNOWN')
+    creation_date = table.get('CreationDateTime', '')
+    if creation_date:
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+
+    # Item count and size
+    item_count = table.get('ItemCount', 0)
+    table_size_bytes = table.get('TableSizeBytes', 0)
+    table_size_mb = round(table_size_bytes / (1024 * 1024), 2)
+
+    # Billing mode
+    billing_mode_summary = table.get('BillingModeSummary', {})
+    billing_mode = billing_mode_summary.get('BillingMode', 'PROVISIONED')
+
+    # Provisioned throughput
+    provisioned_throughput = table.get('ProvisionedThroughput', {})
+    read_capacity = provisioned_throughput.get('ReadCapacityUnits', 0)
+    write_capacity = provisioned_throughput.get('WriteCapacityUnits', 0)
+
+    # Key schema
+    key_schema = table.get('KeySchema', [])
+    partition_key = 'N/A'
+    sort_key = 'N/A'
+    for key in key_schema:
+        if key.get('KeyType') == 'HASH':
+            partition_key = key.get('AttributeName', 'N/A')
+        elif key.get('KeyType') == 'RANGE':
+            sort_key = key.get('AttributeName', 'N/A')
+
+    # Global Secondary Indexes
+    gsi_list = table.get('GlobalSecondaryIndexes', [])
+    gsi_count = len(gsi_list)
+
+    # Local Secondary Indexes
+    lsi_list = table.get('LocalSecondaryIndexes', [])
+    lsi_count = len(lsi_list)
+
+    # Stream specification
+    stream_spec = table.get('StreamSpecification', {})
+    stream_enabled = stream_spec.get('StreamEnabled', False)
+    stream_view_type = stream_spec.get('StreamViewType', 'N/A') if stream_enabled else 'N/A'
+
+    # SSE (encryption)
+    sse_description = table.get('SSEDescription', {})
+    sse_status = sse_description.get('Status', 'DISABLED')
+    sse_type = sse_description.get('SSEType', 'N/A') if sse_status == 'ENABLED' else 'N/A'
+    kms_key_arn = sse_description.get('KMSMasterKeyArn', 'N/A') if sse_type == 'KMS' else 'N/A'
+
+    # Point-in-time recovery (best-effort enrichment; a failure here should not
+    # discard the whole table row)
+    try:
+        pitr_response = client.describe_continuous_backups(TableName=table_name)
+        continuous_backups = pitr_response.get('ContinuousBackupsDescription', {})
+        pitr_status = continuous_backups.get('PointInTimeRecoveryDescription', {}).get('PointInTimeRecoveryStatus', 'DISABLED')
+    except Exception:
+        pitr_status = 'UNKNOWN'
+
+    # Table class
+    table_class_summary = table.get('TableClassSummary', {})
+    table_class = table_class_summary.get('TableClass', 'STANDARD')
+
+    # Tags (best-effort enrichment; a failure here should not discard the
+    # whole table row)
+    try:
+        tags_response = client.list_tags_of_resource(ResourceArn=table_arn)
+        tags = tags_response.get('Tags', [])
+        tags_str = ', '.join([f"{t.get('Key', '')}={t.get('Value', '')}" for t in tags]) if tags else 'None'
+    except Exception:
+        tags_str = 'Error retrieving'
+
+    return {
+        'Region': region,
+        'Table Name': table_name,
+        'Status': table_status,
+        'Billing Mode': billing_mode,
+        'Read Capacity': read_capacity if billing_mode == 'PROVISIONED' else 'On-Demand',
+        'Write Capacity': write_capacity if billing_mode == 'PROVISIONED' else 'On-Demand',
+        'Item Count': item_count,
+        'Table Size (MB)': table_size_mb,
+        'Partition Key': partition_key,
+        'Sort Key': sort_key if sort_key != 'N/A' else 'None',
+        'GSI Count': gsi_count,
+        'LSI Count': lsi_count,
+        'Stream Enabled': stream_enabled,
+        'Stream View Type': stream_view_type,
+        'Encryption Status': sse_status,
+        'Encryption Type': sse_type,
+        'KMS Key ARN': kms_key_arn,
+        'PITR Status': pitr_status,
+        'Table Class': table_class,
+        'Created Date': creation_date if creation_date else 'N/A',
+        'Tags': tags_str,
+        'Table ARN': table_arn
+    }
+
+
+def collect_dynamodb_tables(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect DynamoDB table information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with table information
+        tuple: ``(tables, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING DYNAMODB TABLES ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_tables = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=scan_dynamodb_tables_in_region,
-    ):
-        all_tables.extend(region_data)
+        scan_function=_scan_dynamodb_tables_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_tables = [table for result in region_results for table in result]
 
     utils.log_success(f"Total DynamoDB tables collected: {len(all_tables)}")
-    return all_tables
+    return all_tables, failed_regions
 
 
 def scan_global_secondary_indexes_in_region(region: str) -> list[dict[str, Any]]:
@@ -431,8 +449,9 @@ def export_dynamodb_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect tables
-    tables = collect_dynamodb_tables(regions)
+    # STEP 1: Collect tables (primary scope — region failures must propagate as
+    # failed_regions, never collapse into "empty").
+    tables, failed_regions = collect_dynamodb_tables(regions)
     if tables:
         data_frames['DynamoDB Tables'] = pd.DataFrame(tables)
 
@@ -486,43 +505,55 @@ def export_dynamodb_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'dynamodb',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("DynamoDB data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No DynamoDB data was collected. Nothing to export.")
         print("\nNo DynamoDB resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'dynamodb',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("DynamoDB data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary table scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'dynamodb', failed_regions)
+        print(
+            "\nERROR: DynamoDB export completed with failures — data is incomplete. "
+            "See the *-dynamodb-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/efs_export.py
+++ b/scripts/efs_export.py
@@ -87,133 +87,148 @@ def calculate_efs_monthly_cost(
     return round(standard_gb * standard_rate + ia_gb * ia_rate, 4)
 
 
-def scan_efs_file_systems_in_region(region: str) -> list[dict[str, Any]]:
-    """
-    Scan EFS file systems in a single region.
+def _build_filesystem_row(fs: dict, region: str, pricing: dict[str, float]) -> dict[str, Any]:
+    """Build a single EFS file system export row from a describe response."""
+    file_system_id = fs.get('FileSystemId', '')
+    print(f"  Processing file system: {file_system_id}")
 
-    Args:
-        region: AWS region to scan
+    # Basic information
+    name = fs.get('Name', 'N/A')
+    creation_token = fs.get('CreationToken', '')
+    creation_time = fs.get('CreationTime', '')
+    if creation_time:
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
 
-    Returns:
-        list: List of dictionaries with file system information from this region
+    life_cycle_state = fs.get('LifeCycleState', '')
+    number_of_mount_targets = fs.get('NumberOfMountTargets', 0)
+
+    # Size
+    size_in_bytes = fs.get('SizeInBytes', {})
+    value_bytes = size_in_bytes.get('Value', 0)
+    value_gb = round(value_bytes / (1024**3), 2) if value_bytes else 0
+    value_in_ia = size_in_bytes.get('ValueInIA', 0)
+    value_in_standard = size_in_bytes.get('ValueInStandard', 0)
+
+    # Performance mode
+    performance_mode = fs.get('PerformanceMode', 'N/A')
+
+    # Encrypted
+    encrypted = fs.get('Encrypted', False)
+    kms_key_id = fs.get('KmsKeyId', 'N/A')
+
+    # Throughput mode
+    throughput_mode = fs.get('ThroughputMode', 'N/A')
+    provisioned_throughput = fs.get('ProvisionedThroughputInMibps', 'N/A')
+
+    # Availability zone (for One Zone storage)
+    availability_zone_name = fs.get('AvailabilityZoneName', 'Regional')
+
+    # File system ARN
+    file_system_arn = fs.get('FileSystemArn', '')
+
+    # Tags
+    tags = fs.get('Tags', [])
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags if 'Key' in tag and 'Value' in tag}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    monthly_cost = calculate_efs_monthly_cost(
+        value_in_standard, value_in_ia, availability_zone_name, pricing
+    )
+
+    return {
+        'Region': region,
+        'File System ID': file_system_id,
+        'Name': name,
+        'Life Cycle State': life_cycle_state,
+        'Size (GB)': value_gb,
+        'Size in IA (bytes)': value_in_ia,
+        'Size in Standard (bytes)': value_in_standard,
+        'Performance Mode': performance_mode,
+        'Throughput Mode': throughput_mode,
+        'Provisioned Throughput (MiB/s)': provisioned_throughput,
+        'Encrypted': encrypted,
+        'KMS Key ID': kms_key_id,
+        'Availability Zone': availability_zone_name,
+        'Mount Target Count': number_of_mount_targets,
+        'Creation Time': creation_time,
+        'Creation Token': creation_token,
+        'Tags': tags_str,
+        'File System ARN': file_system_arn,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': 'Estimate (us-east-1 on-demand; storage only; excludes throughput)',
+    }
+
+
+def _scan_efs_region(region: str) -> list[dict[str, Any]]:
     """
-    regional_file_systems = []
+    Collect EFS file systems from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no EFS file systems"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed file systems are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     pricing = load_efs_pricing_data()
+    efs_client = utils.get_boto3_client('efs', region_name=region)
 
-    try:
-        efs_client = utils.get_boto3_client('efs', region_name=region)
+    # Get file systems
+    paginator = efs_client.get_paginator('describe_file_systems')
+    regional_file_systems = []
+    fs_count = 0
 
-        # Get file systems
-        paginator = efs_client.get_paginator('describe_file_systems')
-        fs_count = 0
+    for page in paginator.paginate():
+        file_systems = page.get('FileSystems', [])
+        fs_count += len(file_systems)
 
-        for page in paginator.paginate():
-            file_systems = page.get('FileSystems', [])
-            fs_count += len(file_systems)
-
-            for fs in file_systems:
-                file_system_id = fs.get('FileSystemId', '')
-                print(f"  Processing file system: {file_system_id}")
-
-                # Basic information
-                name = fs.get('Name', 'N/A')
-                creation_token = fs.get('CreationToken', '')
-                creation_time = fs.get('CreationTime', '')
-                if creation_time:
-                    creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
-
-                life_cycle_state = fs.get('LifeCycleState', '')
-                number_of_mount_targets = fs.get('NumberOfMountTargets', 0)
-
-                # Size
-                size_in_bytes = fs.get('SizeInBytes', {})
-                value_bytes = size_in_bytes.get('Value', 0)
-                value_gb = round(value_bytes / (1024**3), 2) if value_bytes else 0
-                value_in_ia = size_in_bytes.get('ValueInIA', 0)
-                value_in_standard = size_in_bytes.get('ValueInStandard', 0)
-
-                # Performance mode
-                performance_mode = fs.get('PerformanceMode', 'N/A')
-
-                # Encrypted
-                encrypted = fs.get('Encrypted', False)
-                kms_key_id = fs.get('KmsKeyId', 'N/A')
-
-                # Throughput mode
-                throughput_mode = fs.get('ThroughputMode', 'N/A')
-                provisioned_throughput = fs.get('ProvisionedThroughputInMibps', 'N/A')
-
-                # Availability zone (for One Zone storage)
-                availability_zone_name = fs.get('AvailabilityZoneName', 'Regional')
-
-                # File system ARN
-                file_system_arn = fs.get('FileSystemArn', '')
-
-                # Tags
-                tags = fs.get('Tags', [])
-                tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
-                tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-                monthly_cost = calculate_efs_monthly_cost(
-                    value_in_standard, value_in_ia, availability_zone_name, pricing
+        for fs in file_systems:
+            try:
+                regional_file_systems.append(_build_filesystem_row(fs, region, pricing))
+            except Exception as e:
+                # One malformed file system is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed EFS file system in {region}: "
+                    f"{fs.get('FileSystemId', '<unknown>')}",
+                    e,
                 )
+                continue
 
-                regional_file_systems.append({
-                    'Region': region,
-                    'File System ID': file_system_id,
-                    'Name': name,
-                    'Life Cycle State': life_cycle_state,
-                    'Size (GB)': value_gb,
-                    'Size in IA (bytes)': value_in_ia,
-                    'Size in Standard (bytes)': value_in_standard,
-                    'Performance Mode': performance_mode,
-                    'Throughput Mode': throughput_mode,
-                    'Provisioned Throughput (MiB/s)': provisioned_throughput,
-                    'Encrypted': encrypted,
-                    'KMS Key ID': kms_key_id,
-                    'Availability Zone': availability_zone_name,
-                    'Mount Target Count': number_of_mount_targets,
-                    'Creation Time': creation_time,
-                    'Creation Token': creation_token,
-                    'Tags': tags_str,
-                    'File System ARN': file_system_arn,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': 'Estimate (us-east-1 on-demand; storage only; excludes throughput)',
-                })
-
-        utils.log_info(f"Found {fs_count} EFS file systems in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for EFS file systems", e)
-
+    utils.log_info(f"Found {fs_count} EFS file systems in {region}")
     return regional_file_systems
 
 
-@utils.aws_error_handler("Collecting EFS file systems", default_return=[])
-def collect_efs_file_systems(regions: list[str]) -> list[dict[str, Any]]:
+def collect_efs_file_systems(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect EFS file system information from AWS regions using concurrent scanning.
+    Collect EFS file system information across regions, surfacing failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with file system information
+        tuple: ``(file_systems, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING EFS FILE SYSTEMS ===")
-    utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_file_systems = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=scan_efs_file_systems_in_region,
-        show_progress=True
-    ):
-        all_file_systems.extend(region_data)
+        scan_function=_scan_efs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_file_systems = [fs for result in region_results for fs in result]
 
     utils.log_success(f"Total EFS file systems collected: {len(all_file_systems)}")
-    return all_file_systems
+    return all_file_systems, failed_regions
 
 
 def scan_mount_targets_in_region(region: str) -> list[dict[str, Any]]:
@@ -411,58 +426,73 @@ def export_efs_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect file systems
-    file_systems = collect_efs_file_systems(regions)
+    # STEP 1: Collect file systems (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    file_systems, failed_regions = collect_efs_file_systems(regions)
     if file_systems:
         data_frames['File Systems'] = pd.DataFrame(file_systems)
 
-    # STEP 2: Collect mount targets
+    # STEP 2: Collect mount targets (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     mount_targets = collect_mount_targets(regions)
     if mount_targets:
         data_frames['Mount Targets'] = pd.DataFrame(mount_targets)
 
-    # STEP 3: Collect access points
+    # STEP 3: Collect access points (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     access_points = collect_access_points(regions)
     if access_points:
         data_frames['Access Points'] = pd.DataFrame(access_points)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'efs',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("EFS data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No EFS data was collected. Nothing to export.")
         print("\nNo EFS file systems found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'efs',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("EFS data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the File Systems scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'efs', failed_regions)
+        print(
+            "\nERROR: EFS export completed with failures — data is incomplete. "
+            "See the *-efs-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/elasticache_export.py
+++ b/scripts/elasticache_export.py
@@ -103,17 +103,115 @@ def calculate_elasticache_monthly_cost(
         return 'N/A'
 
 
-def scan_replication_groups_in_region(region: str) -> list[dict[str, Any]]:
+def _build_replication_group_row(
+    rg: dict[str, Any],
+    region: str,
+    pricing_data: dict[str, Any],
+    cost_note: str,
+) -> dict[str, Any]:
     """
-    Scan ElastiCache replication groups (Redis) in a single region.
+    Build the export row for a single ElastiCache replication group.
 
-    Args:
-        region: AWS region to scan
-
-    Returns:
-        list: List of dictionaries with replication group information from this region
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed replication group entry is logged and skipped rather
+    than discarding the whole region's results. Every field is read with
+    ``.get()`` and a safe default for the same reason.
     """
-    regional_replication_groups = []
+    rg_id = rg.get('ReplicationGroupId', 'N/A')
+    print(f"  Processing replication group: {rg_id}")
+
+    # Basic info
+    description = rg.get('Description', 'N/A')
+    status = rg.get('Status', 'UNKNOWN')
+
+    # Cluster mode
+    cluster_enabled = rg.get('ClusterEnabled', False)
+
+    # Member clusters
+    member_clusters = rg.get('MemberClusters', [])
+    member_count = len(member_clusters)
+
+    # Node type
+    cache_node_type = rg.get('CacheNodeType', 'N/A')
+
+    # Engine
+    engine = 'redis'  # Replication groups are always Redis
+    engine_version = rg.get('EngineVersion', 'N/A')
+
+    # Automatic failover
+    automatic_failover = rg.get('AutomaticFailover', 'disabled')
+
+    # Multi-AZ
+    multi_az = rg.get('MultiAZ', 'disabled')
+
+    # Snapshot retention
+    snapshot_retention_limit = rg.get('SnapshotRetentionLimit', 0)
+    snapshot_window = rg.get('SnapshotWindow', 'N/A')
+
+    # Encryption
+    at_rest_encryption = rg.get('AtRestEncryptionEnabled', False)
+    transit_encryption = rg.get('TransitEncryptionEnabled', False)
+    auth_token_enabled = rg.get('AuthTokenEnabled', False)
+
+    # Parameter group
+    cache_param_group_name = rg.get('CacheParameterGroup', {}).get('CacheParameterGroupName', 'N/A')
+
+    # Subnet group
+    cache_subnet_group = rg.get('CacheSubnetGroupName', 'N/A')
+
+    # ARN
+    arn = rg.get('ARN', 'N/A')
+
+    # Cost estimation (member_count = total nodes across the replication group)
+    monthly_cost = calculate_elasticache_monthly_cost(
+        cache_node_type, member_count, engine, pricing_data
+    )
+
+    return {
+        'Region': region,
+        'Replication Group ID': rg_id,
+        'Description': description,
+        'Status': status,
+        'Engine': engine,
+        'Engine Version': engine_version,
+        'Node Type': cache_node_type,
+        'Cluster Mode': 'Enabled' if cluster_enabled else 'Disabled',
+        'Member Clusters': member_count,
+        'Automatic Failover': automatic_failover.upper(),
+        'Multi-AZ': multi_az.upper(),
+        'Snapshot Retention (days)': snapshot_retention_limit,
+        'Snapshot Window': snapshot_window,
+        'Encryption at Rest': 'Yes' if at_rest_encryption else 'No',
+        'Encryption in Transit': 'Yes' if transit_encryption else 'No',
+        'Auth Token Enabled': 'Yes' if auth_token_enabled else 'No',
+        'Subnet Group': cache_subnet_group,
+        'Parameter Group': cache_param_group_name,
+        'ARN': arn,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
+def _scan_replication_groups_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect ElastiCache replication groups (Redis) from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no replication groups"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed replication groups are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
     pricing_data = load_elasticache_pricing_data(region)
     partition = utils.detect_partition(region)
     cost_note = (
@@ -122,134 +220,162 @@ def scan_replication_groups_in_region(region: str) -> list[dict[str, Any]]:
         else "Estimate (us-east-1 pricing)"
     )
 
-    try:
-        elasticache_client = utils.get_boto3_client('elasticache', region_name=region)
+    elasticache_client = utils.get_boto3_client('elasticache', region_name=region)
+    paginator = elasticache_client.get_paginator('describe_replication_groups')
+    regional_replication_groups = []
+    rg_count = 0
 
-        paginator = elasticache_client.get_paginator('describe_replication_groups')
-        for page in paginator.paginate():
-            replication_groups = page.get('ReplicationGroups', [])
+    for page in paginator.paginate():
+        replication_groups = page.get('ReplicationGroups', [])
+        rg_count += len(replication_groups)
 
-            for rg in replication_groups:
-                rg_id = rg.get('ReplicationGroupId', 'N/A')
-
-                print(f"  Processing replication group: {rg_id}")
-
-                # Basic info
-                description = rg.get('Description', 'N/A')
-                status = rg.get('Status', 'UNKNOWN')
-
-                # Cluster mode
-                cluster_enabled = rg.get('ClusterEnabled', False)
-
-                # Member clusters
-                member_clusters = rg.get('MemberClusters', [])
-                member_count = len(member_clusters)
-
-                # Node type
-                cache_node_type = rg.get('CacheNodeType', 'N/A')
-
-                # Engine
-                engine = 'redis'  # Replication groups are always Redis
-                engine_version = rg.get('EngineVersion', 'N/A')
-
-                # Automatic failover
-                automatic_failover = rg.get('AutomaticFailover', 'disabled')
-
-                # Multi-AZ
-                multi_az = rg.get('MultiAZ', 'disabled')
-
-                # Snapshot retention
-                snapshot_retention_limit = rg.get('SnapshotRetentionLimit', 0)
-                snapshot_window = rg.get('SnapshotWindow', 'N/A')
-
-                # Encryption
-                at_rest_encryption = rg.get('AtRestEncryptionEnabled', False)
-                transit_encryption = rg.get('TransitEncryptionEnabled', False)
-                auth_token_enabled = rg.get('AuthTokenEnabled', False)
-
-                # Parameter group
-                cache_param_group_name = rg.get('CacheParameterGroup', {}).get('CacheParameterGroupName', 'N/A')
-
-                # Subnet group
-                cache_subnet_group = rg.get('CacheSubnetGroupName', 'N/A')
-
-                # ARN
-                arn = rg.get('ARN', 'N/A')
-
-                # Cost estimation (member_count = total nodes across the replication group)
-                monthly_cost = calculate_elasticache_monthly_cost(
-                    cache_node_type, member_count, engine, pricing_data
+        for rg in replication_groups:
+            try:
+                regional_replication_groups.append(
+                    _build_replication_group_row(rg, region, pricing_data, cost_note)
                 )
+            except Exception as e:
+                # One malformed replication group is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed ElastiCache replication group in {region}: "
+                    f"{rg.get('ReplicationGroupId', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                regional_replication_groups.append({
-                    'Region': region,
-                    'Replication Group ID': rg_id,
-                    'Description': description,
-                    'Status': status,
-                    'Engine': engine,
-                    'Engine Version': engine_version,
-                    'Node Type': cache_node_type,
-                    'Cluster Mode': 'Enabled' if cluster_enabled else 'Disabled',
-                    'Member Clusters': member_count,
-                    'Automatic Failover': automatic_failover.upper(),
-                    'Multi-AZ': multi_az.upper(),
-                    'Snapshot Retention (days)': snapshot_retention_limit,
-                    'Snapshot Window': snapshot_window,
-                    'Encryption at Rest': 'Yes' if at_rest_encryption else 'No',
-                    'Encryption in Transit': 'Yes' if transit_encryption else 'No',
-                    'Auth Token Enabled': 'Yes' if auth_token_enabled else 'No',
-                    'Subnet Group': cache_subnet_group,
-                    'Parameter Group': cache_param_group_name,
-                    'ARN': arn,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': cost_note,
-                })
-
-        utils.log_info(f"Found {len(regional_replication_groups)} ElastiCache replication groups in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting replication groups in region {region}", e)
-
+    print(f"  Found {rg_count} ElastiCache replication groups")
     return regional_replication_groups
 
 
-@utils.aws_error_handler("Collecting ElastiCache replication groups", default_return=[])
-def collect_replication_groups(regions: list[str]) -> list[dict[str, Any]]:
+def collect_replication_groups(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect ElastiCache replication group (Redis) information from AWS regions using concurrent scanning.
+    Collect ElastiCache replication group (Redis) information across regions,
+    surfacing failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with replication group information
+        tuple: ``(replication_groups, failed_regions)`` where
+        ``failed_regions`` is a list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING ELASTICACHE REPLICATION GROUPS (Redis) ===")
-    utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_replication_groups = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=scan_replication_groups_in_region,
-    ):
-        all_replication_groups.extend(region_data)
+        scan_function=_scan_replication_groups_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_replication_groups = [rg for result in region_results for rg in result]
 
     utils.log_success(f"Total ElastiCache replication groups collected: {len(all_replication_groups)}")
-    return all_replication_groups
+    return all_replication_groups, failed_regions
 
 
-def scan_cache_clusters_in_region(region: str) -> list[dict[str, Any]]:
+def _build_cache_cluster_row(
+    cluster: dict[str, Any],
+    region: str,
+    pricing_data: dict[str, Any],
+    cost_note: str,
+) -> dict[str, Any]:
     """
-    Scan ElastiCache cache clusters in a single region.
+    Build the export row for a single ElastiCache cache cluster.
 
-    Args:
-        region: AWS region to scan
-
-    Returns:
-        list: List of dictionaries with cache cluster information from this region
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed cluster entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with
+    ``.get()`` and a safe default for the same reason.
     """
-    regional_clusters = []
+    cluster_id = cluster.get('CacheClusterId', 'N/A')
+    print(f"  Processing cache cluster: {cluster_id}")
+
+    # Basic info
+    engine = cluster.get('Engine', 'N/A')
+    engine_version = cluster.get('EngineVersion', 'N/A')
+    status = cluster.get('CacheClusterStatus', 'UNKNOWN')
+
+    # Node info
+    cache_node_type = cluster.get('CacheNodeType', 'N/A')
+    num_cache_nodes = cluster.get('NumCacheNodes', 0)
+
+    # Preferred AZ
+    preferred_az = cluster.get('PreferredAvailabilityZone', 'N/A')
+
+    # Creation time
+    creation_time = cluster.get('CacheClusterCreateTime', '')
+    if creation_time:
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
+
+    # Parameter group
+    param_group = cluster.get('CacheParameterGroup', {}).get('CacheParameterGroupName', 'N/A')
+
+    # Subnet group
+    subnet_group = cluster.get('CacheSubnetGroupName', 'N/A')
+
+    # Security groups
+    security_groups = cluster.get('SecurityGroups', [])
+    sg_ids = ', '.join([sg.get('SecurityGroupId', '') for sg in security_groups]) if security_groups else 'None'
+
+    # Replication group membership
+    replication_group_id = cluster.get('ReplicationGroupId', 'None')
+
+    # Endpoint
+    endpoint = cluster.get('ConfigurationEndpoint') or (cluster.get('CacheNodes') or [{}])[0].get('Endpoint', {})
+    endpoint_address = endpoint.get('Address', 'N/A') if endpoint else 'N/A'
+    endpoint_port = endpoint.get('Port', 'N/A') if endpoint else 'N/A'
+
+    # ARN
+    arn = cluster.get('ARN', 'N/A')
+
+    # Cost estimation
+    monthly_cost = calculate_elasticache_monthly_cost(
+        cache_node_type, num_cache_nodes, engine, pricing_data
+    )
+
+    return {
+        'Region': region,
+        'Cluster ID': cluster_id,
+        'Engine': engine,
+        'Engine Version': engine_version,
+        'Status': status,
+        'Node Type': cache_node_type,
+        'Number of Nodes': num_cache_nodes,
+        'Availability Zone': preferred_az,
+        'Replication Group': replication_group_id,
+        'Parameter Group': param_group,
+        'Subnet Group': subnet_group,
+        'Security Groups': sg_ids,
+        'Endpoint Address': endpoint_address,
+        'Endpoint Port': endpoint_port,
+        'Created Date': creation_time if creation_time else 'N/A',
+        'ARN': arn,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
+def _scan_cache_clusters_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect ElastiCache cache clusters from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no cache clusters" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed clusters are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
     pricing_data = load_elasticache_pricing_data(region)
     partition = utils.detect_partition(region)
     cost_note = (
@@ -258,114 +384,58 @@ def scan_cache_clusters_in_region(region: str) -> list[dict[str, Any]]:
         else "Estimate (us-east-1 pricing)"
     )
 
-    try:
-        elasticache_client = utils.get_boto3_client('elasticache', region_name=region)
+    elasticache_client = utils.get_boto3_client('elasticache', region_name=region)
+    paginator = elasticache_client.get_paginator('describe_cache_clusters')
+    regional_clusters = []
+    cluster_count = 0
 
-        paginator = elasticache_client.get_paginator('describe_cache_clusters')
-        for page in paginator.paginate(ShowCacheNodeInfo=True):
-            cache_clusters = page.get('CacheClusters', [])
+    for page in paginator.paginate(ShowCacheNodeInfo=True):
+        cache_clusters = page.get('CacheClusters', [])
+        cluster_count += len(cache_clusters)
 
-            for cluster in cache_clusters:
-                cluster_id = cluster.get('CacheClusterId', 'N/A')
-
-                print(f"  Processing cache cluster: {cluster_id}")
-
-                # Basic info
-                engine = cluster.get('Engine', 'N/A')
-                engine_version = cluster.get('EngineVersion', 'N/A')
-                status = cluster.get('CacheClusterStatus', 'UNKNOWN')
-
-                # Node info
-                cache_node_type = cluster.get('CacheNodeType', 'N/A')
-                num_cache_nodes = cluster.get('NumCacheNodes', 0)
-
-                # Preferred AZ
-                preferred_az = cluster.get('PreferredAvailabilityZone', 'N/A')
-
-                # Creation time
-                creation_time = cluster.get('CacheClusterCreateTime', '')
-                if creation_time:
-                    creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
-
-                # Parameter group
-                param_group = cluster.get('CacheParameterGroup', {}).get('CacheParameterGroupName', 'N/A')
-
-                # Subnet group
-                subnet_group = cluster.get('CacheSubnetGroupName', 'N/A')
-
-                # Security groups
-                security_groups = cluster.get('SecurityGroups', [])
-                sg_ids = ', '.join([sg.get('SecurityGroupId', '') for sg in security_groups]) if security_groups else 'None'
-
-                # Replication group membership
-                replication_group_id = cluster.get('ReplicationGroupId', 'None')
-
-                # Endpoint
-                endpoint = cluster.get('ConfigurationEndpoint', cluster.get('CacheNodes', [{}])[0].get('Endpoint', {}))
-                endpoint_address = endpoint.get('Address', 'N/A') if endpoint else 'N/A'
-                endpoint_port = endpoint.get('Port', 'N/A') if endpoint else 'N/A'
-
-                # ARN
-                arn = cluster.get('ARN', 'N/A')
-
-                # Cost estimation
-                monthly_cost = calculate_elasticache_monthly_cost(
-                    cache_node_type, num_cache_nodes, engine, pricing_data
+        for cluster in cache_clusters:
+            try:
+                regional_clusters.append(
+                    _build_cache_cluster_row(cluster, region, pricing_data, cost_note)
                 )
+            except Exception as e:
+                # One malformed cluster is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed ElastiCache cache cluster in {region}: "
+                    f"{cluster.get('CacheClusterId', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                regional_clusters.append({
-                    'Region': region,
-                    'Cluster ID': cluster_id,
-                    'Engine': engine,
-                    'Engine Version': engine_version,
-                    'Status': status,
-                    'Node Type': cache_node_type,
-                    'Number of Nodes': num_cache_nodes,
-                    'Availability Zone': preferred_az,
-                    'Replication Group': replication_group_id,
-                    'Parameter Group': param_group,
-                    'Subnet Group': subnet_group,
-                    'Security Groups': sg_ids,
-                    'Endpoint Address': endpoint_address,
-                    'Endpoint Port': endpoint_port,
-                    'Created Date': creation_time if creation_time else 'N/A',
-                    'ARN': arn,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': cost_note,
-                })
-
-        utils.log_info(f"Found {len(regional_clusters)} ElastiCache cache clusters in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting cache clusters in region {region}", e)
-
+    print(f"  Found {cluster_count} ElastiCache cache clusters")
     return regional_clusters
 
 
-@utils.aws_error_handler("Collecting ElastiCache clusters", default_return=[])
-def collect_cache_clusters(regions: list[str]) -> list[dict[str, Any]]:
+def collect_cache_clusters(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect ElastiCache cache cluster information from AWS regions using concurrent scanning.
+    Collect ElastiCache cache cluster information across regions, surfacing
+    failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with cache cluster information
+        tuple: ``(cache_clusters, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING ELASTICACHE CACHE CLUSTERS ===")
-    utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_clusters = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=scan_cache_clusters_in_region,
-    ):
-        all_clusters.extend(region_data)
+        scan_function=_scan_cache_clusters_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_clusters = [cluster for result in region_results for cluster in result]
 
     utils.log_success(f"Total ElastiCache cache clusters collected: {len(all_clusters)}")
-    return all_clusters
+    return all_clusters, failed_regions
 
 
 def scan_cache_subnet_groups_in_region(region: str) -> list[dict[str, Any]]:
@@ -434,6 +504,10 @@ def collect_cache_subnet_groups(regions: list[str]) -> list[dict[str, Any]]:
     """
     Collect ElastiCache cache subnet group information from AWS regions using concurrent scanning.
 
+    Enrichment scope: a region-level failure here degrades gracefully (it is
+    not one of the primary ElastiCache scopes) and does not fail the whole
+    export.
+
     Args:
         regions: List of AWS regions to scan
 
@@ -472,17 +546,26 @@ def export_elasticache_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect replication groups (Redis)
-    replication_groups = collect_replication_groups(regions)
+    # STEP 1: Collect replication groups (Redis) — primary scope. Region
+    # failures must propagate as failed_regions, never collapse into "empty".
+    replication_groups, rg_failed_regions = collect_replication_groups(regions)
     if replication_groups:
         data_frames['Redis Replication Groups'] = pd.DataFrame(replication_groups)
 
-    # STEP 2: Collect cache clusters
-    cache_clusters = collect_cache_clusters(regions)
+    # STEP 2: Collect cache clusters — primary scope. Region failures must
+    # propagate as failed_regions, never collapse into "empty".
+    cache_clusters, cluster_failed_regions = collect_cache_clusters(regions)
     if cache_clusters:
         data_frames['Cache Clusters'] = pd.DataFrame(cache_clusters)
 
-    # STEP 3: Collect subnet groups
+    # Both replication groups and cache clusters are primary ElastiCache
+    # scopes; a failure in either means the export is incomplete, so their
+    # failed regions are merged into one combined list driving a single
+    # marker + exit below.
+    failed_regions = rg_failed_regions + cluster_failed_regions
+
+    # STEP 3: Collect subnet groups (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     subnet_groups = collect_cache_subnet_groups(regions)
     if subnet_groups:
         data_frames['Subnet Groups'] = pd.DataFrame(subnet_groups)
@@ -496,15 +579,15 @@ def export_elasticache_data(account_id: str, account_name: str):
         total_subnet_groups = len(subnet_groups)
 
         # Redis vs Memcached
-        redis_clusters = sum(1 for c in cache_clusters if c['Engine'] == 'redis')
-        memcached_clusters = sum(1 for c in cache_clusters if c['Engine'] == 'memcached')
+        redis_clusters = sum(1 for c in cache_clusters if c.get('Engine') == 'redis')
+        memcached_clusters = sum(1 for c in cache_clusters if c.get('Engine') == 'memcached')
 
         # Encryption
-        encrypted_at_rest = sum(1 for rg in replication_groups if rg['Encryption at Rest'] == 'Yes')
-        encrypted_in_transit = sum(1 for rg in replication_groups if rg['Encryption in Transit'] == 'Yes')
+        encrypted_at_rest = sum(1 for rg in replication_groups if rg.get('Encryption at Rest') == 'Yes')
+        encrypted_in_transit = sum(1 for rg in replication_groups if rg.get('Encryption in Transit') == 'Yes')
 
         # Cluster mode
-        cluster_mode_enabled = sum(1 for rg in replication_groups if rg['Cluster Mode'] == 'Enabled')
+        cluster_mode_enabled = sum(1 for rg in replication_groups if rg.get('Cluster Mode') == 'Enabled')
 
         summary_data.append({'Metric': 'Total Replication Groups', 'Value': total_rgs})
         summary_data.append({'Metric': 'Total Cache Clusters', 'Value': total_clusters})
@@ -517,43 +600,56 @@ def export_elasticache_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'elasticache',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("ElastiCache data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No ElastiCache data was collected. Nothing to export.")
         print("\nNo ElastiCache resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'elasticache',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("ElastiCache data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed either primary ElastiCache scope collection
+    # (replication groups or cache clusters), make it loud: write a marker
+    # and exit non-zero, even if some data was exported. A partial export
+    # that looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'elasticache', failed_regions)
+        print(
+            "\nERROR: ElastiCache export completed with failures — data is incomplete. "
+            "See the *-elasticache-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/fsx_export.py
+++ b/scripts/fsx_export.py
@@ -80,142 +80,188 @@ def calculate_fsx_monthly_cost(
     return round(float(storage_capacity_gb) * rate, 2)
 
 
+def _build_filesystem_row(fs: dict[str, Any], region: str, pricing: dict[str, float]) -> dict[str, Any]:
+    """
+    Build the export row for a single FSx file system.
+
+    Extracted so the per-item processing can be wrapped in try/except by the
+    caller: a malformed file system entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        fs: A single FileSystems entry from describe_file_systems.
+        region: AWS region name.
+        pricing: FSx per-GB-month storage rates.
+
+    Returns:
+        dict: The assembled file system row.
+    """
+    file_system_id = fs.get('FileSystemId', '')
+
+    # Basic information
+    file_system_type = fs.get('FileSystemType', '')
+    lifecycle = fs.get('Lifecycle', '')
+    storage_capacity = fs.get('StorageCapacity', 0)
+    storage_type = fs.get('StorageType', 'N/A')
+    vpc_id = fs.get('VpcId', 'N/A')
+
+    # Creation time
+    creation_time = fs.get('CreationTime', '')
+    if creation_time:
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
+
+    # DNS name
+    dns_name = fs.get('DNSName', 'N/A')
+
+    # KMS key
+    kms_key_id = fs.get('KmsKeyId', 'N/A')
+
+    # Resource ARN
+    resource_arn = fs.get('ResourceARN', '')
+
+    # Subnet IDs
+    subnet_ids = fs.get('SubnetIds', [])
+    subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
+
+    # Network interface IDs
+    network_interface_ids = fs.get('NetworkInterfaceIds', [])
+    eni_count = len(network_interface_ids)
+
+    # File system type-specific configuration
+    type_specific_config = 'N/A'
+    deployment_type = 'N/A'
+    throughput_capacity = 'N/A'
+
+    if file_system_type == 'WINDOWS':
+        windows_config = fs.get('WindowsConfiguration', {})
+        deployment_type = windows_config.get('DeploymentType', 'N/A')
+        throughput_capacity = windows_config.get('ThroughputCapacity', 'N/A')
+        active_directory_id = windows_config.get('ActiveDirectoryId', 'N/A')
+        type_specific_config = f"AD: {active_directory_id}, Throughput: {throughput_capacity} MB/s"
+
+    elif file_system_type == 'LUSTRE':
+        lustre_config = fs.get('LustreConfiguration', {})
+        deployment_type = lustre_config.get('DeploymentType', 'N/A')
+        per_unit_storage_throughput = lustre_config.get('PerUnitStorageThroughput', 'N/A')
+        data_repo_config = lustre_config.get('DataRepositoryConfiguration', {})
+        import_path = data_repo_config.get('ImportPath', 'N/A')
+        type_specific_config = f"S3: {import_path}, Throughput: {per_unit_storage_throughput} MB/s/TiB"
+
+    elif file_system_type == 'ONTAP':
+        ontap_config = fs.get('OntapConfiguration', {})
+        deployment_type = ontap_config.get('DeploymentType', 'N/A')
+        throughput_capacity = ontap_config.get('ThroughputCapacity', 'N/A')
+        endpoint_ip_address_range = ontap_config.get('EndpointIpAddressRange', 'N/A')
+        type_specific_config = f"Endpoint Range: {endpoint_ip_address_range}, Throughput: {throughput_capacity} MB/s"
+
+    elif file_system_type == 'OPENZFS':
+        openzfs_config = fs.get('OpenZFSConfiguration', {})
+        deployment_type = openzfs_config.get('DeploymentType', 'N/A')
+        throughput_capacity = openzfs_config.get('ThroughputCapacity', 'N/A')
+        type_specific_config = f"Throughput: {throughput_capacity} MB/s"
+
+    # Tags
+    tags = fs.get('Tags', [])
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags if 'Key' in tag and 'Value' in tag}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    monthly_cost = calculate_fsx_monthly_cost(
+        file_system_type, storage_type, storage_capacity, pricing
+    )
+
+    return {
+        'Region': region,
+        'File System ID': file_system_id,
+        'File System Type': file_system_type,
+        'Lifecycle': lifecycle,
+        'Storage Capacity (GB)': storage_capacity,
+        'Storage Type': storage_type,
+        'Deployment Type': deployment_type,
+        'Throughput Capacity': throughput_capacity,
+        'Type-Specific Config': type_specific_config,
+        'VPC ID': vpc_id,
+        'Subnet IDs': subnet_ids_str,
+        'Network Interface Count': eni_count,
+        'DNS Name': dns_name,
+        'KMS Key ID': kms_key_id,
+        'Creation Time': creation_time,
+        'Tags': tags_str,
+        'Resource ARN': resource_arn,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': 'Estimate (us-east-1 storage only; excludes throughput capacity charges)',
+    }
+
+
 def _scan_fsx_file_systems_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for FSx file systems."""
+    """
+    Scan a single region for FSx file systems.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no FSx file systems" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed file systems are skipped (logged) rather than
+    aborting the whole region.
+    """
     file_systems_data = []
 
     if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
         return file_systems_data
 
     pricing = _load_fsx_pricing()
 
-    try:
-        fsx_client = utils.get_boto3_client('fsx', region_name=region)
+    fsx_client = utils.get_boto3_client('fsx', region_name=region)
 
-        # Get FSx file systems
-        paginator = fsx_client.get_paginator('describe_file_systems')
+    # Get FSx file systems
+    paginator = fsx_client.get_paginator('describe_file_systems')
 
-        for page in paginator.paginate():
-            file_systems = page.get('FileSystems', [])
+    for page in paginator.paginate():
+        file_systems = page.get('FileSystems', [])
 
-            for fs in file_systems:
-                file_system_id = fs.get('FileSystemId', '')
-
-                # Basic information
-                file_system_type = fs.get('FileSystemType', '')
-                lifecycle = fs.get('Lifecycle', '')
-                storage_capacity = fs.get('StorageCapacity', 0)
-                storage_type = fs.get('StorageType', 'N/A')
-                vpc_id = fs.get('VpcId', 'N/A')
-
-                # Creation time
-                creation_time = fs.get('CreationTime', '')
-                if creation_time:
-                    creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
-
-                # DNS name
-                dns_name = fs.get('DNSName', 'N/A')
-
-                # KMS key
-                kms_key_id = fs.get('KmsKeyId', 'N/A')
-
-                # Resource ARN
-                resource_arn = fs.get('ResourceARN', '')
-
-                # Subnet IDs
-                subnet_ids = fs.get('SubnetIds', [])
-                subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
-
-                # Network interface IDs
-                network_interface_ids = fs.get('NetworkInterfaceIds', [])
-                eni_count = len(network_interface_ids)
-
-                # File system type-specific configuration
-                type_specific_config = 'N/A'
-                deployment_type = 'N/A'
-                throughput_capacity = 'N/A'
-
-                if file_system_type == 'WINDOWS':
-                    windows_config = fs.get('WindowsConfiguration', {})
-                    deployment_type = windows_config.get('DeploymentType', 'N/A')
-                    throughput_capacity = windows_config.get('ThroughputCapacity', 'N/A')
-                    active_directory_id = windows_config.get('ActiveDirectoryId', 'N/A')
-                    type_specific_config = f"AD: {active_directory_id}, Throughput: {throughput_capacity} MB/s"
-
-                elif file_system_type == 'LUSTRE':
-                    lustre_config = fs.get('LustreConfiguration', {})
-                    deployment_type = lustre_config.get('DeploymentType', 'N/A')
-                    per_unit_storage_throughput = lustre_config.get('PerUnitStorageThroughput', 'N/A')
-                    data_repo_config = lustre_config.get('DataRepositoryConfiguration', {})
-                    import_path = data_repo_config.get('ImportPath', 'N/A')
-                    type_specific_config = f"S3: {import_path}, Throughput: {per_unit_storage_throughput} MB/s/TiB"
-
-                elif file_system_type == 'ONTAP':
-                    ontap_config = fs.get('OntapConfiguration', {})
-                    deployment_type = ontap_config.get('DeploymentType', 'N/A')
-                    throughput_capacity = ontap_config.get('ThroughputCapacity', 'N/A')
-                    endpoint_ip_address_range = ontap_config.get('EndpointIpAddressRange', 'N/A')
-                    type_specific_config = f"Endpoint Range: {endpoint_ip_address_range}, Throughput: {throughput_capacity} MB/s"
-
-                elif file_system_type == 'OPENZFS':
-                    openzfs_config = fs.get('OpenZFSConfiguration', {})
-                    deployment_type = openzfs_config.get('DeploymentType', 'N/A')
-                    throughput_capacity = openzfs_config.get('ThroughputCapacity', 'N/A')
-                    type_specific_config = f"Throughput: {throughput_capacity} MB/s"
-
-                # Tags
-                tags = fs.get('Tags', [])
-                tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
-                tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-                monthly_cost = calculate_fsx_monthly_cost(
-                    file_system_type, storage_type, storage_capacity, pricing
+        for fs in file_systems:
+            try:
+                file_systems_data.append(_build_filesystem_row(fs, region, pricing))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed FSx file system in {region}: "
+                    f"{fs.get('FileSystemId', '<unknown>')}",
+                    e,
                 )
-
-                file_systems_data.append({
-                    'Region': region,
-                    'File System ID': file_system_id,
-                    'File System Type': file_system_type,
-                    'Lifecycle': lifecycle,
-                    'Storage Capacity (GB)': storage_capacity,
-                    'Storage Type': storage_type,
-                    'Deployment Type': deployment_type,
-                    'Throughput Capacity': throughput_capacity,
-                    'Type-Specific Config': type_specific_config,
-                    'VPC ID': vpc_id,
-                    'Subnet IDs': subnet_ids_str,
-                    'Network Interface Count': eni_count,
-                    'DNS Name': dns_name,
-                    'KMS Key ID': kms_key_id,
-                    'Creation Time': creation_time,
-                    'Tags': tags_str,
-                    'Resource ARN': resource_arn,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': 'Estimate (us-east-1 storage only; excludes throughput capacity charges)',
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting FSx file systems in {region}", e)
+                continue
 
     return file_systems_data
 
 
-@utils.aws_error_handler("Collecting FSx file systems", default_return=[])
-def collect_fsx_file_systems(regions: list[str]) -> list[dict[str, Any]]:
+def collect_fsx_file_systems(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect FSx file system information from AWS regions.
+    Collect FSx file system information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with FSx file system information
+        tuple: ``(file_systems, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING FSx FILE SYSTEMS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_fsx_file_systems_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_fsx_file_systems_region,
+        show_progress=True,
+        collect_failures=True,
+    )
     all_file_systems = [fs for result in results for fs in result]
     utils.log_success(f"Total FSx file systems collected: {len(all_file_systems)}")
-    return all_file_systems
+    return all_file_systems, failed_regions
 
 
 def _scan_fsx_backups_region(region: str) -> list[dict[str, Any]]:
@@ -313,53 +359,68 @@ def export_fsx_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect file systems
-    file_systems = collect_fsx_file_systems(regions)
+    # STEP 1: Collect file systems (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    file_systems, failed_regions = collect_fsx_file_systems(regions)
     if file_systems:
         data_frames['File Systems'] = pd.DataFrame(file_systems)
 
-    # STEP 2: Collect backups
+    # STEP 2: Collect backups (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     backups = collect_fsx_backups(regions)
     if backups:
         data_frames['Backups'] = pd.DataFrame(backups)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 3: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 4: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'fsx',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("FSx data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No FSx data was collected. Nothing to export.")
         print("\nNo FSx file systems found in the selected region(s).")
-        return
 
-    # STEP 3: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 4: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'fsx',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("FSx data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary file system scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was exported.
+    # A partial export that looks complete is exactly the failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'fsx', failed_regions)
+        print(
+            "\nERROR: FSx export completed with failures — data is incomplete. "
+            "See the *-fsx-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/s3_accesspoints_export.py
+++ b/scripts/s3_accesspoints_export.py
@@ -35,10 +35,81 @@ except ImportError:
 args = utils.parse_script_args("Export S3 access points to Excel")
 
 
-@utils.aws_error_handler("Collecting standard access points", default_return=[])
-def collect_standard_access_points(region: str, account_id: str) -> list[dict[str, Any]]:
+def _build_access_point_row(ap: dict, region: str, account_id: str, s3control) -> dict[str, Any]:
     """
-    Collect standard S3 Access Points for a specific region
+    Build the export row for a single Standard S3 Access Point, including its
+    detail calls (creation date, public access block, policy status).
+
+    Extracted so per-access-point processing can be wrapped in try/except by
+    the caller: a malformed/inaccessible access point is logged and skipped
+    rather than discarding the whole region's results.
+
+    Args:
+        ap: A single AccessPointList entry from list_access_points.
+        region: AWS region name.
+        account_id: AWS account ID.
+        s3control: An s3control client for ``region``.
+
+    Returns:
+        dict: The assembled access point row.
+    """
+    ap_name = ap.get('Name', 'N/A')
+
+    # Get detailed configuration for this access point
+    details = s3control.get_access_point(AccountId=account_id, Name=ap_name)
+
+    # Get block public access settings
+    try:
+        public_access_block = s3control.get_public_access_block(AccountId=account_id)
+        block_settings = public_access_block.get('PublicAccessBlockConfiguration', {})
+    except Exception:
+        # If GetPublicAccessBlock fails, use defaults
+        block_settings = {}
+
+    # Get access point policy status
+    try:
+        policy_status = s3control.get_access_point_policy_status(
+            AccountId=account_id, Name=ap_name
+        )
+        has_policy = policy_status.get('PolicyStatus', {}).get('IsPublic', False)
+    except Exception:
+        has_policy = False
+
+    # Extract VPC configuration
+    vpc_config = ap.get('VpcConfiguration', {}) or {}
+    vpc_id = vpc_config.get('VpcId', 'N/A')
+
+    return {
+        'AccessPointName': ap_name,
+        'AccessPointARN': ap.get('AccessPointArn', 'N/A'),
+        'Alias': ap.get('Alias', 'N/A'),
+        'BucketName': ap.get('Bucket', 'N/A'),
+        'NetworkOrigin': ap.get('NetworkOrigin', 'N/A'),
+        'VpcId': vpc_id,
+        'Region': region,
+        'CreationDate': details.get('CreationDate', 'N/A'),
+        'HasCustomPolicy': 'Yes' if has_policy else 'No',
+        'BlockPublicAcls': block_settings.get('BlockPublicAcls', True),
+        'IgnorePublicAcls': block_settings.get('IgnorePublicAcls', True),
+        'BlockPublicPolicy': block_settings.get('BlockPublicPolicy', True),
+        'RestrictPublicBuckets': block_settings.get('RestrictPublicBuckets', True),
+        'BucketAccountId': ap.get('BucketAccountId', account_id)
+    }
+
+
+def _scan_standard_access_points_region(region: str, account_id: str) -> list[dict[str, Any]]:
+    """
+    Collect standard S3 Access Points from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no access points" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/inaccessible access points are skipped (logged)
+    rather than aborting the whole region.
 
     Args:
         region: AWS region name
@@ -46,7 +117,16 @@ def collect_standard_access_points(region: str, account_id: str) -> list[dict[st
 
     Returns:
         List of dictionaries containing access point information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records
+            it as a failed region and surfaces it; it is never masked as
+            empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     s3control = utils.get_boto3_client('s3control', region_name=region)
 
     access_points = []
@@ -62,79 +142,19 @@ def collect_standard_access_points(region: str, account_id: str) -> list[dict[st
 
         response = s3control.list_access_points(**kwargs)
 
-        # Process each access point
+        # Process each access point. One malformed/inaccessible access point
+        # must not sink the region, so each is built inside try/except;
+        # failures are logged and skipped.
         for ap in response.get('AccessPointList', []):
             ap_name = ap.get('Name', 'N/A')
 
             try:
-                # Get detailed configuration for this access point
-                details = s3control.get_access_point(
-                    AccountId=account_id,
-                    Name=ap_name
-                )
-
-                # Get block public access settings
-                try:
-                    public_access_block = s3control.get_public_access_block(
-                        AccountId=account_id
-                    )
-                    block_settings = public_access_block.get('PublicAccessBlockConfiguration', {})
-                except Exception:
-                    # If GetPublicAccessBlock fails, use defaults
-                    block_settings = {}
-
-                # Get access point policy status
-                try:
-                    policy_status = s3control.get_access_point_policy_status(
-                        AccountId=account_id,
-                        Name=ap_name
-                    )
-                    has_policy = policy_status.get('PolicyStatus', {}).get('IsPublic', False)
-                except Exception:
-                    has_policy = False
-
-                # Extract VPC configuration
-                vpc_config = ap.get('VpcConfiguration', {})
-                vpc_id = vpc_config.get('VpcId', 'N/A')
-
-                access_point_info = {
-                    'AccessPointName': ap_name,
-                    'AccessPointARN': ap.get('AccessPointArn', 'N/A'),
-                    'Alias': ap.get('Alias', 'N/A'),
-                    'BucketName': ap.get('Bucket', 'N/A'),
-                    'NetworkOrigin': ap.get('NetworkOrigin', 'N/A'),
-                    'VpcId': vpc_id,
-                    'Region': region,
-                    'CreationDate': details.get('CreationDate', 'N/A'),
-                    'HasCustomPolicy': 'Yes' if has_policy else 'No',
-                    'BlockPublicAcls': block_settings.get('BlockPublicAcls', True),
-                    'IgnorePublicAcls': block_settings.get('IgnorePublicAcls', True),
-                    'BlockPublicPolicy': block_settings.get('BlockPublicPolicy', True),
-                    'RestrictPublicBuckets': block_settings.get('RestrictPublicBuckets', True),
-                    'BucketAccountId': ap.get('BucketAccountId', account_id)
-                }
-
-                access_points.append(access_point_info)
-
+                access_points.append(_build_access_point_row(ap, region, account_id, s3control))
             except Exception as e:
-                utils.log_warning(f"Could not get details for access point {ap_name}: {e}")
-                # Add basic info even if details fail
-                access_points.append({
-                    'AccessPointName': ap_name,
-                    'AccessPointARN': ap.get('AccessPointArn', 'N/A'),
-                    'Alias': ap.get('Alias', 'N/A'),
-                    'BucketName': ap.get('Bucket', 'N/A'),
-                    'NetworkOrigin': ap.get('NetworkOrigin', 'N/A'),
-                    'VpcId': vpc_config.get('VpcId', 'N/A'),
-                    'Region': region,
-                    'CreationDate': 'N/A',
-                    'HasCustomPolicy': 'Unknown',
-                    'BlockPublicAcls': 'Unknown',
-                    'IgnorePublicAcls': 'Unknown',
-                    'BlockPublicPolicy': 'Unknown',
-                    'RestrictPublicBuckets': 'Unknown',
-                    'BucketAccountId': ap.get('BucketAccountId', account_id)
-                })
+                utils.log_error(
+                    f"Skipping standard access point '{ap_name}' in {region} due to a processing error", e
+                )
+                continue
 
         # Check if there are more results
         next_token = response.get('NextToken')
@@ -145,108 +165,205 @@ def collect_standard_access_points(region: str, account_id: str) -> list[dict[st
     return access_points
 
 
-@utils.aws_error_handler("Collecting multi-region access points", default_return=[])
-def collect_multi_region_access_points(account_id: str) -> list[dict[str, Any]]:
+def collect_standard_access_points(regions: list[str], account_id: str) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Multi-Region Access Points (always queried from us-west-2)
+    Collect standard S3 Access Point information across regions, surfacing
+    failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Args:
+        regions: List of AWS regions to scan
+        account_id: AWS account ID
+
+    Returns:
+        tuple: ``(access_points, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=lambda r: _scan_standard_access_points_region(r, account_id),
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_aps = [ap for result in region_results for ap in result]
+    return all_aps, failed_regions
+
+
+def _build_mrap_row(mrap: dict, account_id: str, s3control) -> dict[str, Any]:
+    """
+    Build the export row for a single Multi-Region Access Point.
+
+    Args:
+        mrap: A single AccessPoints entry from list_multi_region_access_points.
+        account_id: AWS account ID.
+        s3control: An s3control client (us-west-2).
+
+    Returns:
+        dict: The assembled MRAP row.
+    """
+    mrap_name = mrap.get('Name', 'N/A')
+
+    # Get detailed configuration for this MRAP
+    details = s3control.get_multi_region_access_point(AccountId=account_id, Name=mrap_name)
+    mrap_details = details.get('AccessPoint', {})
+
+    # Extract regions and buckets
+    regions_info = mrap_details.get('Regions', [])
+    regions_list = [r.get('Region', 'N/A') for r in regions_info]
+    buckets_list = [r.get('Bucket', 'N/A') for r in regions_info]
+
+    # Extract public access block settings
+    public_access_block = mrap_details.get('PublicAccessBlock', {})
+
+    return {
+        'MRAPName': mrap_name,
+        'MRAPARN': mrap.get('Alias', 'N/A'),  # Alias is the ARN-style identifier
+        'Alias': mrap_details.get('Alias', 'N/A'),
+        'Status': mrap_details.get('Status', 'N/A'),
+        'CreationDate': mrap.get('CreatedAt', 'N/A'),
+        'Regions': ', '.join(regions_list),
+        'RegionCount': len(regions_list),
+        'Buckets': ', '.join(buckets_list),
+        'BlockPublicAcls': public_access_block.get('BlockPublicAcls', True),
+        'IgnorePublicAcls': public_access_block.get('IgnorePublicAcls', True),
+        'BlockPublicPolicy': public_access_block.get('BlockPublicPolicy', True),
+        'RestrictPublicBuckets': public_access_block.get('RestrictPublicBuckets', True)
+    }
+
+
+def collect_multi_region_access_points(account_id: str) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Multi-Region Access Points (always queried from us-west-2).
+
+    This is a GLOBAL scope — a single call, not region-scanned — so there is
+    no per-region loop to attach a failed-region tuple to. A collection
+    error here is instead reported as a single ``('global', error)`` entry
+    in the returned failed-scopes list, using the same ``(scope, error)``
+    contract as the regional scopes so the caller can merge them into one
+    combined failed list (see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
     Args:
         account_id: AWS account ID
 
     Returns:
-        List of dictionaries containing MRAP information
+        tuple: ``(mraps, failed_scopes)`` where ``failed_scopes`` is either
+        ``[]`` or ``[('global', error_message)]``.
     """
     # Multi-Region Access Points are only available in commercial us-west-2.
     # The API rejects calls from any other region with PermanentRedirect.
     partition = utils.detect_partition()
     if partition == "aws-us-gov":
         utils.log_info("Multi-Region Access Points are not available in GovCloud — skipping.")
-        return []
-
-    s3control = utils.get_boto3_client('s3control', region_name='us-west-2')
-
-    mraps = []
-    next_token = None
+        return [], []
 
     utils.log_info("Collecting Multi-Region Access Points (from us-west-2)...")
 
-    while True:
-        # Build paginated request
-        kwargs = {'AccountId': account_id}
-        if next_token:
-            kwargs['NextToken'] = next_token
+    try:
+        s3control = utils.get_boto3_client('s3control', region_name='us-west-2')
 
-        response = s3control.list_multi_region_access_points(**kwargs)
+        mraps = []
+        next_token = None
 
-        # Process each MRAP
-        for mrap in response.get('AccessPoints', []):
-            mrap_name = mrap.get('Name', 'N/A')
+        while True:
+            # Build paginated request
+            kwargs = {'AccountId': account_id}
+            if next_token:
+                kwargs['NextToken'] = next_token
 
-            try:
-                # Get detailed configuration for this MRAP
-                details = s3control.get_multi_region_access_point(
-                    AccountId=account_id,
-                    Name=mrap_name
-                )
+            response = s3control.list_multi_region_access_points(**kwargs)
 
-                mrap_details = details.get('AccessPoint', {})
+            # Process each MRAP. One malformed/inaccessible MRAP must not
+            # sink the whole scope; failures are logged and skipped.
+            for mrap in response.get('AccessPoints', []):
+                mrap_name = mrap.get('Name', 'N/A')
 
-                # Extract regions and buckets
-                regions_info = mrap_details.get('Regions', [])
-                regions_list = [r.get('Region', 'N/A') for r in regions_info]
-                buckets_list = [r.get('Bucket', 'N/A') for r in regions_info]
+                try:
+                    mraps.append(_build_mrap_row(mrap, account_id, s3control))
+                except Exception as e:
+                    utils.log_error(
+                        f"Skipping Multi-Region Access Point '{mrap_name}' due to a processing error", e
+                    )
+                    continue
 
-                # Extract public access block settings
-                public_access_block = mrap_details.get('PublicAccessBlock', {})
+            # Check if there are more results
+            next_token = response.get('NextToken')
+            if not next_token:
+                break
 
-                mrap_info = {
-                    'MRAPName': mrap_name,
-                    'MRAPARN': mrap.get('Alias', 'N/A'),  # Alias is the ARN-style identifier
-                    'Alias': mrap_details.get('Alias', 'N/A'),
-                    'Status': mrap_details.get('Status', 'N/A'),
-                    'CreationDate': mrap.get('CreatedAt', 'N/A'),
-                    'Regions': ', '.join(regions_list),
-                    'RegionCount': len(regions_list),
-                    'Buckets': ', '.join(buckets_list),
-                    'BlockPublicAcls': public_access_block.get('BlockPublicAcls', True),
-                    'IgnorePublicAcls': public_access_block.get('IgnorePublicAcls', True),
-                    'BlockPublicPolicy': public_access_block.get('BlockPublicPolicy', True),
-                    'RestrictPublicBuckets': public_access_block.get('RestrictPublicBuckets', True)
-                }
+        utils.log_info(f"Found {len(mraps)} Multi-Region Access Points")
+        return mraps, []
 
-                mraps.append(mrap_info)
-
-            except Exception as e:
-                utils.log_warning(f"Could not get details for MRAP {mrap_name}: {e}")
-                # Add basic info even if details fail
-                mraps.append({
-                    'MRAPName': mrap_name,
-                    'MRAPARN': mrap.get('Alias', 'N/A'),
-                    'Alias': mrap.get('Alias', 'N/A'),
-                    'Status': 'Unknown',
-                    'CreationDate': mrap.get('CreatedAt', 'N/A'),
-                    'Regions': 'N/A',
-                    'RegionCount': 0,
-                    'Buckets': 'N/A',
-                    'BlockPublicAcls': 'Unknown',
-                    'IgnorePublicAcls': 'Unknown',
-                    'BlockPublicPolicy': 'Unknown',
-                    'RestrictPublicBuckets': 'Unknown'
-                })
-
-        # Check if there are more results
-        next_token = response.get('NextToken')
-        if not next_token:
-            break
-
-    utils.log_info(f"Found {len(mraps)} Multi-Region Access Points")
-    return mraps
+    except Exception as e:
+        # The MRAP scope call itself failed (e.g. throttling, access denied).
+        # Surface it as a failed 'global' scope rather than swallowing it
+        # into an empty list indistinguishable from "no MRAPs configured".
+        utils.log_error("Error collecting Multi-Region Access Points", e)
+        return [], [('global', str(e))]
 
 
-@utils.aws_error_handler("Collecting Object Lambda Access Points", default_return=[])
-def collect_object_lambda_access_points(region: str, account_id: str) -> list[dict[str, Any]]:
+def _build_object_lambda_row(ol_ap: dict, region: str, account_id: str, s3control) -> dict[str, Any]:
     """
-    Collect Object Lambda Access Points for a specific region
+    Build the export row for a single Object Lambda Access Point.
+
+    Args:
+        ol_ap: A single ObjectLambdaAccessPointList entry from
+            list_access_points_for_object_lambda.
+        region: AWS region name.
+        account_id: AWS account ID.
+        s3control: An s3control client for ``region``.
+
+    Returns:
+        dict: The assembled Object Lambda access point row.
+    """
+    ol_name = ol_ap.get('Name', 'N/A')
+
+    # Get detailed configuration for this Object Lambda access point
+    details = s3control.get_access_point_configuration_for_object_lambda(
+        AccountId=account_id, Name=ol_name
+    )
+    config = details.get('Configuration', {})
+
+    # Extract transformation configurations
+    transformations = config.get('TransformationConfigurations', [])
+    lambda_arns = []
+    allowed_features = []
+
+    for transform in transformations:
+        content_transform = transform.get('ContentTransformation', {})
+        if 'AwsLambda' in content_transform:
+            lambda_arns.append(content_transform['AwsLambda'].get('FunctionArn', 'N/A'))
+
+        actions = transform.get('Actions', [])
+        allowed_features.extend(actions)
+
+    return {
+        'ObjectLambdaName': ol_name,
+        'ObjectLambdaARN': ol_ap.get('ObjectLambdaAccessPointArn', 'N/A'),
+        'SupportingAccessPoint': config.get('SupportingAccessPoint', 'N/A'),
+        'LambdaFunctions': ', '.join(lambda_arns) if lambda_arns else 'N/A',
+        'AllowedFeatures': ', '.join(set(allowed_features)) if allowed_features else 'N/A',
+        'CloudWatchMetricsEnabled': config.get('CloudWatchMetricsEnabled', False),
+        'Region': region,
+        'Alias': ol_ap.get('Alias', 'N/A')
+    }
+
+
+def _scan_object_lambda_access_points_region(region: str, account_id: str) -> list[dict[str, Any]]:
+    """
+    Collect Object Lambda Access Points from a single region.
+
+    Object Lambda support varies by region/partition, and the API can
+    respond to an unsupported region with an error rather than an empty
+    list. That "not available here" error cannot be reliably distinguished
+    from a genuine collection failure (throttling, access denied), so —
+    unlike the standard access points primary scope — it is deliberately
+    still caught and treated as "no Object Lambda access points in this
+    region" rather than raised. Per-item failures are logged and skipped
+    individually either way.
 
     Args:
         region: AWS region name
@@ -255,6 +372,9 @@ def collect_object_lambda_access_points(region: str, account_id: str) -> list[di
     Returns:
         List of dictionaries containing Object Lambda access point information
     """
+    if not utils.is_aws_region(region):
+        return []
+
     s3control = utils.get_boto3_client('s3control', region_name=region)
 
     ol_access_points = []
@@ -280,53 +400,14 @@ def collect_object_lambda_access_points(region: str, account_id: str) -> list[di
             ol_name = ol_ap.get('Name', 'N/A')
 
             try:
-                # Get detailed configuration for this Object Lambda access point
-                details = s3control.get_access_point_configuration_for_object_lambda(
-                    AccountId=account_id,
-                    Name=ol_name
+                ol_access_points.append(
+                    _build_object_lambda_row(ol_ap, region, account_id, s3control)
                 )
-
-                config = details.get('Configuration', {})
-
-                # Extract transformation configurations
-                transformations = config.get('TransformationConfigurations', [])
-                lambda_arns = []
-                allowed_features = []
-
-                for transform in transformations:
-                    content_transform = transform.get('ContentTransformation', {})
-                    if 'AwsLambda' in content_transform:
-                        lambda_arns.append(content_transform['AwsLambda'].get('FunctionArn', 'N/A'))
-
-                    actions = transform.get('Actions', [])
-                    allowed_features.extend(actions)
-
-                ol_info = {
-                    'ObjectLambdaName': ol_name,
-                    'ObjectLambdaARN': ol_ap.get('ObjectLambdaAccessPointArn', 'N/A'),
-                    'SupportingAccessPoint': config.get('SupportingAccessPoint', 'N/A'),
-                    'LambdaFunctions': ', '.join(lambda_arns) if lambda_arns else 'N/A',
-                    'AllowedFeatures': ', '.join(set(allowed_features)) if allowed_features else 'N/A',
-                    'CloudWatchMetricsEnabled': config.get('CloudWatchMetricsEnabled', False),
-                    'Region': region,
-                    'Alias': ol_ap.get('Alias', 'N/A')
-                }
-
-                ol_access_points.append(ol_info)
-
             except Exception as e:
-                utils.log_warning(f"Could not get details for Object Lambda AP {ol_name}: {e}")
-                # Add basic info even if details fail
-                ol_access_points.append({
-                    'ObjectLambdaName': ol_name,
-                    'ObjectLambdaARN': ol_ap.get('ObjectLambdaAccessPointArn', 'N/A'),
-                    'SupportingAccessPoint': 'N/A',
-                    'LambdaFunctions': 'N/A',
-                    'AllowedFeatures': 'N/A',
-                    'CloudWatchMetricsEnabled': 'Unknown',
-                    'Region': region,
-                    'Alias': ol_ap.get('Alias', 'N/A')
-                })
+                utils.log_error(
+                    f"Skipping Object Lambda access point '{ol_name}' in {region} due to a processing error", e
+                )
+                continue
 
         # Check if there are more results
         next_token = response.get('NextToken')
@@ -335,6 +416,31 @@ def collect_object_lambda_access_points(region: str, account_id: str) -> list[di
 
     utils.log_info(f"Found {len(ol_access_points)} Object Lambda Access Points in {region}")
     return ol_access_points
+
+
+def collect_object_lambda_access_points(regions: list[str], account_id: str) -> list[dict[str, Any]]:
+    """
+    Collect Object Lambda Access Point information across regions.
+
+    Enrichment-style regional scope: it degrades gracefully per region (see
+    ``_scan_object_lambda_access_points_region``), so it is scanned without
+    ``collect_failures`` and does not contribute to the failed-scopes list.
+
+    Args:
+        regions: List of AWS regions to scan
+        account_id: AWS account ID
+
+    Returns:
+        list: List of dictionaries with Object Lambda access point information
+    """
+    region_results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=lambda r: _scan_object_lambda_access_points_region(r, account_id),
+        show_progress=True,
+    )
+    all_ol_aps = [ap for result in region_results for ap in result]
+    utils.log_success(f"Total Object Lambda Access Points collected: {len(all_ol_aps)}")
+    return all_ol_aps
 
 
 def create_summary_sheet(
@@ -480,27 +586,26 @@ def main():
 
     # Detect partition for region examples
     regions = utils.prompt_region_selection()
-    # Collect all access points
-    all_standard_aps = []
-    all_ol_aps = []
 
     utils.log_info(f"Scanning {len(regions)} region(s) for Access Points...")
 
-    # Collect standard and Object Lambda access points from each region
-    for i, region in enumerate(regions, 1):
-        progress = (i / len(regions)) * 100
-        utils.log_info(f"[{progress:.1f}%] Processing region {i}/{len(regions)}: {region}")
+    # STEP 1: Collect standard access points (primary scope — region
+    # failures must propagate as failed_regions, never collapse into
+    # "empty").
+    all_standard_aps, failed_regions = collect_standard_access_points(regions, account_id)
 
-        # Standard Access Points
-        standard_aps = collect_standard_access_points(region, account_id)
-        all_standard_aps.extend(standard_aps)
+    # STEP 2: Collect Object Lambda Access Points (enrichment-style regional
+    # scope — degrades gracefully; see
+    # collect_object_lambda_access_points()/_scan_object_lambda_access_points_region()).
+    all_ol_aps = collect_object_lambda_access_points(regions, account_id)
 
-        # Object Lambda Access Points
-        ol_aps = collect_object_lambda_access_points(region, account_id)
-        all_ol_aps.extend(ol_aps)
+    # STEP 3: Collect Multi-Region Access Points (global scope, queried once
+    # from us-west-2; a failure here is reported as a 'global' scope).
+    mraps, mrap_failed = collect_multi_region_access_points(account_id)
 
-    # Collect Multi-Region Access Points (only once, from us-west-2)
-    mraps = collect_multi_region_access_points(account_id)
+    # Merge failed scopes: regional failures from the primary scope + the
+    # global MRAP scope (if it failed).
+    failed = list(failed_regions) + list(mrap_failed)
 
     # Log collection summary
     utils.log_info("=" * 60)
@@ -511,20 +616,33 @@ def main():
     utils.log_info(f"  Total Access Points: {len(all_standard_aps) + len(mraps) + len(all_ol_aps)}")
     utils.log_info("=" * 60)
 
-    # Check if we found any access points
-    if not all_standard_aps and not mraps and not all_ol_aps:
+    if all_standard_aps or mraps or all_ol_aps:
+        # Export whatever succeeded — a partial export is required even
+        # when some scopes failed (see the silent-collection-failure
+        # blast-radius audit).
+        utils.log_info("Exporting data to Excel...")
+        output_file = export_to_excel(all_standard_aps, mraps, all_ol_aps, account_name)
+
+        if output_file:
+            print("\nScript execution completed successfully.")
+        else:
+            utils.log_error("Failed to export data. Please check the logs.")
+    elif not failed:
+        # Genuinely empty account: every scope succeeded and returned
+        # nothing.
         utils.log_warning("No S3 Access Points found in the selected regions")
         utils.log_info("This is normal if Access Points are not configured in your account")
-        return
 
-    # Export to Excel
-    utils.log_info("Exporting data to Excel...")
-    output_file = export_to_excel(all_standard_aps, mraps, all_ol_aps, account_name)
-
-    if output_file:
-        print("\nScript execution completed successfully.")
-    else:
-        utils.log_error("Failed to export data. Please check the logs.")
+    # If ANY scope failed collection, make it loud: write a marker and exit
+    # non-zero, even if some data was exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed:
+        utils.report_collection_failures(account_name, 's3-accesspoints', failed)
+        print(
+            "\nERROR: S3 Access Points export completed with failures — data is incomplete. "
+            "See the *-s3-accesspoints-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_script_end("S3 Access Points Export")
 

--- a/tests/test_exporters/test_bedrock_export.py
+++ b/tests/test_exporters/test_bedrock_export.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for bedrock_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Moto's Bedrock support is limited: ``list_foundation_models`` raises
+``NotImplementedError`` and ``list_guardrails`` is absent from the local
+botocore service model entirely (confirmed via
+``bedrock_client.meta.service_model.operation_names``). Because of this,
+cases (b)/(c) below (region-API-failure and failed-regions-surfaced) are
+exercised via monkeypatch against ``_scan_foundation_models_region`` rather
+than by driving a real moto failure through ``list_foundation_models``.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import bedrock_export  # noqa: E402
+from bedrock_export import _scan_foundation_models_region, _scan_guardrails_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _fake_model_summary(model_id="anthropic.claude-v2", model_name="Claude V2"):
+    return {
+        "modelId": model_id,
+        "modelArn": f"arn:aws:bedrock:{REGION}::foundation-model/{model_id}",
+        "modelName": model_name,
+        "providerName": "Anthropic",
+        "inputModalities": ["TEXT"],
+        "outputModalities": ["TEXT"],
+        "responseStreamingSupported": True,
+        "customizationsSupported": [],
+        "inferenceTypesSupported": ["ON_DEMAND"],
+        "modelLifecycle": {"status": "ACTIVE"},
+    }
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_a_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """
+        One foundation model that fails to process must not discard the
+        whole region's results — the healthy model is still collected.
+
+        moto does not implement list_foundation_models, so the client call
+        is monkeypatched to yield two fake model summaries directly.
+        """
+
+        def fake_list_foundation_models(self):
+            return {
+                "modelSummaries": [
+                    _fake_model_summary("good-model", "Good Model"),
+                    _fake_model_summary("bad-model", "Bad Model"),
+                ]
+            }
+
+        monkeypatch.setattr(
+            botocore.client.BaseClient, "_make_api_call",
+            lambda self, operation_name, kwargs: (
+                fake_list_foundation_models(self)
+                if operation_name == "ListFoundationModels"
+                else (_ for _ in ()).throw(AssertionError(f"unexpected call: {operation_name}"))
+            ),
+        )
+
+        original = bedrock_export._build_foundation_model_row
+
+        def raise_for_bad(model, region):
+            if model.get("modelId") == "bad-model":
+                raise KeyError("SomeUnexpectedField")
+            return original(model, region)
+
+        monkeypatch.setattr(bedrock_export, "_build_foundation_model_row", raise_for_bad)
+
+        rows = _scan_foundation_models_region(REGION)
+
+        ids = {row["Model ID"] for row in rows}
+        assert "good-model" in ids, "healthy model was lost when a sibling failed"
+        assert "bad-model" not in ids, "malformed model should have been skipped"
+
+    def test_b_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record
+        a FAILED region) rather than being swallowed into an empty list.
+
+        moto has no working mock for list_foundation_models (it raises
+        NotImplementedError, not a realistic ClientError), so the boto3
+        client factory itself is monkeypatched to simulate a genuine AWS
+        error at the region-collector boundary.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListFoundationModels",
+            )
+
+        monkeypatch.setattr(bedrock_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_foundation_models_region(REGION)
+
+    def test_c_collect_foundation_models_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker and
+        exit 1.
+
+        moto's list_foundation_models is not implemented, so the
+        per-region scan function is monkeypatched directly to simulate a
+        genuine collection failure.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListFoundationModels",
+            )
+
+        monkeypatch.setattr(bedrock_export, "_scan_foundation_models_region", boom)
+
+        models, failed_regions = bedrock_export.collect_foundation_models([REGION])
+
+        assert models == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_guardrails_op_availability_probe_still_skips_gracefully(self):
+        """
+        The pre-existing #224 op-availability probe must be preserved:
+        when ``list_guardrails`` is absent from the local botocore service
+        model (confirmed true for this environment/moto combination), the
+        region is skipped cleanly with an empty result — NOT recorded as a
+        failed region.
+        """
+        client = boto3.client("bedrock", region_name=REGION)
+        assert "list_guardrails" not in client.meta.service_model.operation_names, (
+            "This test assumes list_guardrails is absent at the botocore floor "
+            "(per Issue #224); if this now fails, botocore has added the "
+            "operation and the op-probe scenario should be revisited."
+        )
+
+        rows = _scan_guardrails_region(REGION)
+        assert rows == []
+
+        # And the scope wrapper must not report this as a failed region.
+        all_guardrails, failed_regions = bedrock_export.collect_guardrails([REGION])
+        assert all_guardrails == []
+        assert failed_regions == []

--- a/tests/test_exporters/test_datasync_export.py
+++ b/tests/test_exporters/test_datasync_export.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Tests for datasync_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2), scoped to the
+primary DataSync Tasks collector. See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's DataSync support does not cover the full ``describe_task``
+field set this exporter reads (Tags, Schedule, Options, ...), so these tests
+build a fake boto3 client via monkeypatch rather than ``@mock_aws``.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import datasync_export  # noqa: E402
+from datasync_export import collect_datasync_tasks  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _make_fake_client(tasks, describe_map):
+    """
+    Build a fake DataSync client whose ``list_tasks`` paginator yields
+    ``tasks`` (a list of ``{'TaskArn': ...}`` dicts) and whose
+    ``describe_task`` returns ``describe_map[task_arn]``.
+    """
+    client = MagicMock()
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{'Tasks': tasks}]
+    client.get_paginator.return_value = paginator
+
+    def describe_task(**kwargs):
+        return describe_map[kwargs["TaskArn"]]
+
+    client.describe_task.side_effect = describe_task
+    return client
+
+
+class TestCollectDatasyncTasks:
+    """Happy-path collection."""
+
+    def test_collects_tasks(self, monkeypatch):
+        task_arn = "arn:aws:datasync:us-east-1:111222333444:task/task-1"
+        fake_client = _make_fake_client(
+            tasks=[{'TaskArn': task_arn}],
+            describe_map={
+                task_arn: {
+                    'TaskArn': task_arn,
+                    'Status': 'AVAILABLE',
+                    'SourceLocationArn': 'arn:aws:datasync:us-east-1:111222333444:location/loc-1',
+                    'DestinationLocationArn': 'arn:aws:datasync:us-east-1:111222333444:location/loc-2',
+                }
+            },
+        )
+        monkeypatch.setattr(datasync_export.utils, "get_boto3_client", lambda *a, **k: fake_client)
+
+        result = collect_datasync_tasks(REGION)
+
+        assert len(result) == 1
+        assert result[0]["Task ARN"] == task_arn
+        assert result[0]["Status"] == "AVAILABLE"
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _make_fake_client(tasks=[], describe_map={})
+        monkeypatch.setattr(datasync_export.utils, "get_boto3_client", lambda *a, **k: fake_client)
+
+        result = collect_datasync_tasks(REGION)
+
+        assert result == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One task that fails to process must not discard the whole region."""
+        good_arn = "arn:aws:datasync:us-east-1:111222333444:task/good"
+        bad_arn = "arn:aws:datasync:us-east-1:111222333444:task/bad"
+
+        fake_client = _make_fake_client(
+            tasks=[{'TaskArn': good_arn}, {'TaskArn': bad_arn}],
+            describe_map={
+                good_arn: {'TaskArn': good_arn, 'Status': 'AVAILABLE'},
+                bad_arn: {'TaskArn': bad_arn, 'Status': 'AVAILABLE'},
+            },
+        )
+        monkeypatch.setattr(datasync_export.utils, "get_boto3_client", lambda *a, **k: fake_client)
+
+        original = datasync_export._build_task_row
+
+        def raise_for_bad(item, region):
+            if item == bad_arn:
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(datasync_export, "_build_task_row", raise_for_bad)
+
+        result = collect_datasync_tasks(REGION)
+
+        arns = {row["Task ARN"] for row in result}
+        assert good_arn in arns, "healthy task was lost when a sibling failed"
+        assert bad_arn not in arns, "malformed task should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListTasks",
+            )
+
+        monkeypatch.setattr(datasync_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_datasync_tasks(REGION)
+
+    def test_collect_datasync_tasks_all_regions_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker and
+        exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListTasks",
+            )
+
+        monkeypatch.setattr(datasync_export, "collect_datasync_tasks", boom)
+
+        tasks, failed_regions = datasync_export.collect_datasync_tasks_all_regions([REGION])
+
+        assert tasks == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_dynamodb_export.py
+++ b/tests/test_exporters/test_dynamodb_export.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for dynamodb_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import dynamodb_export  # noqa: E402
+from dynamodb_export import _scan_dynamodb_tables_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_table(client, name):
+    """Create a simple pay-per-request DynamoDB table named ``name``."""
+    client.create_table(
+        TableName=name,
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+class TestScanDynamodbTablesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_tables(self):
+        client = boto3.client("dynamodb", region_name=REGION)
+        _create_table(client, "orders-table")
+
+        rows = _scan_dynamodb_tables_region(REGION)
+
+        names = {row["Table Name"] for row in rows}
+        assert "orders-table" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("dynamodb", region_name=REGION)  # region exists, no tables
+
+        rows = _scan_dynamodb_tables_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One table that fails to process must not discard the whole region."""
+        client = boto3.client("dynamodb", region_name=REGION)
+        _create_table(client, "good-table")
+        _create_table(client, "bad-table")
+
+        original = dynamodb_export._build_table_row
+
+        def raise_for_bad(client_arg, table, region):
+            if table.get("TableName") == "bad-table":
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, table, region)
+
+        monkeypatch.setattr(dynamodb_export, "_build_table_row", raise_for_bad)
+
+        rows = _scan_dynamodb_tables_region(REGION)
+
+        names = {row["Table Name"] for row in rows}
+        assert "good-table" in names, "healthy table was lost when a sibling failed"
+        assert "bad-table" not in names, "malformed table should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListTables",
+            )
+
+        monkeypatch.setattr(dynamodb_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_dynamodb_tables_region(REGION)
+
+    @mock_aws
+    def test_collect_dynamodb_tables_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListTables",
+            )
+
+        monkeypatch.setattr(dynamodb_export, "_scan_dynamodb_tables_region", boom)
+
+        tables, failed_regions = dynamodb_export.collect_dynamodb_tables([REGION])
+
+        assert tables == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_efs_export.py
+++ b/tests/test_exporters/test_efs_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for efs_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2b). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import efs_export  # noqa: E402
+from efs_export import _scan_efs_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_file_system(client, creation_token):
+    """Create an EFS file system with the given creation token."""
+    return client.create_file_system(CreationToken=creation_token)
+
+
+class TestScanEfsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_file_systems(self):
+        client = boto3.client("efs", region_name=REGION)
+        _create_file_system(client, "web-fs")
+
+        rows = _scan_efs_region(REGION)
+
+        tokens = {row["Creation Token"] for row in rows}
+        assert "web-fs" in tokens
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("efs", region_name=REGION)  # region exists, no file systems
+
+        rows = _scan_efs_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One file system that fails to process must not discard the whole region."""
+        client = boto3.client("efs", region_name=REGION)
+        _create_file_system(client, "good-fs")
+        _create_file_system(client, "bad-fs")
+
+        original = efs_export._build_filesystem_row
+
+        def raise_for_bad(fs, region, pricing):
+            if fs.get("CreationToken") == "bad-fs":
+                raise KeyError("SomeUnexpectedField")
+            return original(fs, region, pricing)
+
+        monkeypatch.setattr(efs_export, "_build_filesystem_row", raise_for_bad)
+
+        rows = _scan_efs_region(REGION)
+
+        tokens = {row["Creation Token"] for row in rows}
+        assert "good-fs" in tokens, "healthy file system was lost when a sibling failed"
+        assert "bad-fs" not in tokens, "malformed file system should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeFileSystems",
+            )
+
+        monkeypatch.setattr(efs_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_efs_region(REGION)
+
+    @mock_aws
+    def test_collect_efs_file_systems_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeFileSystems",
+            )
+
+        monkeypatch.setattr(efs_export, "_scan_efs_region", boom)
+
+        file_systems, failed_regions = efs_export.collect_efs_file_systems([REGION])
+
+        assert file_systems == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_elasticache_export.py
+++ b/tests/test_exporters/test_elasticache_export.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for elasticache_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's ElastiCache support does not implement create_cache_cluster's
+error paths the way we need for the region-API-failure regression test, so
+that case (and the malformed-item case) monkeypatch the boto3 client factory
+/ row builder directly rather than relying on moto to produce the failure.
+create_replication_group itself is fully supported by moto and used for the
+happy-path and scope-aggregation tests.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import elasticache_export  # noqa: E402
+from elasticache_export import _scan_replication_groups_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_replication_group(client, rg_id):
+    """Create a minimal ElastiCache (Redis) replication group named ``rg_id``."""
+    client.create_replication_group(
+        ReplicationGroupId=rg_id,
+        ReplicationGroupDescription=f"test group {rg_id}",
+        Engine="redis",
+        CacheNodeType="cache.t3.micro",
+        NumCacheClusters=1,
+    )
+
+
+class TestScanReplicationGroupsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_replication_groups(self):
+        client = boto3.client("elasticache", region_name=REGION)
+        _create_replication_group(client, "web-cache")
+
+        rows = _scan_replication_groups_region(REGION)
+
+        ids = {row["Replication Group ID"] for row in rows}
+        assert "web-cache" in ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("elasticache", region_name=REGION)  # region exists, no groups
+
+        rows = _scan_replication_groups_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One replication group that fails to process must not discard the whole region."""
+        client = boto3.client("elasticache", region_name=REGION)
+        _create_replication_group(client, "good-cache")
+        _create_replication_group(client, "bad-cache")
+
+        original = elasticache_export._build_replication_group_row
+
+        def raise_for_bad(rg, region, pricing_data, cost_note):
+            if rg.get("ReplicationGroupId") == "bad-cache":
+                raise KeyError("SomeUnexpectedField")
+            return original(rg, region, pricing_data, cost_note)
+
+        monkeypatch.setattr(elasticache_export, "_build_replication_group_row", raise_for_bad)
+
+        rows = _scan_replication_groups_region(REGION)
+
+        ids = {row["Replication Group ID"] for row in rows}
+        assert "good-cache" in ids, "healthy replication group was lost when a sibling failed"
+        assert "bad-cache" not in ids, "malformed replication group should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeReplicationGroups",
+            )
+
+        monkeypatch.setattr(elasticache_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_replication_groups_region(REGION)
+
+    @mock_aws
+    def test_collect_replication_groups_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeReplicationGroups",
+            )
+
+        monkeypatch.setattr(elasticache_export, "_scan_replication_groups_region", boom)
+
+        replication_groups, failed_regions = elasticache_export.collect_replication_groups([REGION])
+
+        assert replication_groups == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_fsx_export.py
+++ b/tests/test_exporters/test_fsx_export.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for fsx_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's FSx support does not implement create_file_system /
+describe_file_systems in a way this suite can rely on for happy-path
+fixture creation, so the malformed-item and region-failure regression
+cases below are driven via monkeypatch instead of real moto-created
+file systems.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import fsx_export  # noqa: E402
+from fsx_export import _scan_fsx_file_systems_region  # noqa: E402
+
+REGION = "us-east-1"
+
+_FAKE_FS_GOOD = {
+    "FileSystemId": "fs-good",
+    "FileSystemType": "WINDOWS",
+    "Lifecycle": "AVAILABLE",
+    "StorageCapacity": 300,
+    "StorageType": "SSD",
+    "VpcId": "vpc-12345",
+}
+
+_FAKE_FS_BAD = {
+    "FileSystemId": "fs-bad",
+    "FileSystemType": "WINDOWS",
+    "Lifecycle": "AVAILABLE",
+    "StorageCapacity": 300,
+    "StorageType": "SSD",
+    "VpcId": "vpc-12345",
+}
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Yields a single page containing the given file systems."""
+
+    def __init__(self, file_systems):
+        self._file_systems = file_systems
+
+    def paginate(self, **kwargs):
+        yield {"FileSystems": self._file_systems}
+
+
+class _FakeFsxClient:
+    def __init__(self, file_systems):
+        self._file_systems = file_systems
+
+    def get_paginator(self, name):
+        assert name == "describe_file_systems"
+        return _FakePaginator(self._file_systems)
+
+
+class TestScanFsxFileSystemsRegion:
+    """Happy-path collection, driven via monkeypatch since moto FSx support
+    is limited."""
+
+    def test_collects_file_systems(self, monkeypatch):
+        monkeypatch.setattr(
+            fsx_export.utils,
+            "get_boto3_client",
+            lambda service, region_name=None: _FakeFsxClient([_FAKE_FS_GOOD]),
+        )
+
+        rows = _scan_fsx_file_systems_region(REGION)
+
+        ids = {row["File System ID"] for row in rows}
+        assert "fs-good" in ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        # moto does support the fsx client existing even without real FSx
+        # CRUD support, so this exercises the "no file systems" path via a
+        # real (empty) paginator.
+        rows = _scan_fsx_file_systems_region(REGION)
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One file system that fails to process must not discard the whole
+        region."""
+        monkeypatch.setattr(
+            fsx_export.utils,
+            "get_boto3_client",
+            lambda service, region_name=None: _FakeFsxClient([_FAKE_FS_GOOD, _FAKE_FS_BAD]),
+        )
+
+        original = fsx_export._build_filesystem_row
+
+        def raise_for_bad(fs, region, pricing):
+            if fs.get("FileSystemId") == "fs-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(fs, region, pricing)
+
+        monkeypatch.setattr(fsx_export, "_build_filesystem_row", raise_for_bad)
+
+        rows = _scan_fsx_file_systems_region(REGION)
+
+        ids = {row["File System ID"] for row in rows}
+        assert "fs-good" in ids, "healthy file system was lost when a sibling failed"
+        assert "fs-bad" not in ids, "malformed file system should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeFileSystems",
+            )
+
+        monkeypatch.setattr(fsx_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_fsx_file_systems_region(REGION)
+
+    def test_collect_fsx_file_systems_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeFileSystems",
+            )
+
+        monkeypatch.setattr(fsx_export, "_scan_fsx_file_systems_region", boom)
+
+        file_systems, failed_regions = fsx_export.collect_fsx_file_systems([REGION])
+
+        assert file_systems == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_s3_accesspoints_export.py
+++ b/tests/test_exporters/test_s3_accesspoints_export.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for s3_accesspoints_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2b) for the primary
+regional scope, collect_standard_access_points()/
+_scan_standard_access_points_region(). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+moto's S3 Control (Access Points) support covers create/list/get for a
+single happy-path access point, but not the full surface (pagination
+tokens, GetPublicAccessBlock/GetAccessPointPolicyStatus edge cases, error
+injection). The regression tests below therefore monkeypatch the s3control
+client directly rather than relying on moto for the error-path and
+malformed-item cases; only the happy-path class exercises real moto calls.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import s3_accesspoints_export  # noqa: E402
+from s3_accesspoints_export import _scan_standard_access_points_region  # noqa: E402
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakeS3Control:
+    """
+    Minimal stand-in for an s3control client used by the regression tests
+    below, since moto's Access Points support does not cover pagination
+    tokens or error injection. ``list_access_points`` returns the fixed
+    ``access_points`` list; the detail calls return the same "nothing
+    configured" responses AWS returns for a fresh access point (verified
+    against moto's real GetPublicAccessBlock/GetAccessPointPolicyStatus
+    behavior).
+    """
+
+    def __init__(self, access_points):
+        self._access_points = access_points
+
+    def list_access_points(self, **kwargs):
+        return {"AccessPointList": self._access_points}
+
+    def get_access_point(self, **kwargs):
+        return {"CreationDate": "N/A"}
+
+    def get_public_access_block(self, **kwargs):
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "NoSuchPublicAccessBlockConfiguration",
+                    "Message": "The public access block configuration was not found",
+                }
+            },
+            "GetPublicAccessBlock",
+        )
+
+    def get_access_point_policy_status(self, **kwargs):
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "NoSuchAccessPointPolicy",
+                    "Message": "The specified accesspoint policy does not exist",
+                }
+            },
+            "GetAccessPointPolicyStatus",
+        )
+
+
+class TestScanStandardAccessPointsRegion:
+    """Happy-path collection (real moto S3 Control calls)."""
+
+    @mock_aws
+    def test_collects_access_points(self):
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket="test-bucket-ap")
+        s3control = boto3.client("s3control", region_name=REGION)
+        s3control.create_access_point(AccountId=ACCOUNT_ID, Name="test-ap", Bucket="test-bucket-ap")
+
+        rows = _scan_standard_access_points_region(REGION, ACCOUNT_ID)
+
+        names = {row["AccessPointName"] for row in rows}
+        assert "test-ap" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("s3control", region_name=REGION)  # region exists, no access points
+
+        rows = _scan_standard_access_points_region(REGION, ACCOUNT_ID)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One access point that fails to process must not discard the whole region."""
+        fake_client = _FakeS3Control(
+            [
+                {
+                    "Name": "good-ap",
+                    "AccessPointArn": f"arn:aws:s3:{REGION}:{ACCOUNT_ID}:accesspoint/good-ap",
+                    "Bucket": "good-bucket",
+                    "NetworkOrigin": "Internet",
+                },
+                {
+                    "Name": "bad-ap",
+                    "AccessPointArn": f"arn:aws:s3:{REGION}:{ACCOUNT_ID}:accesspoint/bad-ap",
+                    "Bucket": "bad-bucket",
+                    "NetworkOrigin": "Internet",
+                },
+            ]
+        )
+        monkeypatch.setattr(
+            s3_accesspoints_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        original = s3_accesspoints_export._build_access_point_row
+
+        def raise_for_bad(ap, region, account_id, s3control):
+            if ap.get("Name") == "bad-ap":
+                raise KeyError("SomeUnexpectedField")
+            return original(ap, region, account_id, s3control)
+
+        monkeypatch.setattr(s3_accesspoints_export, "_build_access_point_row", raise_for_bad)
+
+        rows = _scan_standard_access_points_region(REGION, ACCOUNT_ID)
+
+        names = {row["AccessPointName"] for row in rows}
+        assert "good-ap" in names, "healthy access point was lost when a sibling failed"
+        assert "bad-ap" not in names, "malformed access point should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListAccessPoints",
+            )
+
+        monkeypatch.setattr(s3_accesspoints_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_standard_access_points_region(REGION, ACCOUNT_ID)
+
+    def test_collect_standard_access_points_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region, account_id):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListAccessPoints",
+            )
+
+        monkeypatch.setattr(s3_accesspoints_export, "_scan_standard_access_points_region", boom)
+
+        access_points, failed_regions = s3_accesspoints_export.collect_standard_access_points(
+            [REGION], ACCOUNT_ID
+        )
+
+        assert access_points == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -63,10 +63,11 @@ _EXCLUDED = {
     # mocked environment. The scripts are correct in production (the APIs exist
     # there); adding an availability-probe skip would reintroduce silent loss on
     # a real throttle/deny. Behavior is covered by the dedicated regression
-    # suites: tests/test_exporters/test_image_builder_export.py and
-    # test_ssm_fleet_export.py.
+    # suites under tests/test_exporters/. bedrock joins them for the same reason:
+    # moto's bedrock:ListFoundationModels raises NotImplementedError.
     "image_builder_export.py",
     "ssm_fleet_export.py",
+    "bedrock_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. Third phase of the phased rollout — **Batch B: data & storage (7 exporters)** — onto the shared plumbing from #234 (Batch A = #237).

## What
Each exporter's PRIMARY scope collector(s) converted onto the shared contract (scope raises → `scan_regions_concurrent(collect_failures=True)` → per-item guard → partial export → `report_collection_failures` + `sys.exit(1)`), matching the Tier-1/Tier-2a pattern.

| Exporter | Scopes fixed | Slug |
|---|---|---|
| dynamodb | 1 | `dynamodb` |
| efs | 1 | `efs` |
| elasticache | 2 (replication groups + cache clusters) | `elasticache` |
| fsx | 1 | `fsx` |
| datasync | 1 (tasks) | `datasync` |
| s3_accesspoints | 2 regional + global MRAP | `s3-accesspoints` |
| bedrock | 6 | `bedrock` |

Notable per-file handling: `elasticache` guards `rg['Cluster Mode']` + siblings and hardens empty `CacheNodes`; `datasync` guards `task['TaskArn']`; `s3_accesspoints` surfaces its **global** MRAP failure as a `('global', err)` scope; `bedrock` preserves the #224 `list_guardrails` op-availability probe as a graceful skip (never a failed region) and its GovCloud partition guard. Enrichment sheets (GSIs, mount targets, backups, subnet groups, locations/agents, object-lambda APs) stay graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite (malformed-item-skipped; scope API failure raises-not-empty; wrapper surfaces failed scopes). moto covers dynamodb/efs/elasticache/s3-control happy paths; fsx/datasync/bedrock use monkeypatch where moto lacks the service. **Batch-B suites: 34 passed. Full suite: 850 passed, 2 skipped. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusion
`bedrock_export` added to `_EXCLUDED` — moto's `bedrock:ListFoundationModels` raises `NotImplementedError`, so the correct fail-loud behavior exits 1 against an empty mocked env (same rationale as `image_builder`/`ssm_fleet`; an availability-probe skip would reintroduce silent loss on a real throttle/deny). Dedicated regression suite covers it. The other 6 pass smoke normally.

## Remaining
Tier-2 **C** security & identity, **D** networking, **E** messaging/cost/governance. Then Tier-3 (48 PARTIAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)