### PR TITLE
Silent collection failure: Tier-2c (security & identity exporters)

### DIFF
--- a/scripts/access_analyzer_export.py
+++ b/scripts/access_analyzer_export.py
@@ -45,16 +45,90 @@ except ImportError:
 args = utils.parse_script_args("Export IAM Access Analyzer findings and analyzers to Excel")
 
 
-@utils.aws_error_handler("Collecting Access Analyzers from region", default_return=[])
+def _build_analyzer_row(analyzer: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single Access Analyzer.
+
+    Extracted so the per-analyzer processing can be wrapped in try/except by
+    the caller: a malformed analyzer entry is logged and skipped rather than
+    discarding the whole region's results.
+
+    Args:
+        analyzer: A single analyzers entry from list_analyzers.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled analyzer row.
+    """
+    analyzer_name = analyzer.get('name', '')
+    analyzer_arn = analyzer.get('arn', '')
+
+    # Type (ACCOUNT or ORGANIZATION)
+    analyzer_type = analyzer.get('type', '')
+
+    # Status
+    status = analyzer.get('status', '')
+
+    # Created at
+    created_at = analyzer.get('createdAt', '')
+    if created_at:
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
+
+    # Last resource analyzed
+    last_resource_analyzed = analyzer.get('lastResourceAnalyzed', 'N/A')
+
+    # Last resource analyzed at
+    last_resource_analyzed_at = analyzer.get('lastResourceAnalyzedAt', '')
+    if last_resource_analyzed_at:
+        last_resource_analyzed_at = last_resource_analyzed_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_resource_analyzed_at, datetime.datetime) else str(last_resource_analyzed_at)
+    else:
+        last_resource_analyzed_at = 'Never'
+
+    # Tags
+    tags = analyzer.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    # Status reason
+    status_reason = analyzer.get('statusReason', {})
+    status_reason_code = status_reason.get('code', 'N/A')
+
+    return {
+        'Region': region,
+        'Analyzer Name': analyzer_name,
+        'Type': analyzer_type,
+        'Status': status,
+        'Status Reason': status_reason_code,
+        'Last Resource Analyzed': last_resource_analyzed,
+        'Last Analysis Time': last_resource_analyzed_at,
+        'Created At': created_at,
+        'Tags': tags_str,
+        'Analyzer ARN': analyzer_arn
+    }
+
+
 def collect_analyzers_from_region(region: str) -> list[dict[str, Any]]:
     """
     Collect IAM Access Analyzer information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no analyzers" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed analyzers are skipped (logged) rather than aborting
+    the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with analyzer information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
         return []
@@ -70,64 +144,41 @@ def collect_analyzers_from_region(region: str) -> list[dict[str, Any]]:
         analyzers = page.get('analyzers', [])
 
         for analyzer in analyzers:
-            analyzer_name = analyzer.get('name', '')
-            analyzer_arn = analyzer.get('arn', '')
-
-            # Type (ACCOUNT or ORGANIZATION)
-            analyzer_type = analyzer.get('type', '')
-
-            # Status
-            status = analyzer.get('status', '')
-
-            # Created at
-            created_at = analyzer.get('createdAt', '')
-            if created_at:
-                created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
-
-            # Last resource analyzed
-            last_resource_analyzed = analyzer.get('lastResourceAnalyzed', 'N/A')
-
-            # Last resource analyzed at
-            last_resource_analyzed_at = analyzer.get('lastResourceAnalyzedAt', '')
-            if last_resource_analyzed_at:
-                last_resource_analyzed_at = last_resource_analyzed_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_resource_analyzed_at, datetime.datetime) else str(last_resource_analyzed_at)
-            else:
-                last_resource_analyzed_at = 'Never'
-
-            # Tags
-            tags = analyzer.get('tags', {})
-            tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-            # Status reason
-            status_reason = analyzer.get('statusReason', {})
-            status_reason_code = status_reason.get('code', 'N/A')
-
-            analyzers_data.append({
-                'Region': region,
-                'Analyzer Name': analyzer_name,
-                'Type': analyzer_type,
-                'Status': status,
-                'Status Reason': status_reason_code,
-                'Last Resource Analyzed': last_resource_analyzed,
-                'Last Analysis Time': last_resource_analyzed_at,
-                'Created At': created_at,
-                'Tags': tags_str,
-                'Analyzer ARN': analyzer_arn
-            })
+            try:
+                analyzers_data.append(_build_analyzer_row(analyzer, region))
+            except Exception as e:
+                # One malformed analyzer is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Access Analyzer in {region}: "
+                    f"{analyzer.get('name', '<unknown>')}",
+                    e,
+                )
+                continue
 
     utils.log_info(f"Found {len(analyzers_data)} analyzers in {region}")
     return analyzers_data
 
 
-def collect_analyzers(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect IAM Access Analyzer information using concurrent scanning."""
+def collect_analyzers(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect IAM Access Analyzer information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(analyzers, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING ACCESS ANALYZERS ===")
     utils.log_info(f"Scanning {len(regions)} regions for Access Analyzers...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_analyzers_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -136,7 +187,7 @@ def collect_analyzers(regions: list[str]) -> list[dict[str, Any]]:
         all_analyzers.extend(analyzers_in_region)
 
     utils.log_success(f"Total Access Analyzers collected: {len(all_analyzers)}")
-    return all_analyzers
+    return all_analyzers, failed_regions
 
 
 @utils.aws_error_handler("Collecting active findings from region", default_return=[])
@@ -478,8 +529,9 @@ def export_access_analyzer_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect analyzers
-    analyzers = collect_analyzers(regions)
+    # STEP 1: Collect analyzers (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    analyzers, failed_regions = collect_analyzers(regions)
     if analyzers:
         data_frames['Analyzers'] = pd.DataFrame(analyzers)
 
@@ -498,43 +550,56 @@ def export_access_analyzer_data(account_id: str, account_name: str):
     if archive_rules:
         data_frames['Archive Rules'] = pd.DataFrame(archive_rules)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'access-analyzer',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Access Analyzer data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Access Analyzer data was collected. Nothing to export.")
         print("\nNo Access Analyzers found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'access-analyzer',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Access Analyzer data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the Analyzers scope collection, make it loud: write
+    # a marker and exit non-zero, even if some data was exported. A partial
+    # export that looks complete is exactly the failure mode this guards
+    # against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'access-analyzer', failed_regions)
+        print(
+            "\nERROR: Access Analyzer export completed with failures — data is incomplete. "
+            "See the *-access-analyzer-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/config_export.py
+++ b/scripts/config_export.py
@@ -47,16 +47,111 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Config rules, recorders, and compliance data to Excel")
 
 
-@utils.aws_error_handler("Collecting Config recorders from region", default_return=[])
-def collect_configuration_recorders_from_region(region: str) -> list[dict[str, Any]]:
+def _build_recorder_row(recorder: dict, region: str, config_client: Any) -> dict[str, Any]:
     """
-    Collect AWS Config configuration recorder information from a single region.
+    Build the export row for a single Config configuration recorder.
+
+    Extracted so per-recorder processing can be wrapped in try/except by the
+    caller: a malformed recorder entry is logged and skipped rather than
+    discarding the whole region's results.
+
+    Args:
+        recorder: A single ConfigurationRecorders entry.
+        region: AWS region name.
+        config_client: boto3 Config client for the region (used to fetch
+            recorder status).
+
+    Returns:
+        dict: The assembled recorder row.
+    """
+    recorder_name = recorder.get('name', '')
+    utils.log_info(f"Processing recorder: {recorder_name} in {region}")
+
+    # Role ARN
+    role_arn = recorder.get('roleARN', '')
+
+    # Recording group
+    recording_group = recorder.get('recordingGroup', {})
+    all_supported = recording_group.get('allSupported', False)
+    include_global_resources = recording_group.get('includeGlobalResourceTypes', False)
+    resource_types = recording_group.get('resourceTypes', [])
+    resource_type_count = len(resource_types)
+
+    # Get recorder status
+    try:
+        status_response = config_client.describe_configuration_recorder_status(
+            ConfigurationRecorderNames=[recorder_name]
+        )
+        statuses = status_response.get('ConfigurationRecordersStatus', [])
+
+        if statuses:
+            status = statuses[0]
+            recording = status.get('recording', False)
+            last_status = status.get('lastStatus', 'N/A')
+
+            last_start_time = status.get('lastStartTime', '')
+            if last_start_time:
+                last_start_time = last_start_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_start_time, datetime.datetime) else str(last_start_time)
+
+            last_stop_time = status.get('lastStopTime', '')
+            if last_stop_time:
+                last_stop_time = last_stop_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_stop_time, datetime.datetime) else str(last_stop_time)
+
+            last_status_change = status.get('lastStatusChangeTime', '')
+            if last_status_change:
+                last_status_change = last_status_change.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_status_change, datetime.datetime) else str(last_status_change)
+        else:
+            recording = False
+            last_status = 'Unknown'
+            last_start_time = 'N/A'
+            last_stop_time = 'N/A'
+            last_status_change = 'N/A'
+
+    except Exception:
+        recording = False
+        last_status = 'Unknown'
+        last_start_time = 'N/A'
+        last_stop_time = 'N/A'
+        last_status_change = 'N/A'
+
+    return {
+        'Region': region,
+        'Recorder Name': recorder_name,
+        'Recording': recording,
+        'Last Status': last_status,
+        'Role ARN': role_arn,
+        'All Supported': all_supported,
+        'Include Global Resources': include_global_resources,
+        'Resource Type Count': resource_type_count,
+        'Last Start': last_start_time,
+        'Last Stop': last_stop_time if last_stop_time != 'N/A' else 'N/A',
+        'Last Status Change': last_status_change
+    }
+
+
+def _scan_recorders_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect AWS Config configuration recorders from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no recorders" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed recorders are skipped (logged) rather than aborting
+    the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with recorder information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
         utils.log_error(f"Skipping invalid AWS region: {region}")
@@ -71,92 +166,45 @@ def collect_configuration_recorders_from_region(region: str) -> list[dict[str, A
     recorders = recorders_response.get('ConfigurationRecorders', [])
 
     for recorder in recorders:
-        recorder_name = recorder.get('name', '')
-        utils.log_info(f"Processing recorder: {recorder_name} in {region}")
-
-        # Role ARN
-        role_arn = recorder.get('roleARN', '')
-
-        # Recording group
-        recording_group = recorder.get('recordingGroup', {})
-        all_supported = recording_group.get('allSupported', False)
-        include_global_resources = recording_group.get('includeGlobalResourceTypes', False)
-        resource_types = recording_group.get('resourceTypes', [])
-        resource_type_count = len(resource_types)
-
-        # Get recorder status
         try:
-            status_response = config_client.describe_configuration_recorder_status(
-                ConfigurationRecorderNames=[recorder_name]
+            recorders_data.append(_build_recorder_row(recorder, region, config_client))
+        except Exception as e:
+            utils.log_error(
+                f"Skipping malformed configuration recorder in {region}: "
+                f"{recorder.get('name', '<unknown>')}",
+                e,
             )
-            statuses = status_response.get('ConfigurationRecordersStatus', [])
-
-            if statuses:
-                status = statuses[0]
-                recording = status.get('recording', False)
-                last_status = status.get('lastStatus', 'N/A')
-
-                last_start_time = status.get('lastStartTime', '')
-                if last_start_time:
-                    last_start_time = last_start_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_start_time, datetime.datetime) else str(last_start_time)
-
-                last_stop_time = status.get('lastStopTime', '')
-                if last_stop_time:
-                    last_stop_time = last_stop_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_stop_time, datetime.datetime) else str(last_stop_time)
-
-                last_status_change = status.get('lastStatusChangeTime', '')
-                if last_status_change:
-                    last_status_change = last_status_change.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_status_change, datetime.datetime) else str(last_status_change)
-            else:
-                recording = False
-                last_status = 'Unknown'
-                last_start_time = 'N/A'
-                last_stop_time = 'N/A'
-                last_status_change = 'N/A'
-
-        except Exception:
-            recording = False
-            last_status = 'Unknown'
-            last_start_time = 'N/A'
-            last_stop_time = 'N/A'
-            last_status_change = 'N/A'
-
-        recorders_data.append({
-            'Region': region,
-            'Recorder Name': recorder_name,
-            'Recording': recording,
-            'Last Status': last_status,
-            'Role ARN': role_arn,
-            'All Supported': all_supported,
-            'Include Global Resources': include_global_resources,
-            'Resource Type Count': resource_type_count,
-            'Last Start': last_start_time,
-            'Last Stop': last_stop_time if last_stop_time != 'N/A' else 'N/A',
-            'Last Status Change': last_status_change
-        })
+            continue
 
     utils.log_info(f"Found {len(recorders_data)} recorders in {region}")
     return recorders_data
 
 
-def collect_configuration_recorders(regions: list[str]) -> list[dict[str, Any]]:
+def collect_configuration_recorders(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect AWS Config configuration recorder information using concurrent scanning.
+    Collect AWS Config configuration recorder information across regions,
+    surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with recorder information
+        tuple: ``(recorders, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING CONFIGURATION RECORDERS ===")
     utils.log_info(f"Scanning {len(regions)} regions for configuration recorders...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=collect_configuration_recorders_from_region,
-        show_progress=True
+        scan_function=_scan_recorders_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -165,19 +213,58 @@ def collect_configuration_recorders(regions: list[str]) -> list[dict[str, Any]]:
         all_recorders.extend(recorders_in_region)
 
     utils.log_success(f"Total configuration recorders collected: {len(all_recorders)}")
-    return all_recorders
+    return all_recorders, failed_regions
 
 
-@utils.aws_error_handler("Collecting delivery channels from region", default_return=[])
-def collect_delivery_channels_from_region(region: str) -> list[dict[str, Any]]:
+def _build_channel_row(channel: dict, region: str) -> dict[str, Any]:
+    """Build the export row for a single Config delivery channel."""
+    channel_name = channel.get('name', '')
+
+    # S3 bucket
+    s3_bucket = channel.get('s3BucketName', '')
+
+    # S3 key prefix
+    s3_prefix = channel.get('s3KeyPrefix', 'N/A')
+
+    # S3 KMS key
+    s3_kms_key = channel.get('s3KmsKeyArn', 'N/A')
+
+    # SNS topic
+    sns_topic = channel.get('snsTopicARN', 'N/A')
+
+    # Config snapshot delivery properties
+    snapshot_props = channel.get('configSnapshotDeliveryProperties', {})
+    delivery_frequency = snapshot_props.get('deliveryFrequency', 'N/A')
+
+    return {
+        'Region': region,
+        'Channel Name': channel_name,
+        'S3 Bucket': s3_bucket,
+        'S3 Prefix': s3_prefix,
+        'S3 KMS Key': s3_kms_key,
+        'SNS Topic': sns_topic,
+        'Delivery Frequency': delivery_frequency
+    }
+
+
+def _scan_delivery_channels_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect AWS Config delivery channel information from a single region.
+    Collect AWS Config delivery channels from a single region.
+
+    Region-level failures are allowed to raise so ``scan_regions_concurrent``
+    can record the region as FAILED rather than empty (see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+    Per-channel errors are contained internally (logged and skipped) via
+    ``_build_channel_row``.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with delivery channel information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     if not utils.is_aws_region(region):
         return []
@@ -191,56 +278,41 @@ def collect_delivery_channels_from_region(region: str) -> list[dict[str, Any]]:
     channels = channels_response.get('DeliveryChannels', [])
 
     for channel in channels:
-        channel_name = channel.get('name', '')
-
-        # S3 bucket
-        s3_bucket = channel.get('s3BucketName', '')
-
-        # S3 key prefix
-        s3_prefix = channel.get('s3KeyPrefix', 'N/A')
-
-        # S3 KMS key
-        s3_kms_key = channel.get('s3KmsKeyArn', 'N/A')
-
-        # SNS topic
-        sns_topic = channel.get('snsTopicARN', 'N/A')
-
-        # Config snapshot delivery properties
-        snapshot_props = channel.get('configSnapshotDeliveryProperties', {})
-        delivery_frequency = snapshot_props.get('deliveryFrequency', 'N/A')
-
-        channels_data.append({
-            'Region': region,
-            'Channel Name': channel_name,
-            'S3 Bucket': s3_bucket,
-            'S3 Prefix': s3_prefix,
-            'S3 KMS Key': s3_kms_key,
-            'SNS Topic': sns_topic,
-            'Delivery Frequency': delivery_frequency
-        })
+        try:
+            channels_data.append(_build_channel_row(channel, region))
+        except Exception as e:
+            utils.log_error(
+                f"Skipping malformed delivery channel in {region}: "
+                f"{channel.get('name', '<unknown>')}",
+                e,
+            )
+            continue
 
     utils.log_info(f"Found {len(channels_data)} delivery channels in {region}")
     return channels_data
 
 
-def collect_delivery_channels(regions: list[str]) -> list[dict[str, Any]]:
+def collect_delivery_channels(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect AWS Config delivery channel information using concurrent scanning.
+    Collect AWS Config delivery channel information across regions, surfacing
+    failures.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with delivery channel information
+        tuple: ``(channels, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING DELIVERY CHANNELS ===")
     utils.log_info(f"Scanning {len(regions)} regions for delivery channels...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=collect_delivery_channels_from_region,
-        show_progress=True
+        scan_function=_scan_delivery_channels_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -249,19 +321,99 @@ def collect_delivery_channels(regions: list[str]) -> list[dict[str, Any]]:
         all_channels.extend(channels_in_region)
 
     utils.log_success(f"Total delivery channels collected: {len(all_channels)}")
-    return all_channels
+    return all_channels, failed_regions
 
 
-@utils.aws_error_handler("Collecting Config rules from region", default_return=[])
-def collect_config_rules_from_region(region: str) -> list[dict[str, Any]]:
+def _build_rule_row(rule: dict, region: str, config_client: Any) -> dict[str, Any]:
     """
-    Collect AWS Config rule information from a single region with compliance status.
+    Build the export row for a single Config rule, including compliance status.
+
+    Args:
+        rule: A single ConfigRules entry.
+        region: AWS region name.
+        config_client: boto3 Config client for the region (used to fetch
+            compliance status).
+
+    Returns:
+        dict: The assembled rule row.
+    """
+    rule_name = rule.get('ConfigRuleName', '')
+    rule_arn = rule.get('ConfigRuleArn', '')
+    rule_id = rule.get('ConfigRuleId', '')
+
+    # Description
+    description = rule.get('Description', 'N/A')
+
+    # Source
+    source = rule.get('Source', {})
+    source_identifier = source.get('SourceIdentifier', '')
+    owner = source.get('Owner', '')
+
+    # State
+    state = rule.get('ConfigRuleState', '')
+
+    # Get compliance status
+    compliance_status = 'UNKNOWN'
+    compliant_count = 0
+    non_compliant_count = 0
+
+    try:
+        compliance_response = config_client.describe_compliance_by_config_rule(
+            ConfigRuleNames=[rule_name]
+        )
+        compliance_results = compliance_response.get('ComplianceByConfigRules', [])
+
+        if compliance_results:
+            compliance = compliance_results[0].get('Compliance', {})
+            compliance_status = compliance.get('ComplianceType', 'UNKNOWN')
+
+            # Get detailed counts
+            try:
+                summary_response = config_client.get_compliance_summary_by_config_rule()
+                summary = summary_response.get('ComplianceSummary', {})
+                compliant_summary = summary.get('CompliantResourceCount', {})
+                non_compliant_summary = summary.get('NonCompliantResourceCount', {})
+                compliant_count = compliant_summary.get('CappedCount', 0)
+                non_compliant_count = non_compliant_summary.get('CappedCount', 0)
+            except Exception:
+                pass
+
+    except Exception:
+        pass
+
+    return {
+        'Region': region,
+        'Rule Name': rule_name,
+        'Rule ID': rule_id,
+        'State': state,
+        'Compliance Status': compliance_status,
+        'Compliant Resources': compliant_count,
+        'Non-Compliant Resources': non_compliant_count,
+        'Owner': owner,
+        'Source Identifier': source_identifier,
+        'Description': description[:200] + '...' if len(description) > 200 else description,
+        'Rule ARN': rule_arn
+    }
+
+
+def _scan_config_rules_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect AWS Config rules (with compliance status) from a single region.
+
+    Region-level failures are allowed to raise so ``scan_regions_concurrent``
+    can record the region as FAILED rather than empty (see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+    Per-rule errors are contained internally (logged and skipped) via
+    ``_build_rule_row``.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with config rule information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     if not utils.is_aws_region(region):
         return []
@@ -277,86 +429,40 @@ def collect_config_rules_from_region(region: str) -> list[dict[str, Any]]:
         rules = rules_page.get('ConfigRules', [])
 
         for rule in rules:
-            rule_name = rule.get('ConfigRuleName', '')
-            rule_arn = rule.get('ConfigRuleArn', '')
-            rule_id = rule.get('ConfigRuleId', '')
-
-            # Description
-            description = rule.get('Description', 'N/A')
-
-            # Source
-            source = rule.get('Source', {})
-            source_identifier = source.get('SourceIdentifier', '')
-            owner = source.get('Owner', '')
-
-            # State
-            state = rule.get('ConfigRuleState', '')
-
-            # Get compliance status
-            compliance_status = 'UNKNOWN'
-            compliant_count = 0
-            non_compliant_count = 0
-
             try:
-                compliance_response = config_client.describe_compliance_by_config_rule(
-                    ConfigRuleNames=[rule_name]
+                rules_data.append(_build_rule_row(rule, region, config_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Config rule in {region}: "
+                    f"{rule.get('ConfigRuleName', '<unknown>')}",
+                    e,
                 )
-                compliance_results = compliance_response.get('ComplianceByConfigRules', [])
-
-                if compliance_results:
-                    compliance = compliance_results[0].get('Compliance', {})
-                    compliance_status = compliance.get('ComplianceType', 'UNKNOWN')
-
-                    # Get detailed counts
-                    try:
-                        summary_response = config_client.get_compliance_summary_by_config_rule()
-                        summary = summary_response.get('ComplianceSummary', {})
-                        compliant_summary = summary.get('CompliantResourceCount', {})
-                        non_compliant_summary = summary.get('NonCompliantResourceCount', {})
-                        compliant_count = compliant_summary.get('CappedCount', 0)
-                        non_compliant_count = non_compliant_summary.get('CappedCount', 0)
-                    except Exception:
-                        pass
-
-            except Exception:
-                pass
-
-            rules_data.append({
-                'Region': region,
-                'Rule Name': rule_name,
-                'Rule ID': rule_id,
-                'State': state,
-                'Compliance Status': compliance_status,
-                'Compliant Resources': compliant_count,
-                'Non-Compliant Resources': non_compliant_count,
-                'Owner': owner,
-                'Source Identifier': source_identifier,
-                'Description': description[:200] + '...' if len(description) > 200 else description,
-                'Rule ARN': rule_arn
-            })
+                continue
 
     utils.log_info(f"Found {len(rules_data)} Config rules in {region}")
     return rules_data
 
 
-def collect_config_rules(regions: list[str]) -> list[dict[str, Any]]:
+def collect_config_rules(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect AWS Config rule information using concurrent scanning.
+    Collect AWS Config rule information across regions, surfacing failures.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with config rule information
+        tuple: ``(rules, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING CONFIG RULES ===")
     utils.log_info(f"Scanning {len(regions)} regions for Config rules...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=collect_config_rules_from_region,
-        show_progress=True
+        scan_function=_scan_config_rules_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -365,19 +471,83 @@ def collect_config_rules(regions: list[str]) -> list[dict[str, Any]]:
         all_rules.extend(rules_in_region)
 
     utils.log_success(f"Total Config rules collected: {len(all_rules)}")
-    return all_rules
+    return all_rules, failed_regions
 
 
-@utils.aws_error_handler("Collecting conformance packs from region", default_return=[])
-def collect_conformance_packs_from_region(region: str) -> list[dict[str, Any]]:
+def _build_pack_row(pack: dict, region: str, config_client: Any) -> dict[str, Any]:
     """
-    Collect AWS Config conformance pack information from a single region.
+    Build the export row for a single Config conformance pack, including
+    compliance status.
+
+    Args:
+        pack: A single ConformancePackDetails entry.
+        region: AWS region name.
+        config_client: boto3 Config client for the region (used to fetch
+            compliance status).
+
+    Returns:
+        dict: The assembled conformance pack row.
+    """
+    pack_name = pack.get('ConformancePackName', '')
+    pack_arn = pack.get('ConformancePackArn', '')
+    pack_id = pack.get('ConformancePackId', '')
+
+    # Created by
+    created_by = pack.get('CreatedBy', 'N/A')
+
+    # Delivery S3 bucket
+    delivery_s3_bucket = pack.get('DeliveryS3Bucket', 'N/A')
+
+    # Get compliance status
+    compliance_status = 'UNKNOWN'
+    try:
+        compliance_response = config_client.describe_conformance_pack_compliance(
+            ConformancePackName=pack_name
+        )
+        rules_compliance = compliance_response.get('ConformancePackRuleComplianceList', [])
+
+        compliant = sum(1 for r in rules_compliance if r.get('ComplianceType') == 'COMPLIANT')
+        non_compliant = sum(1 for r in rules_compliance if r.get('ComplianceType') == 'NON_COMPLIANT')
+
+        if non_compliant > 0:
+            compliance_status = f"{compliant} compliant, {non_compliant} non-compliant"
+        elif compliant > 0:
+            compliance_status = f"{compliant} compliant"
+        else:
+            compliance_status = 'No rules evaluated'
+
+    except Exception:
+        pass
+
+    return {
+        'Region': region,
+        'Pack Name': pack_name,
+        'Pack ID': pack_id,
+        'Compliance Status': compliance_status,
+        'Created By': created_by,
+        'Delivery S3 Bucket': delivery_s3_bucket,
+        'Pack ARN': pack_arn
+    }
+
+
+def _scan_conformance_packs_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect AWS Config conformance packs from a single region.
+
+    Region-level failures are allowed to raise so ``scan_regions_concurrent``
+    can record the region as FAILED rather than empty (see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+    Per-pack errors are contained internally (logged and skipped) via
+    ``_build_pack_row``.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with conformance pack information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region.
     """
     if not utils.is_aws_region(region):
         return []
@@ -393,69 +563,41 @@ def collect_conformance_packs_from_region(region: str) -> list[dict[str, Any]]:
         packs = packs_page.get('ConformancePackDetails', [])
 
         for pack in packs:
-            pack_name = pack.get('ConformancePackName', '')
-            pack_arn = pack.get('ConformancePackArn', '')
-            pack_id = pack.get('ConformancePackId', '')
-
-            # Created by
-            created_by = pack.get('CreatedBy', 'N/A')
-
-            # Delivery S3 bucket
-            delivery_s3_bucket = pack.get('DeliveryS3Bucket', 'N/A')
-
-            # Get compliance status
-            compliance_status = 'UNKNOWN'
             try:
-                compliance_response = config_client.describe_conformance_pack_compliance(
-                    ConformancePackName=pack_name
+                packs_data.append(_build_pack_row(pack, region, config_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed conformance pack in {region}: "
+                    f"{pack.get('ConformancePackName', '<unknown>')}",
+                    e,
                 )
-                rules_compliance = compliance_response.get('ConformancePackRuleComplianceList', [])
-
-                compliant = sum(1 for r in rules_compliance if r.get('ComplianceType') == 'COMPLIANT')
-                non_compliant = sum(1 for r in rules_compliance if r.get('ComplianceType') == 'NON_COMPLIANT')
-
-                if non_compliant > 0:
-                    compliance_status = f"{compliant} compliant, {non_compliant} non-compliant"
-                elif compliant > 0:
-                    compliance_status = f"{compliant} compliant"
-                else:
-                    compliance_status = 'No rules evaluated'
-
-            except Exception:
-                pass
-
-            packs_data.append({
-                'Region': region,
-                'Pack Name': pack_name,
-                'Pack ID': pack_id,
-                'Compliance Status': compliance_status,
-                'Created By': created_by,
-                'Delivery S3 Bucket': delivery_s3_bucket,
-                'Pack ARN': pack_arn
-            })
+                continue
 
     utils.log_info(f"Found {len(packs_data)} conformance packs in {region}")
     return packs_data
 
 
-def collect_conformance_packs(regions: list[str]) -> list[dict[str, Any]]:
+def collect_conformance_packs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect AWS Config conformance pack information using concurrent scanning.
+    Collect AWS Config conformance pack information across regions, surfacing
+    failures.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with conformance pack information
+        tuple: ``(packs, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING CONFORMANCE PACKS ===")
     utils.log_info(f"Scanning {len(regions)} regions for conformance packs...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=collect_conformance_packs_from_region,
-        show_progress=True
+        scan_function=_scan_conformance_packs_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -464,7 +606,7 @@ def collect_conformance_packs(regions: list[str]) -> list[dict[str, Any]]:
         all_packs.extend(packs_in_region)
 
     utils.log_success(f"Total conformance packs collected: {len(all_packs)}")
-    return all_packs
+    return all_packs, failed_regions
 
 
 def export_config_data(account_id: str, account_name: str):
@@ -484,63 +626,87 @@ def export_config_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect configuration recorders
-    recorders = collect_configuration_recorders(regions)
+    # Combined failed-region list across all four region-scanned scopes
+    # (recorders, delivery channels, rules, conformance packs). Any scope's
+    # failure must be surfaced — a partial export that looks complete is
+    # exactly the failure mode this guards against (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    failed_regions = []
+
+    # STEP 1: Collect configuration recorders (scope collection — region
+    # failures must propagate as failed_regions, never collapse into "empty").
+    recorders, recorder_failures = collect_configuration_recorders(regions)
+    failed_regions.extend(recorder_failures)
     if recorders:
         data_frames['Configuration Recorders'] = pd.DataFrame(recorders)
 
-    # STEP 2: Collect delivery channels
-    channels = collect_delivery_channels(regions)
+    # STEP 2: Collect delivery channels (scope collection)
+    channels, channel_failures = collect_delivery_channels(regions)
+    failed_regions.extend(channel_failures)
     if channels:
         data_frames['Delivery Channels'] = pd.DataFrame(channels)
 
-    # STEP 3: Collect Config rules
-    rules = collect_config_rules(regions)
+    # STEP 3: Collect Config rules (scope collection)
+    rules, rule_failures = collect_config_rules(regions)
+    failed_regions.extend(rule_failures)
     if rules:
         data_frames['Config Rules'] = pd.DataFrame(rules)
 
-    # STEP 4: Collect conformance packs
-    packs = collect_conformance_packs(regions)
+    # STEP 4: Collect conformance packs (scope collection)
+    packs, pack_failures = collect_conformance_packs(regions)
+    failed_regions.extend(pack_failures)
     if packs:
         data_frames['Conformance Packs'] = pd.DataFrame(packs)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed.
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'config',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("AWS Config data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No AWS Config data was collected. Nothing to export.")
         print("\nNo AWS Config resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'config',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("AWS Config data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY scope failed in ANY region, make it loud: write a marker and
+    # exit non-zero, even if some data was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'config', failed_regions)
+        print(
+            "\nERROR: AWS Config export completed with failures — data is incomplete. "
+            "See the *-config-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/detective_export.py
+++ b/scripts/detective_export.py
@@ -47,61 +47,81 @@ except ImportError:
 args = utils.parse_script_args("Export Amazon Detective graphs and findings to Excel")
 
 
-@utils.aws_error_handler("Collecting Detective graphs", default_return=[])
-def collect_graphs(region: str) -> list[dict[str, Any]]:
+def _scan_graphs_region(region: str) -> list[dict[str, Any]]:
     """
-    Collect Detective graphs from a specific region.
+    Collect Detective graphs from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Detective graphs" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed graphs are skipped (logged) rather than aborting the
+    whole region.
 
     Args:
         region: AWS region to collect graphs from
 
     Returns:
         list: List of graph information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
-    graphs_data = []
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     client = utils.get_boto3_client('detective', region_name=region)
 
-    try:
-        # List graphs
-        response = client.list_graphs()
-        graphs = response.get('GraphList', [])
+    response = client.list_graphs()
+    graphs = response.get('GraphList', [])
 
-        if not graphs:
-            utils.log_info(f"No Detective graphs found in {region}")
-            return []
+    if not graphs:
+        utils.log_info(f"No Detective graphs found in {region}")
+        return []
 
-        utils.log_info(f"Found {len(graphs)} Detective graph(s) in {region}")
+    utils.log_info(f"Found {len(graphs)} Detective graph(s) in {region}")
 
-        for graph in graphs:
-            graph_arn = graph.get('Arn', 'N/A')
-
-            # Get member count by listing members
-            member_count = 0
-            try:
-                members_response = client.list_members(GraphArn=graph_arn)
-                member_count = len(members_response.get('MemberDetails', []))
-            except Exception as e:
-                utils.log_debug(f"Could not get member count for graph {graph_arn}: {e}")
-
-            graph_info = {
-                'Region': region,
-                'Graph ARN': graph_arn,
-                'Created Time': graph.get('CreatedTime', 'N/A'),
-                'Status': 'Active',  # Graphs returned by list_graphs are active
-                'Member Count': member_count,
-                'Tags': format_tags(graph_arn, client)
-            }
-
-            graphs_data.append(graph_info)
-
-    except ClientError as e:
-        error_code = e.response['Error']['Code']
-        if error_code == 'AccessDeniedException':
-            utils.log_warning(f"Detective not available or access denied in {region}")
-        else:
-            utils.log_error(f"Error collecting Detective graphs from {region}: {error_code}")
+    graphs_data = []
+    for graph in graphs:
+        try:
+            graphs_data.append(_build_graph_row(graph, region, client))
+        except Exception as e:
+            # One malformed graph is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed Detective graph in {region}: "
+                f"{graph.get('Arn', '<unknown>')}",
+                e,
+            )
+            continue
 
     return graphs_data
+
+
+def _build_graph_row(graph: dict, region: str, client) -> dict[str, Any]:
+    """Build a single Detective graph export row."""
+    graph_arn = graph.get('Arn', 'N/A')
+
+    # Get member count by listing members (enrichment — degrades gracefully)
+    member_count = 0
+    try:
+        members_response = client.list_members(GraphArn=graph_arn)
+        member_count = len(members_response.get('MemberDetails', []))
+    except Exception as e:
+        utils.log_debug(f"Could not get member count for graph {graph_arn}: {e}")
+
+    return {
+        'Region': region,
+        'Graph ARN': graph_arn,
+        'Created Time': graph.get('CreatedTime', 'N/A'),
+        'Status': 'Active',  # Graphs returned by list_graphs are active
+        'Member Count': member_count,
+        'Tags': format_tags(graph_arn, client)
+    }
 
 
 @utils.aws_error_handler("Collecting Detective members", default_return=[])
@@ -278,23 +298,29 @@ def format_tags(resource_arn: str, client) -> str:
         return 'N/A'
 
 
-def collect_all_graphs(regions: list[str]) -> list[dict[str, Any]]:
+def collect_graphs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Detective graphs using concurrent scanning.
+    Collect Detective graphs across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of all graph information from all regions
+        tuple: ``(graphs, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING DETECTIVE GRAPHS ===")
     utils.log_info(f"Scanning {len(regions)} regions for Detective graphs...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=collect_graphs,
-        show_progress=True
+        scan_function=_scan_graphs_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -303,7 +329,7 @@ def collect_all_graphs(regions: list[str]) -> list[dict[str, Any]]:
         all_graphs.extend(graphs_in_region)
 
     utils.log_success(f"Total Detective graphs collected: {len(all_graphs)}")
-    return all_graphs
+    return all_graphs, failed_regions
 
 
 def collect_all_invitations(regions: list[str]) -> list[dict[str, Any]]:
@@ -496,10 +522,13 @@ def main():
 
         utils.log_info(f"Will scan Detective in regions: {', '.join(regions)}")
 
-        # Collect graphs concurrently
-        all_graphs_data = collect_all_graphs(regions)
+        # Collect graphs concurrently (primary scope — region failures must
+        # propagate as failed_regions, never collapse into "empty").
+        all_graphs_data, failed_regions = collect_graphs(regions)
 
-        # For each graph, collect members (members need graph ARNs, so sequential is OK)
+        # For each graph, collect members (members need graph ARNs, so
+        # sequential is OK). Enrichment — a per-graph failure degrades
+        # gracefully and does not fail the whole export.
         all_members_data = []
         for graph in all_graphs_data:
             graph_arn = graph.get('Graph ARN')
@@ -512,32 +541,46 @@ def main():
         # Collect invitations concurrently
         all_invitations_data = collect_all_invitations(regions)
 
-        # Check if any data was collected
-        if not all_graphs_data and not all_invitations_data:
+        # Export whatever succeeded first — a partial export is required even
+        # when some regions failed (see the silent-collection-failure
+        # blast-radius audit).
+        if all_graphs_data or all_invitations_data:
+            print("\n====================================================================")
+            print("COLLECTION COMPLETE")
+            print("====================================================================")
+
+            # Export to Excel
+            filename = export_to_excel(
+                all_graphs_data,
+                all_members_data,
+                all_invitations_data,
+                account_name
+            )
+
+            if filename:
+                utils.log_info(f"Total graphs processed: {len(all_graphs_data)}")
+                utils.log_info(f"Total members processed: {len(all_members_data)}")
+                utils.log_info(f"Total invitations processed: {len(all_invitations_data)}")
+                print("\nScript execution completed.")
+            else:
+                utils.log_error("Export failed. Please check the logs.")
+        elif not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
             utils.log_warning("No Detective data found in any region.")
             utils.log_info("Detective may not be enabled in this account.")
             utils.log_info("To enable Detective, visit the AWS Console > Detective > Enable Detective")
-            return
 
-        print("\n====================================================================")
-        print("COLLECTION COMPLETE")
-        print("====================================================================")
-
-        # Export to Excel
-        filename = export_to_excel(
-            all_graphs_data,
-            all_members_data,
-            all_invitations_data,
-            account_name
-        )
-
-        if filename:
-            utils.log_info(f"Total graphs processed: {len(all_graphs_data)}")
-            utils.log_info(f"Total members processed: {len(all_members_data)}")
-            utils.log_info(f"Total invitations processed: {len(all_invitations_data)}")
-            print("\nScript execution completed.")
-        else:
-            utils.log_error("Export failed. Please check the logs.")
+        # If ANY region failed the primary graphs scope collection, make it
+        # loud: write a marker and exit non-zero, even if some data was
+        # exported. A partial export that looks complete is exactly the
+        # failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'detective', failed_regions)
+            print(
+                "\nERROR: Detective export completed with failures — data is incomplete. "
+                "See the *-detective-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/guardduty_export.py
+++ b/scripts/guardduty_export.py
@@ -47,16 +47,103 @@ except ImportError:
 args = utils.parse_script_args("Export GuardDuty detectors and findings to Excel")
 
 
-@utils.aws_error_handler("Collecting GuardDuty detectors from region", default_return=[])
+def _build_detector_row(detector: dict, detector_id: str, region: str) -> dict[str, Any]:
+    """
+    Build a single GuardDuty detector export row from a get_detector response.
+
+    Extracted so the per-detector processing can be wrapped in try/except by
+    the caller: a malformed detector entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        detector: The get_detector response body.
+        detector_id: The detector's ID.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled detector row.
+    """
+    # Status
+    status = detector.get('Status', '')
+
+    # Service role
+    service_role = detector.get('ServiceRole', 'N/A')
+
+    # Data sources
+    data_sources = detector.get('DataSources', {})
+    cloud_trail = data_sources.get('CloudTrail', {}).get('Status', 'N/A')
+    dns_logs = data_sources.get('DNSLogs', {}).get('Status', 'N/A')
+    flow_logs = data_sources.get('FlowLogs', {}).get('Status', 'N/A')
+    s3_logs = data_sources.get('S3Logs', {}).get('Status', 'N/A')
+    kubernetes = data_sources.get('Kubernetes', {})
+    k8s_audit_logs = kubernetes.get('AuditLogs', {}).get('Status', 'N/A') if kubernetes else 'N/A'
+
+    # Finding publishing frequency
+    finding_frequency = detector.get('FindingPublishingFrequency', 'N/A')
+
+    # Created at
+    created_at = detector.get('CreatedAt', '')
+    if created_at:
+        created_at = created_at if isinstance(created_at, str) else created_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Updated at
+    updated_at = detector.get('UpdatedAt', '')
+    if updated_at:
+        updated_at = updated_at if isinstance(updated_at, str) else updated_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Protection features (newer GuardDuty categories: EKS Runtime, RDS, Lambda, Malware)
+    features = detector.get('Features', [])
+    features_str = ', '.join(
+        f"{f.get('Name', '')}: {f.get('Status', '')}"
+        for f in features
+    ) if features else 'N/A'
+
+    # Tags
+    tags = detector.get('Tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Detector ID': detector_id,
+        'Status': status,
+        'Finding Frequency': finding_frequency,
+        'CloudTrail': cloud_trail,
+        'DNS Logs': dns_logs,
+        'VPC Flow Logs': flow_logs,
+        'S3 Logs': s3_logs,
+        'Kubernetes Audit Logs': k8s_audit_logs,
+        'Protection Features': features_str,
+        'Service Role': service_role,
+        'Created At': created_at,
+        'Updated At': updated_at,
+        'Tags': tags_str
+    }
+
+
 def collect_detectors_from_region(region: str) -> list[dict[str, Any]]:
     """
     Collect GuardDuty detector information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no GuardDuty detectors" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/unreachable detectors are skipped (logged) rather
+    than aborting the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with detector information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
         utils.log_error(f"Skipping invalid AWS region: {region}")
@@ -77,91 +164,45 @@ def collect_detectors_from_region(region: str) -> list[dict[str, Any]]:
     for detector_id in detector_ids:
         utils.log_info(f"Processing detector: {detector_id} in {region}")
 
+        # One malformed/unreachable detector is skipped, not fatal to the
+        # region.
         try:
-            # Get detector details
             detector = gd_client.get_detector(DetectorId=detector_id)
-
-            # Status
-            status = detector.get('Status', '')
-
-            # Service role
-            service_role = detector.get('ServiceRole', 'N/A')
-
-            # Data sources
-            data_sources = detector.get('DataSources', {})
-            cloud_trail = data_sources.get('CloudTrail', {}).get('Status', 'N/A')
-            dns_logs = data_sources.get('DNSLogs', {}).get('Status', 'N/A')
-            flow_logs = data_sources.get('FlowLogs', {}).get('Status', 'N/A')
-            s3_logs = data_sources.get('S3Logs', {}).get('Status', 'N/A')
-            kubernetes = data_sources.get('Kubernetes', {})
-            k8s_audit_logs = kubernetes.get('AuditLogs', {}).get('Status', 'N/A') if kubernetes else 'N/A'
-
-            # Finding publishing frequency
-            finding_frequency = detector.get('FindingPublishingFrequency', 'N/A')
-
-            # Created at
-            created_at = detector.get('CreatedAt', '')
-            if created_at:
-                created_at = created_at if isinstance(created_at, str) else created_at.strftime('%Y-%m-%d %H:%M:%S')
-
-            # Updated at
-            updated_at = detector.get('UpdatedAt', '')
-            if updated_at:
-                updated_at = updated_at if isinstance(updated_at, str) else updated_at.strftime('%Y-%m-%d %H:%M:%S')
-
-            # Protection features (newer GuardDuty categories: EKS Runtime, RDS, Lambda, Malware)
-            features = detector.get('Features', [])
-            features_str = ', '.join(
-                f"{f.get('Name', '')}: {f.get('Status', '')}"
-                for f in features
-            ) if features else 'N/A'
-
-            # Tags
-            tags = detector.get('Tags', {})
-            tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'N/A'
-
-            detectors_data.append({
-                'Region': region,
-                'Detector ID': detector_id,
-                'Status': status,
-                'Finding Frequency': finding_frequency,
-                'CloudTrail': cloud_trail,
-                'DNS Logs': dns_logs,
-                'VPC Flow Logs': flow_logs,
-                'S3 Logs': s3_logs,
-                'Kubernetes Audit Logs': k8s_audit_logs,
-                'Protection Features': features_str,
-                'Service Role': service_role,
-                'Created At': created_at,
-                'Updated At': updated_at,
-                'Tags': tags_str
-            })
-
+            detectors_data.append(_build_detector_row(detector, detector_id, region))
         except Exception as e:
-            utils.log_warning(f"Could not get details for detector {detector_id}: {e}")
+            utils.log_error(
+                f"Skipping GuardDuty detector {detector_id} in {region} due to a processing error", e
+            )
+            continue
 
     utils.log_info(f"Found {len(detectors_data)} detectors in {region}")
     return detectors_data
 
 
-def collect_detectors(regions: list[str]) -> list[dict[str, Any]]:
+def collect_detectors(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect GuardDuty detector information using concurrent scanning.
+    Collect GuardDuty detector information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with detector information
+        tuple: ``(detectors, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING GUARDDUTY DETECTORS ===")
     utils.log_info(f"Scanning {len(regions)} regions for GuardDuty detectors...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_detectors_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -170,7 +211,7 @@ def collect_detectors(regions: list[str]) -> list[dict[str, Any]]:
         all_detectors.extend(detectors_in_region)
 
     utils.log_success(f"Total GuardDuty detectors collected: {len(all_detectors)}")
-    return all_detectors
+    return all_detectors, failed_regions
 
 
 @utils.aws_error_handler("Collecting GuardDuty findings from region", default_return=[])
@@ -533,63 +574,80 @@ def export_guardduty_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect detectors
-    detectors = collect_detectors(regions)
+    # STEP 1: Collect detectors (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    detectors, failed_regions = collect_detectors(regions)
     if detectors:
         data_frames['Detectors'] = pd.DataFrame(detectors)
 
-    # STEP 2: Collect findings
+    # STEP 2: Collect findings (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     findings = collect_findings(regions)
     if findings:
         data_frames['Findings'] = pd.DataFrame(findings)
 
-    # STEP 3: Collect threat intel sets
+    # STEP 3: Collect threat intel sets (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     threat_sets = collect_threat_intel_sets(regions)
     if threat_sets:
         data_frames['Threat Intel Sets'] = pd.DataFrame(threat_sets)
 
-    # STEP 4: Collect IP sets
+    # STEP 4: Collect IP sets (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     ip_sets = collect_ip_sets(regions)
     if ip_sets:
         data_frames['IP Sets'] = pd.DataFrame(ip_sets)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'guardduty',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("GuardDuty data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No GuardDuty data was collected. Nothing to export.")
         print("\nNo GuardDuty detectors found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'guardduty',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("GuardDuty data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary detector scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data (from this
+    # scope or the enrichment sheets) was exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'guardduty', failed_regions)
+        print(
+            "\nERROR: GuardDuty export completed with failures — data is incomplete. "
+            "See the *-guardduty-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/secrets_manager_export.py
+++ b/scripts/secrets_manager_export.py
@@ -49,9 +49,118 @@ except ImportError:
 args = utils.parse_script_args("Export Secrets Manager secrets to Excel")
 
 
+def _build_secret_row(item: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single Secrets Manager secret.
+
+    Extracted so the per-secret processing can be wrapped in try/except by
+    the caller: a malformed secret entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    SECURITY: This function does NOT retrieve secret values, only metadata.
+
+    Args:
+        item: A single SecretList entry from list_secrets.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled secret row.
+    """
+    secret_name = item.get('Name', '')
+    secret_arn = item.get('ARN', '')
+
+    # Description
+    description = item.get('Description', 'N/A')
+
+    # KMS key
+    kms_key_id = item.get('KmsKeyId', 'N/A')
+
+    # Rotation enabled
+    rotation_enabled = item.get('RotationEnabled', False)
+
+    # Rotation Lambda ARN
+    rotation_lambda_arn = item.get('RotationLambdaARN', 'N/A')
+
+    # Rotation rules
+    rotation_rules = item.get('RotationRules', {}) or {}
+    automatically_after_days = rotation_rules.get('AutomaticallyAfterDays', 'N/A')
+
+    # Last rotated date
+    last_rotated_date = item.get('LastRotatedDate', '')
+    if last_rotated_date:
+        last_rotated_date = last_rotated_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_rotated_date, datetime.datetime) else str(last_rotated_date)
+    else:
+        last_rotated_date = 'Never'
+
+    # Last changed date
+    last_changed_date = item.get('LastChangedDate', '')
+    if last_changed_date:
+        last_changed_date = last_changed_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_changed_date, datetime.datetime) else str(last_changed_date)
+
+    # Last accessed date
+    last_accessed_date = item.get('LastAccessedDate', '')
+    if last_accessed_date:
+        last_accessed_date = last_accessed_date.strftime('%Y-%m-%d') if isinstance(last_accessed_date, datetime.datetime) else str(last_accessed_date)
+    else:
+        last_accessed_date = 'Never'
+
+    # Deleted date
+    deleted_date = item.get('DeletedDate', '')
+    if deleted_date:
+        deleted_date = deleted_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(deleted_date, datetime.datetime) else str(deleted_date)
+    else:
+        deleted_date = 'N/A'
+
+    # Created date
+    created_date = item.get('CreatedDate', '')
+    if created_date:
+        created_date = created_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_date, datetime.datetime) else str(created_date)
+
+    # Primary region (for replicated secrets)
+    primary_region = item.get('PrimaryRegion', region)
+
+    # Tags
+    tags = item.get('Tags', []) or []
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags if tag.get('Key') is not None and tag.get('Value') is not None}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    # Owning service
+    owning_service = item.get('OwningService', 'N/A')
+
+    return {
+        'Region': region,
+        'Secret Name': secret_name,
+        'Description': description,
+        'Rotation Enabled': rotation_enabled,
+        'Rotation Interval (days)': automatically_after_days,
+        'Rotation Lambda ARN': rotation_lambda_arn,
+        'Last Rotated': last_rotated_date,
+        'Last Changed': last_changed_date,
+        'Last Accessed': last_accessed_date,
+        'KMS Key ID': kms_key_id,
+        'Primary Region': primary_region,
+        'Owning Service': owning_service,
+        'Deleted Date': deleted_date,
+        'Created Date': created_date,
+        'Tags': tags_str,
+        'Secret ARN': secret_arn
+    }
+
+
 def scan_secrets_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan Secrets Manager secrets in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no secrets" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed secrets are skipped (logged) rather than aborting the
+    whole region.
 
     SECURITY: This function does NOT retrieve secret values, only metadata.
 
@@ -60,111 +169,62 @@ def scan_secrets_in_region(region: str) -> list[dict[str, Any]]:
 
     Returns:
         list: List of dictionaries with secret metadata from this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_secrets = []
 
-    try:
-        secrets_client = utils.get_boto3_client('secretsmanager', region_name=region)
+    secrets_client = utils.get_boto3_client('secretsmanager', region_name=region)
 
-        # Get secrets (metadata only, no values)
-        paginator = secrets_client.get_paginator('list_secrets')
+    # Get secrets (metadata only, no values)
+    paginator = secrets_client.get_paginator('list_secrets')
+    secret_count = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            secrets = page.get('SecretList', [])
+    for page in paginator.paginate():
+        secrets = page.get('SecretList', [])
+        secret_count += len(secrets)
 
-            for secret in secrets:
-                secret_name = secret.get('Name', '')
-                secret_arn = secret.get('ARN', '')
+        # Process each secret. One malformed secret must not sink the
+        # region, so each is built inside try/except; failures are logged
+        # and skipped.
+        for secret in secrets:
+            try:
+                regional_secrets.append(_build_secret_row(secret, region))
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping malformed Secrets Manager secret in {region}: "
+                    f"{secret.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                # Description
-                description = secret.get('Description', 'N/A')
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {secret_count} secret(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining secrets were still collected."
+        )
 
-                # KMS key
-                kms_key_id = secret.get('KmsKeyId', 'N/A')
-
-                # Rotation enabled
-                rotation_enabled = secret.get('RotationEnabled', False)
-
-                # Rotation Lambda ARN
-                rotation_lambda_arn = secret.get('RotationLambdaARN', 'N/A')
-
-                # Rotation rules
-                rotation_rules = secret.get('RotationRules', {})
-                automatically_after_days = rotation_rules.get('AutomaticallyAfterDays', 'N/A')
-
-                # Last rotated date
-                last_rotated_date = secret.get('LastRotatedDate', '')
-                if last_rotated_date:
-                    last_rotated_date = last_rotated_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_rotated_date, datetime.datetime) else str(last_rotated_date)
-                else:
-                    last_rotated_date = 'Never'
-
-                # Last changed date
-                last_changed_date = secret.get('LastChangedDate', '')
-                if last_changed_date:
-                    last_changed_date = last_changed_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_changed_date, datetime.datetime) else str(last_changed_date)
-
-                # Last accessed date
-                last_accessed_date = secret.get('LastAccessedDate', '')
-                if last_accessed_date:
-                    last_accessed_date = last_accessed_date.strftime('%Y-%m-%d') if isinstance(last_accessed_date, datetime.datetime) else str(last_accessed_date)
-                else:
-                    last_accessed_date = 'Never'
-
-                # Deleted date
-                deleted_date = secret.get('DeletedDate', '')
-                if deleted_date:
-                    deleted_date = deleted_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(deleted_date, datetime.datetime) else str(deleted_date)
-                else:
-                    deleted_date = 'N/A'
-
-                # Created date
-                created_date = secret.get('CreatedDate', '')
-                if created_date:
-                    created_date = created_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_date, datetime.datetime) else str(created_date)
-
-                # Primary region (for replicated secrets)
-                primary_region = secret.get('PrimaryRegion', region)
-
-                # Tags
-                tags = secret.get('Tags', [])
-                tag_dict = {tag['Key']: tag['Value'] for tag in tags if 'Key' in tag and 'Value' in tag}
-                tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-                # Owning service
-                owning_service = secret.get('OwningService', 'N/A')
-
-                regional_secrets.append({
-                    'Region': region,
-                    'Secret Name': secret_name,
-                    'Description': description,
-                    'Rotation Enabled': rotation_enabled,
-                    'Rotation Interval (days)': automatically_after_days,
-                    'Rotation Lambda ARN': rotation_lambda_arn,
-                    'Last Rotated': last_rotated_date,
-                    'Last Changed': last_changed_date,
-                    'Last Accessed': last_accessed_date,
-                    'KMS Key ID': kms_key_id,
-                    'Primary Region': primary_region,
-                    'Owning Service': owning_service,
-                    'Deleted Date': deleted_date,
-                    'Created Date': created_date,
-                    'Tags': tags_str,
-                    'Secret ARN': secret_arn
-                })
-
-        utils.log_info(f"Found {len(regional_secrets)} secrets in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for secrets", e)
+    utils.log_info(f"Found {len(regional_secrets)} secrets in {region}")
 
     return regional_secrets
 
 
-@utils.aws_error_handler("Collecting Secrets Manager secrets", default_return=[])
-def collect_secrets(regions: list[str]) -> list[dict[str, Any]]:
+def collect_secrets(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
     Collect Secrets Manager secret information from AWS regions using concurrent scanning.
+
+    Uses ``collect_failures=True``: ``scan_secrets_in_region`` raises on a
+    region-level failure so that failure is recorded and surfaced by the
+    caller, never silently collapsed into "no secrets" (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
 
     SECURITY: This function does NOT retrieve secret values, only metadata.
 
@@ -172,21 +232,27 @@ def collect_secrets(regions: list[str]) -> list[dict[str, Any]]:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with secret metadata
+        tuple: (secrets, failed_regions) where failed_regions is a list of
+            (region, error_message) tuples for regions whose scan raised.
     """
     print("\n=== COLLECTING SECRETS MANAGER SECRETS ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_secrets = []
-    for region_data in utils.scan_regions_concurrent(
+    # Use concurrent scanning, surfacing failed regions rather than
+    # silently dropping them.
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_secrets_in_region,
-    ):
+        show_progress=True,
+        collect_failures=True,
+    )
+
+    all_secrets = []
+    for region_data in region_results:
         all_secrets.extend(region_data)
 
     utils.log_success(f"Total secrets collected: {len(all_secrets)}")
-    return all_secrets
+    return all_secrets, failed_regions
 
 
 def scan_secret_versions_in_region(region: str) -> list[dict[str, Any]]:
@@ -394,58 +460,74 @@ def export_secrets_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect secrets
-    secrets = collect_secrets(regions)
+    # STEP 1: Collect secrets (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    secrets, failed_regions = collect_secrets(regions)
     if secrets:
         data_frames['Secrets'] = pd.DataFrame(secrets)
 
-    # STEP 2: Collect versions
+    # STEP 2: Collect versions (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     versions = collect_secret_versions(regions)
     if versions:
         data_frames['Secret Versions'] = pd.DataFrame(versions)
 
-    # STEP 3: Collect replications
+    # STEP 3: Collect replications (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     replications = collect_secret_replications(regions)
     if replications:
         data_frames['Replications'] = pd.DataFrame(replications)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'secrets-manager',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Secrets Manager data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Secrets Manager data was collected. Nothing to export.")
         print("\nNo secrets found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'secrets-manager',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Secrets Manager data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary secrets scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was
+    # exported. A partial export that looks complete is exactly the failure
+    # mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'secrets-manager', failed_regions)
+        print(
+            "\nERROR: Secrets Manager export completed with failures — data is incomplete. "
+            "See the *-secrets-manager-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/shield_export.py
+++ b/scripts/shield_export.py
@@ -87,77 +87,122 @@ def check_subscription() -> dict[str, Any]:
             raise
 
 
-@utils.aws_error_handler("Collecting Shield protections", default_return=[])
+def _build_protection_row(client, protection: dict[str, Any], processed: int, total_protections: int) -> dict[str, Any]:
+    """
+    Build the export row for a single Shield protection.
+
+    Extracted so per-protection processing can be wrapped in try/except by
+    the caller: a malformed protection entry must not sink the whole
+    account-scope collection. Required fields are read with ``.get()`` and a
+    safe default for the same reason.
+
+    Args:
+        client: The boto3 Shield client.
+        protection (dict): A single Protections entry from list_protections.
+        processed: 1-based index of this protection within the current run.
+        total_protections: Total protection count, for progress logging.
+
+    Returns:
+        dict: The assembled protection row.
+    """
+    progress = (processed / total_protections) * 100 if total_protections > 0 else 0
+
+    # Log progress every 10 protections or at completion
+    if processed % 10 == 0 or processed == total_protections:
+        utils.log_info(f"[{progress:.1f}%] Processed {processed}/{total_protections} protections")
+
+    # Get detailed protection info
+    protection_id = protection.get('Id')
+    protection_detail = None
+
+    try:
+        if protection_id:
+            detail_response = client.describe_protection(ProtectionId=protection_id)
+            protection_detail = detail_response.get('Protection', {})
+    except Exception as e:
+        utils.log_debug(f"Could not get details for protection {protection_id}: {e}")
+
+    # Parse resource ARN for type
+    resource_arn = protection.get('ResourceArn', 'N/A')
+    resource_type = parse_resource_type(resource_arn)
+
+    return {
+        'Protection ID': protection.get('Id', 'N/A'),
+        'Protection Name': protection.get('Name', 'N/A'),
+        'Resource ARN': resource_arn,
+        'Resource Type': resource_type,
+        'Health Check IDs': format_list(protection.get('HealthCheckIds', [])),
+        'Protection ARN': protection.get('ProtectionArn', 'N/A'),
+        'Application Layer Automatic Response': 'Configured' if protection_detail and protection_detail.get('ApplicationLayerAutomaticResponseConfiguration') else 'Not Configured'
+    }
+
+
 def collect_protections() -> list[dict[str, Any]]:
     """
     Collect all Shield Advanced protections.
 
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no protections configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Shield Advanced is a global, account-scope service (not
+    multi-region — see scripts/iam_export.py for the account-scope
+    reference pattern this follows). Account-scope failures (client
+    creation, pagination) are allowed to raise so the caller (main) can
+    record this scope as *failed* rather than *empty*. Per-protection
+    errors are contained internally (logged and skipped).
+
     Returns:
-        list: List of protection information dictionaries
+        list: List of protection information dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     protections_data = []
     home_region = utils.get_partition_default_region()
     client = utils.get_boto3_client('shield', region_name=home_region)
 
-    try:
-        # List protections using paginator
-        paginator = client.get_paginator('list_protections')
+    # List protections using paginator
+    paginator = client.get_paginator('list_protections')
 
-        total_protections = 0
-        for page in paginator.paginate():
-            protections = page.get('Protections', [])
-            total_protections += len(protections)
+    total_protections = 0
+    for page in paginator.paginate():
+        protections = page.get('Protections', [])
+        total_protections += len(protections)
 
-        if total_protections > 0:
-            utils.log_info(f"Found {total_protections} Shield protection(s) to process")
-        else:
-            utils.log_info("No Shield protections found")
-            return []
+    if total_protections > 0:
+        utils.log_info(f"Found {total_protections} Shield protection(s) to process")
+    else:
+        utils.log_info("No Shield protections found")
+        return []
 
-        # Reset paginator and process protections
-        paginator = client.get_paginator('list_protections')
-        processed = 0
+    # Reset paginator and process protections
+    paginator = client.get_paginator('list_protections')
+    processed = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            protections = page.get('Protections', [])
+    for page in paginator.paginate():
+        protections = page.get('Protections', [])
 
-            for protection in protections:
-                processed += 1
-                progress = (processed / total_protections) * 100 if total_protections > 0 else 0
+        for protection in protections:
+            processed += 1
 
-                # Log progress every 10 protections or at completion
-                if processed % 10 == 0 or processed == total_protections:
-                    utils.log_info(f"[{progress:.1f}%] Processed {processed}/{total_protections} protections")
+            try:
+                protection_info = _build_protection_row(client, protection, processed, total_protections)
+            except Exception as e:
+                skipped += 1
+                protection_id = protection.get('Id', 'Unknown') if isinstance(protection, dict) else 'Unknown'
+                utils.log_error(f"Skipping Shield protection '{protection_id}' due to a processing error", e)
+                continue
 
-                # Get detailed protection info
-                protection_id = protection.get('Id')
-                protection_detail = None
+            protections_data.append(protection_info)
 
-                try:
-                    if protection_id:
-                        detail_response = client.describe_protection(ProtectionId=protection_id)
-                        protection_detail = detail_response.get('Protection', {})
-                except Exception as e:
-                    utils.log_debug(f"Could not get details for protection {protection_id}: {e}")
-
-                # Parse resource ARN for type
-                resource_arn = protection.get('ResourceArn', 'N/A')
-                resource_type = parse_resource_type(resource_arn)
-
-                protection_info = {
-                    'Protection ID': protection.get('Id', 'N/A'),
-                    'Protection Name': protection.get('Name', 'N/A'),
-                    'Resource ARN': resource_arn,
-                    'Resource Type': resource_type,
-                    'Health Check IDs': format_list(protection.get('HealthCheckIds', [])),
-                    'Protection ARN': protection.get('ProtectionArn', 'N/A'),
-                    'Application Layer Automatic Response': 'Configured' if protection_detail and protection_detail.get('ApplicationLayerAutomaticResponseConfiguration') else 'Not Configured'
-                }
-
-                protections_data.append(protection_info)
-
-    except Exception as e:
-        utils.log_error("Error collecting Shield protections", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_protections} Shield protection(s) were skipped due to "
+            "processing errors (see log above); the remaining protections were still collected."
+        )
 
     return protections_data
 
@@ -669,6 +714,18 @@ def export_to_excel(
 def main():
     """
     Main function to orchestrate the Shield Advanced information collection.
+
+    Shield Advanced is a global, account-scope service (not multi-region),
+    so failures are tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/iam_export.py for the
+    account-scope reference pattern). Subscription-not-active is a
+    legitimate, graceful "service not enabled" state (exit 0, no marker)
+    and must not be confused with a real collection failure on the
+    ``protections`` scope, which is exported as a partial result (if any
+    data was collected) and always surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit — it must never
+    be silently collapsed into "no protections" (07.15.2026 / 07.16.2026
+    audits).
     """
     try:
         # Check dependencies first
@@ -723,15 +780,31 @@ def main():
             print("  2. Review pricing and terms")
             print("  3. Complete subscription process")
             print("\nExiting without export.")
-            return
+            # Graceful skip — Shield Advanced not being subscribed is a
+            # legitimate, expected state, NOT a collection failure. No
+            # failure marker is written.
+            sys.exit(0)
 
         utils.log_success("Shield Advanced subscription confirmed")
         utils.log_info("Collecting Shield Advanced information...")
 
-        # Collect all data
-        utils.log_info("Collecting protected resources...")
-        protections_data = collect_protections()
+        # Account-scope failure tracking (see scripts/iam_export.py).
+        failed_scopes = []
 
+        # STEP 1: Collect protections (PRIMARY scope — a real API error here
+        # must propagate to failed_scopes, never collapse into an empty list
+        # that reads as "no protections configured").
+        utils.log_info("Collecting protected resources...")
+        try:
+            protections_data = collect_protections()
+        except Exception as e:
+            failed_scopes.append(('protections', str(e)))
+            utils.log_error(f"Shield protections collection failed: {e}")
+            protections_data = []
+
+        # STEP 2+: Enrichment collectors — degrade gracefully to a safe
+        # default via their own aws_error_handler decorators; a failure here
+        # does not fail the whole export.
         utils.log_info("Collecting attack history (last 90 days)...")
         attacks_data = collect_attacks()
 
@@ -748,7 +821,9 @@ def main():
         print("COLLECTION COMPLETE")
         print("====================================================================")
 
-        # Export to Excel
+        # Export whatever succeeded — a partial export is required even
+        # when the protections scope failed (see
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
         filename = export_to_excel(
             subscription,
             protections_data,
@@ -766,8 +841,25 @@ def main():
             utils.log_info(f"Protection groups: {len(groups_data)}")
             utils.log_info(f"DRT access: {drt_data.get('Status', 'Unknown')}")
             print("\nScript execution completed.")
+        elif not failed_scopes:
+            # Genuinely empty: subscription active, protections scope
+            # succeeded, and there is simply nothing configured.
+            utils.log_warning("No Shield Advanced data was collected. Nothing to export.")
         else:
             utils.log_error("Export failed. Please check the logs.")
+
+        # If the protections scope failed, make it loud: write a marker and
+        # exit non-zero, even if a partial export (enrichment sheets) was
+        # written. A partial export that looks complete is exactly the
+        # failure mode this guards against.
+        if failed_scopes:
+            utils.report_collection_failures(account_name, 'shield-advanced', failed_scopes)
+            print(
+                "\nERROR: Shield Advanced export completed with failures — data is "
+                "incomplete. See the *-shield-advanced-FAILED-*.txt marker in the "
+                "output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/waf_export.py
+++ b/scripts/waf_export.py
@@ -48,10 +48,99 @@ except ImportError:
 args = utils.parse_script_args("Export AWS WAF web ACLs and rules to Excel")
 
 
-@utils.aws_error_handler("Collecting WAF web ACLs from region", default_return=[])
+def _build_web_acl_row(acl_summary: dict, region: str, scope: str, wafv2_client) -> dict[str, Any]:
+    """
+    Build the export row for a single WAF web ACL, including its detail call
+    (get_web_acl).
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed/inaccessible web ACL is logged and skipped rather
+    than discarding the whole region's results.
+
+    Args:
+        acl_summary: A single WebACLs entry from list_web_acls.
+        region: AWS region name.
+        scope: REGIONAL or CLOUDFRONT.
+        wafv2_client: A wafv2 client for ``region``.
+
+    Returns:
+        dict: The assembled web ACL row.
+    """
+    acl_name = acl_summary.get('Name', '')
+    acl_id = acl_summary.get('Id', '')
+    acl_arn = acl_summary.get('ARN', '')
+
+    # Get web ACL details
+    acl_response = wafv2_client.get_web_acl(
+        Name=acl_name,
+        Scope=scope,
+        Id=acl_id
+    )
+
+    acl = acl_response.get('WebACL', {})
+
+    # Default action
+    default_action = acl.get('DefaultAction', {})
+    if 'Allow' in default_action:
+        default_action_type = 'ALLOW'
+    elif 'Block' in default_action:
+        default_action_type = 'BLOCK'
+    else:
+        default_action_type = 'N/A'
+
+    # Description
+    description = acl.get('Description', 'N/A')
+
+    # Rules
+    rules = acl.get('Rules', [])
+    rule_count = len(rules)
+
+    # Capacity
+    capacity = acl.get('Capacity', 0)
+
+    # Visibility config
+    visibility_config = acl.get('VisibilityConfig', {})
+    sampled_requests_enabled = visibility_config.get('SampledRequestsEnabled', False)
+    cloudwatch_metrics_enabled = visibility_config.get('CloudWatchMetricsEnabled', False)
+    metric_name = visibility_config.get('MetricName', 'N/A')
+
+    # Managed by firewall manager
+    managed_by_firewall_manager = acl.get('ManagedByFirewallManager', False)
+
+    # Label namespace
+    label_namespace = acl.get('LabelNamespace', 'N/A')
+
+    return {
+        'Region': region,
+        'Scope': scope,
+        'Name': acl_name,
+        'ID': acl_id,
+        'Default Action': default_action_type,
+        'Rule Count': rule_count,
+        'Capacity': capacity,
+        'Description': description,
+        'Sampled Requests': sampled_requests_enabled,
+        'CloudWatch Metrics': cloudwatch_metrics_enabled,
+        'Metric Name': metric_name,
+        'Managed by FW Manager': managed_by_firewall_manager,
+        'Label Namespace': label_namespace,
+        'ARN': acl_arn
+    }
+
+
 def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[dict[str, Any]]:
     """
     Collect WAF web ACL information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no web ACLs" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/inaccessible web ACLs are skipped (logged) rather
+    than aborting the whole region.
 
     Args:
         region: AWS region to scan
@@ -59,8 +148,14 @@ def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[d
 
     Returns:
         list: List of dictionaries with web ACL information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records
+            it as a failed region and surfaces it; it is never masked as
+            empty).
     """
     if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
         return []
 
     web_acls_data = []
@@ -76,71 +171,19 @@ def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[d
         page = wafv2_client.list_web_acls(**params)
         web_acls = page.get('WebACLs', [])
 
+        # Process each web ACL. One malformed/inaccessible web ACL must not
+        # sink the region, so each is built inside try/except; failures are
+        # logged and skipped.
         for acl_summary in web_acls:
             acl_name = acl_summary.get('Name', '')
-            acl_id = acl_summary.get('Id', '')
-            acl_arn = acl_summary.get('ARN', '')
 
             try:
-                # Get web ACL details
-                acl_response = wafv2_client.get_web_acl(
-                    Name=acl_name,
-                    Scope=scope,
-                    Id=acl_id
-                )
-
-                acl = acl_response.get('WebACL', {})
-
-                # Default action
-                default_action = acl.get('DefaultAction', {})
-                if 'Allow' in default_action:
-                    default_action_type = 'ALLOW'
-                elif 'Block' in default_action:
-                    default_action_type = 'BLOCK'
-                else:
-                    default_action_type = 'N/A'
-
-                # Description
-                description = acl.get('Description', 'N/A')
-
-                # Rules
-                rules = acl.get('Rules', [])
-                rule_count = len(rules)
-
-                # Capacity
-                capacity = acl.get('Capacity', 0)
-
-                # Visibility config
-                visibility_config = acl.get('VisibilityConfig', {})
-                sampled_requests_enabled = visibility_config.get('SampledRequestsEnabled', False)
-                cloudwatch_metrics_enabled = visibility_config.get('CloudWatchMetricsEnabled', False)
-                metric_name = visibility_config.get('MetricName', 'N/A')
-
-                # Managed by firewall manager
-                managed_by_firewall_manager = acl.get('ManagedByFirewallManager', False)
-
-                # Label namespace
-                label_namespace = acl.get('LabelNamespace', 'N/A')
-
-                web_acls_data.append({
-                    'Region': region,
-                    'Scope': scope,
-                    'Name': acl_name,
-                    'ID': acl_id,
-                    'Default Action': default_action_type,
-                    'Rule Count': rule_count,
-                    'Capacity': capacity,
-                    'Description': description,
-                    'Sampled Requests': sampled_requests_enabled,
-                    'CloudWatch Metrics': cloudwatch_metrics_enabled,
-                    'Metric Name': metric_name,
-                    'Managed by FW Manager': managed_by_firewall_manager,
-                    'Label Namespace': label_namespace,
-                    'ARN': acl_arn
-                })
-
+                web_acls_data.append(_build_web_acl_row(acl_summary, region, scope, wafv2_client))
             except Exception as e:
-                utils.log_warning(f"Could not get details for web ACL {acl_name}: {e}")
+                utils.log_error(
+                    f"Skipping web ACL '{acl_name}' ({scope}) in {region} due to a processing error", e
+                )
+                continue
 
         next_marker = page.get('NextMarker')
         if not next_marker:
@@ -150,22 +193,46 @@ def collect_web_acls_from_region(region: str, scope: str = 'REGIONAL') -> list[d
     return web_acls_data
 
 
-def collect_web_acls(regions: list[str], scope: str = 'REGIONAL') -> list[dict[str, Any]]:
+def collect_web_acls(regions: list[str], scope: str = 'REGIONAL') -> tuple[list[dict[str, Any]], list]:
     """
-    Collect WAF web ACL information from AWS regions using concurrent scanning.
+    Collect WAF web ACL information, surfacing failures.
+
+    REGIONAL scope uses ``collect_failures=True`` so a region whose
+    collection errors is reported as a failed scope rather than silently
+    collapsed into an empty result.
+
+    CLOUDFRONT scope is a single global call (CloudFront WAF only exists in
+    us-east-1) — a single call, not region-scanned — so there is no
+    per-region loop to attach a failed-region tuple to. A collection error
+    there is instead reported as a single ``('cloudfront-global', error)``
+    entry, using the same ``(scope, error)`` contract as the regional scope
+    so the caller can merge them into one combined failed list (see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
     Args:
-        regions: List of AWS regions to scan
+        regions: List of AWS regions to scan (ignored for CLOUDFRONT scope)
         scope: REGIONAL or CLOUDFRONT
 
     Returns:
-        list: List of dictionaries with web ACL information
+        tuple: ``(web_acls, failed_scopes)`` where ``failed_scopes`` is
+        either a list of ``(region, error_message)`` tuples (REGIONAL) or
+        ``[]``/``[('cloudfront-global', error_message)]`` (CLOUDFRONT).
     """
     print(f"\n=== COLLECTING WAF WEB ACLs ({scope}) ===")
 
-    # CloudFront WAF is only in us-east-1
     if scope == 'CLOUDFRONT':
-        regions = ['us-east-1']
+        utils.log_info("Scanning CloudFront (global) scope...")
+        try:
+            web_acls = collect_web_acls_from_region('us-east-1', scope='CLOUDFRONT')
+            utils.log_success(f"Total WAF web ACLs (CLOUDFRONT) collected: {len(web_acls)}")
+            return web_acls, []
+        except Exception as e:
+            # The CLOUDFRONT scope call itself failed (e.g. throttling,
+            # access denied). Surface it as a failed global scope rather
+            # than swallowing it into an empty list indistinguishable from
+            # "no CloudFront web ACLs configured".
+            utils.log_error("Error collecting CloudFront (global) WAF web ACLs", e)
+            return [], [('cloudfront-global', str(e))]
 
     utils.log_info(f"Scanning {len(regions)} regions...")
 
@@ -173,10 +240,11 @@ def collect_web_acls(regions: list[str], scope: str = 'REGIONAL') -> list[dict[s
     def scan_region_with_scope(region: str) -> list[dict[str, Any]]:
         return collect_web_acls_from_region(region, scope)
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_region_with_scope,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     all_web_acls = []
@@ -184,7 +252,7 @@ def collect_web_acls(regions: list[str], scope: str = 'REGIONAL') -> list[dict[s
         all_web_acls.extend(web_acls_in_region)
 
     utils.log_success(f"Total WAF web ACLs ({scope}) collected: {len(all_web_acls)}")
-    return all_web_acls
+    return all_web_acls, failed_regions
 
 
 @utils.aws_error_handler("Collecting WAF rules from region", default_return=[])
@@ -590,14 +658,21 @@ def export_waf_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect regional Web ACLs
-    regional_acls = collect_web_acls(regions, scope='REGIONAL')
-    cloudfront_acls = collect_web_acls(regions, scope='CLOUDFRONT')
+    # STEP 1: Collect Web ACLs (primary scope — REGIONAL failures must
+    # propagate as failed_regions, never collapse into "empty"; the
+    # CLOUDFRONT global scope's failure is surfaced as a single
+    # ('cloudfront-global', error) entry).
+    regional_acls, failed_regions = collect_web_acls(regions, scope='REGIONAL')
+    cloudfront_acls, cloudfront_failed = collect_web_acls(regions, scope='CLOUDFRONT')
     all_acls = regional_acls + cloudfront_acls
     if all_acls:
         data_frames['Web ACLs'] = pd.DataFrame(all_acls)
 
-    # STEP 2: Collect regional rules
+    # Merge failed scopes: regional failures from the primary Web ACLs scope
+    # + the CLOUDFRONT (global) scope (if it failed).
+    failed = list(failed_regions) + list(cloudfront_failed)
+
+    # STEP 2: Collect regional rules (enrichment — degrades gracefully)
     regional_rules = collect_waf_rules(regions, scope='REGIONAL')
     cloudfront_rules = collect_waf_rules(regions, scope='CLOUDFRONT')
     all_rules = regional_rules + cloudfront_rules
@@ -618,43 +693,57 @@ def export_waf_data(account_id: str, account_name: str):
     if all_rule_groups:
         data_frames['Rule Groups'] = pd.DataFrame(all_rule_groups)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some scopes failed (see the silent-collection-failure
+    # blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'waf',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("WAF data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s) + CloudFront (global)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed:
+        # Genuinely empty account: every scope succeeded and returned nothing.
         utils.log_warning("No WAF data was collected. Nothing to export.")
         print("\nNo WAF resources found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'waf',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("WAF data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s) + CloudFront (global)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY scope failed the Web ACLs collection (regional or the
+    # CLOUDFRONT global scope), make it loud: write a marker and exit
+    # non-zero, even if some data was exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed:
+        utils.report_collection_failures(account_name, 'waf', failed)
+        print(
+            "\nERROR: WAF export completed with failures — data is incomplete. "
+            "See the *-waf-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/tests/test_exporters/test_access_analyzer_export.py
+++ b/tests/test_exporters/test_access_analyzer_export.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Tests for access_analyzer_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+NOTE: moto (5.1.21) does not implement an ``accessanalyzer`` backend
+(``create_analyzer`` returns a 404 "Not yet implemented" from moto itself,
+and the service has no entry in ``moto.backends.list_of_moto_modules()``).
+These tests therefore monkeypatch ``utils.get_boto3_client`` to return a
+fake client with a fake paginator rather than using ``@mock_aws`` against a
+real accessanalyzer backend.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import access_analyzer_export  # noqa: E402
+from access_analyzer_export import collect_analyzers_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakePaginator:
+    """Minimal stand-in for a boto3 paginator yielding fixed pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeAccessAnalyzerClient:
+    """Minimal stand-in for the accessanalyzer boto3 client."""
+
+    def __init__(self, analyzers):
+        self._analyzers = analyzers
+
+    def get_paginator(self, operation_name):
+        if operation_name == "list_analyzers":
+            return _FakePaginator([{"analyzers": self._analyzers}])
+        raise ValueError(f"Unexpected paginator requested: {operation_name}")
+
+
+def _make_analyzer(name, analyzer_type="ACCOUNT", status="ACTIVE"):
+    return {
+        "arn": f"arn:aws:access-analyzer:{REGION}:123456789012:analyzer/{name}",
+        "name": name,
+        "type": analyzer_type,
+        "status": status,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "tags": {},
+    }
+
+
+class TestCollectAnalyzersFromRegion:
+    """Happy-path collection."""
+
+    def test_collects_analyzers(self, monkeypatch):
+        client = _FakeAccessAnalyzerClient([_make_analyzer("web-analyzer")])
+        monkeypatch.setattr(
+            access_analyzer_export.utils, "get_boto3_client", lambda *a, **k: client
+        )
+
+        rows = collect_analyzers_from_region(REGION)
+
+        names = {row["Analyzer Name"] for row in rows}
+        assert "web-analyzer" in names
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _FakeAccessAnalyzerClient([])
+        monkeypatch.setattr(
+            access_analyzer_export.utils, "get_boto3_client", lambda *a, **k: client
+        )
+
+        rows = collect_analyzers_from_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One analyzer that fails to process must not discard the whole region."""
+        client = _FakeAccessAnalyzerClient(
+            [_make_analyzer("good-analyzer"), _make_analyzer("bad-analyzer")]
+        )
+        monkeypatch.setattr(
+            access_analyzer_export.utils, "get_boto3_client", lambda *a, **k: client
+        )
+
+        original = access_analyzer_export._build_analyzer_row
+
+        def raise_for_bad(analyzer, region):
+            if analyzer.get("name") == "bad-analyzer":
+                raise KeyError("SomeUnexpectedField")
+            return original(analyzer, region)
+
+        monkeypatch.setattr(access_analyzer_export, "_build_analyzer_row", raise_for_bad)
+
+        rows = collect_analyzers_from_region(REGION)
+
+        names = {row["Analyzer Name"] for row in rows}
+        assert "good-analyzer" in names, "healthy analyzer was lost when a sibling failed"
+        assert "bad-analyzer" not in names, "malformed analyzer should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListAnalyzers",
+            )
+
+        monkeypatch.setattr(access_analyzer_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_analyzers_from_region(REGION)
+
+    def test_collect_analyzers_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListAnalyzers",
+            )
+
+        monkeypatch.setattr(access_analyzer_export, "collect_analyzers_from_region", boom)
+
+        analyzers, failed_regions = access_analyzer_export.collect_analyzers([REGION])
+
+        assert analyzers == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_config_export.py
+++ b/tests/test_exporters/test_config_export.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for config_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import config_export  # noqa: E402
+from config_export import _scan_recorders_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_recorder(client, name):
+    """Create a Config configuration recorder named ``name``."""
+    client.put_configuration_recorder(
+        ConfigurationRecorder={
+            "name": name,
+            "roleARN": "arn:aws:iam::123456789012:role/config-role",
+            "recordingGroup": {
+                "allSupported": True,
+                "includeGlobalResourceTypes": True,
+            },
+        }
+    )
+
+
+class TestScanRecordersRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_recorders(self):
+        client = boto3.client("config", region_name=REGION)
+        _create_recorder(client, "default")
+
+        rows = _scan_recorders_region(REGION)
+
+        names = {row["Recorder Name"] for row in rows}
+        assert "default" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("config", region_name=REGION)  # region exists, no recorders
+
+        rows = _scan_recorders_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One recorder that fails to process must not discard the whole region."""
+        # AWS Config only allows a single configuration recorder per region,
+        # so a second "bad" recorder is injected via a wrapped
+        # describe_configuration_recorders response rather than a real
+        # put_configuration_recorder call.
+        client = boto3.client("config", region_name=REGION)
+        _create_recorder(client, "good-recorder")
+
+        real_describe = client.describe_configuration_recorders
+
+        def fake_describe(*args, **kwargs):
+            resp = dict(real_describe(*args, **kwargs))
+            resp["ConfigurationRecorders"] = list(resp["ConfigurationRecorders"]) + [
+                {
+                    "name": "bad-recorder",
+                    "roleARN": "arn:aws:iam::123456789012:role/config-role",
+                    "recordingGroup": {"allSupported": True},
+                }
+            ]
+            return resp
+
+        monkeypatch.setattr(client, "describe_configuration_recorders", fake_describe)
+        monkeypatch.setattr(
+            config_export.utils, "get_boto3_client", lambda service, region_name=None: client
+        )
+
+        original = config_export._build_recorder_row
+
+        def raise_for_bad(recorder, region, config_client):
+            if recorder.get("name") == "bad-recorder":
+                raise KeyError("SomeUnexpectedField")
+            return original(recorder, region, config_client)
+
+        monkeypatch.setattr(config_export, "_build_recorder_row", raise_for_bad)
+
+        rows = _scan_recorders_region(REGION)
+
+        names = {row["Recorder Name"] for row in rows}
+        assert "good-recorder" in names, "healthy recorder was lost when a sibling failed"
+        assert "bad-recorder" not in names, "malformed recorder should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeConfigurationRecorders",
+            )
+
+        monkeypatch.setattr(config_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_recorders_region(REGION)
+
+    @mock_aws
+    def test_collect_configuration_recorders_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeConfigurationRecorders",
+            )
+
+        monkeypatch.setattr(config_export, "_scan_recorders_region", boom)
+
+        recorders, failed_regions = config_export.collect_configuration_recorders([REGION])
+
+        assert recorders == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_detective_export.py
+++ b/tests/test_exporters/test_detective_export.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for detective_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's AWS Detective support is limited (no ``create_graph``/member
+management surface as of this writing), so cases (b) and (c) below exercise
+the contract via monkeypatch rather than a real moto-backed Detective graph.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import detective_export  # noqa: E402
+from detective_export import _scan_graphs_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakeGraphsClient:
+    """Fake Detective client returning two graphs, one of which is malformed."""
+
+    def list_graphs(self):
+        return {
+            "GraphList": [
+                {"Arn": "arn:aws:detective:us-east-1:111122223333:graph:good-graph"},
+                {"Arn": "arn:aws:detective:us-east-1:111122223333:graph:bad-graph"},
+            ]
+        }
+
+    def list_members(self, **kwargs):
+        return {"MemberDetails": []}
+
+    def list_tags_for_resource(self, **kwargs):
+        return {"Tags": {}}
+
+
+class _FakeEmptyGraphsClient:
+    """Fake Detective client with no graphs (Detective not enabled)."""
+
+    def list_graphs(self):
+        return {"GraphList": []}
+
+
+class TestScanGraphsRegion:
+    """Happy-path collection.
+
+    moto has no working AWS Detective backend (``ListGraphs`` responds "Not
+    yet implemented"), so these exercise the contract via a fake client
+    rather than @mock_aws.
+    """
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        # No graphs — Detective is not enabled in this region.
+        monkeypatch.setattr(
+            detective_export.utils,
+            "get_boto3_client",
+            lambda *a, **k: _FakeEmptyGraphsClient(),
+        )
+
+        rows = _scan_graphs_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One graph that fails to process must not discard the whole region."""
+        fake_client = _FakeGraphsClient()
+        monkeypatch.setattr(
+            detective_export.utils, "get_boto3_client", lambda *a, **k: fake_client
+        )
+
+        original = detective_export._build_graph_row
+
+        def raise_for_bad(graph, region, client):
+            if graph.get("Arn", "").endswith("bad-graph"):
+                raise KeyError("SomeUnexpectedField")
+            return original(graph, region, client)
+
+        monkeypatch.setattr(detective_export, "_build_graph_row", raise_for_bad)
+
+        rows = _scan_graphs_region(REGION)
+
+        arns = {row["Graph ARN"] for row in rows}
+        assert any(a.endswith("good-graph") for a in arns), (
+            "healthy graph was lost when a sibling failed"
+        )
+        assert not any(a.endswith("bad-graph") for a in arns), (
+            "malformed graph should have been skipped"
+        )
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListGraphs",
+            )
+
+        monkeypatch.setattr(detective_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_graphs_region(REGION)
+
+    def test_collect_graphs_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListGraphs",
+            )
+
+        monkeypatch.setattr(detective_export, "_scan_graphs_region", boom)
+
+        graphs, failed_regions = detective_export.collect_graphs([REGION])
+
+        assert graphs == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_guardduty_export.py
+++ b/tests/test_exporters/test_guardduty_export.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for guardduty_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import guardduty_export  # noqa: E402
+from guardduty_export import collect_detectors_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_detector(client):
+    """Create a GuardDuty detector and return its ID."""
+    response = client.create_detector(Enable=True)
+    return response["DetectorId"]
+
+
+class TestCollectDetectorsFromRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_detectors(self):
+        client = boto3.client("guardduty", region_name=REGION)
+        detector_id = _create_detector(client)
+
+        rows = collect_detectors_from_region(REGION)
+
+        detector_ids = {row["Detector ID"] for row in rows}
+        assert detector_id in detector_ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("guardduty", region_name=REGION)  # region exists, no detectors
+
+        rows = collect_detectors_from_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One detector that fails to process must not discard the whole region."""
+        client = boto3.client("guardduty", region_name=REGION)
+        good_id = _create_detector(client)
+        bad_id = _create_detector(client)
+
+        original = guardduty_export._build_detector_row
+
+        def raise_for_bad(detector, detector_id, region):
+            if detector_id == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(detector, detector_id, region)
+
+        monkeypatch.setattr(guardduty_export, "_build_detector_row", raise_for_bad)
+
+        rows = collect_detectors_from_region(REGION)
+
+        detector_ids = {row["Detector ID"] for row in rows}
+        assert good_id in detector_ids, "healthy detector was lost when a sibling failed"
+        assert bad_id not in detector_ids, "malformed detector should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListDetectors",
+            )
+
+        monkeypatch.setattr(guardduty_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_detectors_from_region(REGION)
+
+    @mock_aws
+    def test_collect_detectors_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListDetectors",
+            )
+
+        monkeypatch.setattr(guardduty_export, "collect_detectors_from_region", boom)
+
+        detectors, failed_regions = guardduty_export.collect_detectors([REGION])
+
+        assert detectors == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_secrets_manager_export.py
+++ b/tests/test_exporters/test_secrets_manager_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for secrets_manager_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2c). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import secrets_manager_export  # noqa: E402
+from secrets_manager_export import scan_secrets_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_secret(client, name):
+    """Create a Secrets Manager secret named ``name``."""
+    client.create_secret(Name=name, SecretString="super-secret-value")
+
+
+class TestScanSecretsInRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_secrets(self):
+        client = boto3.client("secretsmanager", region_name=REGION)
+        _create_secret(client, "app/db-password")
+
+        rows = scan_secrets_in_region(REGION)
+
+        names = {row["Secret Name"] for row in rows}
+        assert "app/db-password" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("secretsmanager", region_name=REGION)  # region exists, no secrets
+
+        rows = scan_secrets_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One secret that fails to process must not discard the whole region."""
+        client = boto3.client("secretsmanager", region_name=REGION)
+        _create_secret(client, "good-secret")
+        _create_secret(client, "bad-secret")
+
+        original = secrets_manager_export._build_secret_row
+
+        def raise_for_bad(item, region):
+            if item.get("Name") == "bad-secret":
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(secrets_manager_export, "_build_secret_row", raise_for_bad)
+
+        rows = scan_secrets_in_region(REGION)
+
+        names = {row["Secret Name"] for row in rows}
+        assert "good-secret" in names, "healthy secret was lost when a sibling failed"
+        assert "bad-secret" not in names, "malformed secret should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListSecrets",
+            )
+
+        monkeypatch.setattr(secrets_manager_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_secrets_in_region(REGION)
+
+    @mock_aws
+    def test_collect_secrets_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListSecrets",
+            )
+
+        monkeypatch.setattr(secrets_manager_export, "scan_secrets_in_region", boom)
+
+        secrets, failed_regions = secrets_manager_export.collect_secrets([REGION])
+
+        assert secrets == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_shield_export.py
+++ b/tests/test_exporters/test_shield_export.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Tests for shield_export.py.
+
+Covers:
+- check_subscription() as a graceful availability probe
+- collect_protections() per-item guarding and account-scope failure propagation
+- main()'s failed-scope tracking, finalize, and exit-code behavior
+
+Shield Advanced is a global/account-scope service (not multi-region), so
+collect_protections() is the account-scope PRIMARY collector -- mirrors the
+scripts/iam_export.py account-scope pattern (see scripts/lambda_export.py
+for the finalize shape). moto's Shield support is limited (no
+protection-mutation APIs and no configurable subscription state), so these
+tests drive the module through monkeypatched boto3 clients / module
+functions rather than real moto-backed Shield state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import shield_export  # noqa: E402
+from shield_export import check_subscription, collect_protections  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(shield_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_shield_client(protections=None):
+    """Build a MagicMock standing in for a boto3 Shield client."""
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Protections": protections or []}]
+    client.get_paginator.return_value = paginator
+    client.describe_protection.return_value = {"Protection": {}}
+    return client
+
+
+class TestCheckSubscription:
+    """
+    check_subscription() is a graceful availability probe: Shield Advanced
+    not being subscribed (ResourceNotFoundException) is a legitimate,
+    expected state and returns None rather than raising.
+    """
+
+    def test_resource_not_found_returns_none(self, monkeypatch):
+        client = MagicMock()
+        client.describe_subscription.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "not subscribed"}},
+            "DescribeSubscription",
+        )
+        monkeypatch.setattr(shield_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert check_subscription() is None
+
+    def test_active_subscription_returns_dict(self, monkeypatch):
+        client = MagicMock()
+        client.describe_subscription.return_value = {
+            "Subscription": {"SubscriptionArn": "arn:aws:shield::123456789012:subscription/x"}
+        }
+        monkeypatch.setattr(shield_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        result = check_subscription()
+
+        assert result == {"SubscriptionArn": "arn:aws:shield::123456789012:subscription/x"}
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Shield Advanced: collect_protections() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error into
+    an empty list, indistinguishable from an account with no protections
+    configured. main() also used to have no way to signal that failure
+    downstream. These tests cover: (a) a malformed protection is skipped, not
+    fatal; (b) collect_protections() raises rather than swallowing a real API
+    error; (c) that failure surfaces through main() as a non-zero exit plus a
+    utils.report_collection_failures() call; (d) a genuine "not subscribed"
+    state is a graceful exit 0 with no failure marker.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    def test_malformed_protection_is_skipped_not_fatal(self, monkeypatch):
+        """One protection that fails to process must not discard the others."""
+        good = {
+            "Id": "good-id",
+            "Name": "good-protection",
+            "ResourceArn": "arn:aws:ec2:us-east-1:123456789012:eip-allocation/eipalloc-good",
+        }
+        bad = {
+            "Id": "bad-id",
+            "Name": "bad-protection",
+            "ResourceArn": "arn:aws:ec2:us-east-1:123456789012:eip-allocation/eipalloc-bad",
+        }
+
+        client = _fake_shield_client(protections=[good, bad])
+        monkeypatch.setattr(shield_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = shield_export._build_protection_row
+
+        def raise_for_bad(client_arg, protection, processed, total):
+            if protection.get("Id") == "bad-id":
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, protection, processed, total)
+
+        monkeypatch.setattr(shield_export, "_build_protection_row", raise_for_bad)
+
+        result = collect_protections()
+
+        ids = {row["Protection ID"] for row in result}
+        assert "good-id" in ids, "healthy protection was lost when a sibling failed"
+        assert "bad-id" not in ids, "malformed protection should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_protections_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Shield API error during collection must propagate, not
+        collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListProtections",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(shield_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_protections()
+
+    # -- (c) main(): failure surfaced, non-zero exit ------------------------
+
+    def test_main_protections_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A protections API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+        monkeypatch.setattr(shield_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(shield_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            shield_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+        monkeypatch.setattr(
+            shield_export.utils, "get_boto3_client", lambda service, *a, **kw: sts_client
+        )
+
+        monkeypatch.setattr(
+            shield_export,
+            "check_subscription",
+            lambda: {"SubscriptionArn": "arn:aws:shield::123456789012:subscription/x"},
+        )
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListProtections",
+            )
+
+        monkeypatch.setattr(shield_export, "collect_protections", boom)
+        monkeypatch.setattr(shield_export, "collect_attacks", lambda: [])
+        monkeypatch.setattr(shield_export, "collect_emergency_contacts", lambda: [])
+        monkeypatch.setattr(shield_export, "collect_protection_groups", lambda: [])
+        monkeypatch.setattr(shield_export, "collect_drt_access", lambda: {})
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(shield_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            shield_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "shield-advanced"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "protections"
+
+    # -- (d) Subscription not active: graceful skip, no marker --------------
+
+    def test_subscription_not_active_exits_zero_no_marker(self, monkeypatch):
+        """Shield Advanced not being subscribed is a legitimate, expected
+        state -- exit 0, and utils.report_collection_failures is never
+        called (no *-FAILED-*.txt marker is written)."""
+        monkeypatch.setattr(shield_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(shield_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            shield_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+        monkeypatch.setattr(
+            shield_export.utils, "get_boto3_client", lambda service, *a, **kw: sts_client
+        )
+
+        monkeypatch.setattr(shield_export, "check_subscription", lambda: None)
+
+        report_called = []
+        monkeypatch.setattr(
+            shield_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            shield_export.main()
+
+        assert exc_info.value.code == 0
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_waf_export.py
+++ b/tests/test_exporters/test_waf_export.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for waf_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2c) for the primary
+REGIONAL scope, collect_web_acls()/collect_web_acls_from_region(). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+moto's WAFv2 support does not cover list_web_acls/get_web_acl well enough
+to inject pagination or per-item errors, so all three regression cases
+below monkeypatch the wafv2 client (or the collector functions) directly
+rather than relying on moto.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import waf_export  # noqa: E402
+from waf_export import collect_web_acls_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakeWafv2Client:
+    """
+    Minimal stand-in for a wafv2 client used by the regression tests below,
+    since moto's WAFv2 support does not cover list_web_acls/get_web_acl
+    error injection or NextMarker pagination for the scenarios exercised
+    here. ``list_web_acls`` returns the fixed ``web_acls`` summary list (no
+    NextMarker, i.e. a single page); ``get_web_acl`` raises for the name
+    given in ``error_for`` and otherwise returns an empty-but-valid WebACL.
+    """
+
+    def __init__(self, web_acls, error_for=None):
+        self._web_acls = web_acls
+        self._error_for = error_for
+
+    def list_web_acls(self, **kwargs):
+        return {"WebACLs": self._web_acls}
+
+    def get_web_acl(self, **kwargs):
+        name = kwargs.get("Name")
+        if self._error_for and name == self._error_for:
+            raise KeyError("SomeUnexpectedField")
+        return {"WebACL": {"DefaultAction": {"Allow": {}}}}
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One web ACL that fails to process must not discard the whole region."""
+        fake_client = _FakeWafv2Client(
+            web_acls=[
+                {"Name": "good-acl", "Id": "good-id", "ARN": f"arn:aws:wafv2:{REGION}:123456789012:regional/webacl/good-acl/good-id"},
+                {"Name": "bad-acl", "Id": "bad-id", "ARN": f"arn:aws:wafv2:{REGION}:123456789012:regional/webacl/bad-acl/bad-id"},
+            ],
+            error_for="bad-acl",
+        )
+        monkeypatch.setattr(waf_export.utils, "get_boto3_client", lambda *a, **kw: fake_client)
+
+        rows = collect_web_acls_from_region(REGION, scope="REGIONAL")
+
+        names = {row["Name"] for row in rows}
+        assert "good-acl" in names, "healthy web ACL was lost when a sibling failed"
+        assert "bad-acl" not in names, "malformed web ACL should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListWebACLs",
+            )
+
+        monkeypatch.setattr(waf_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_web_acls_from_region(REGION, scope="REGIONAL")
+
+    def test_collect_web_acls_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region, scope="REGIONAL"):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListWebACLs",
+            )
+
+        monkeypatch.setattr(waf_export, "collect_web_acls_from_region", boom)
+
+        web_acls, failed_regions = waf_export.collect_web_acls([REGION], scope="REGIONAL")
+
+        assert web_acls == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -63,11 +63,18 @@ _EXCLUDED = {
     # mocked environment. The scripts are correct in production (the APIs exist
     # there); adding an availability-probe skip would reintroduce silent loss on
     # a real throttle/deny. Behavior is covered by the dedicated regression
-    # suites under tests/test_exporters/. bedrock joins them for the same reason:
-    # moto's bedrock:ListFoundationModels raises NotImplementedError.
+    # suites under tests/test_exporters/. The others below join for the same
+    # reason — moto does not implement their primary collection API:
+    #   bedrock:ListFoundationModels        -> NotImplementedError
+    #   accessanalyzer:ListAnalyzers        -> 404 "Not yet implemented"
+    #   detective:ListGraphs                -> 404 "Not yet implemented"
+    #   config:DescribeConformancePacks     -> NotImplementedError (one of its scopes)
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
+    "access_analyzer_export.py",
+    "detective_export.py",
+    "config_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. Fourth phase — **Batch C: security & identity (7 exporters)** — onto the shared plumbing from #234 (A=#237, B=#238).

## What
Each exporter's PRIMARY scope collector(s) converted onto the shared contract (scope raises → surfaced failures → per-item guard → partial export → `report_collection_failures` + `sys.exit(1)`).

| Exporter | Scopes | Slug |
|---|---|---|
| guardduty | 1 | `guardduty` |
| secrets_manager | 1 | `secrets-manager` |
| waf | regional + global CLOUDFRONT | `waf` |
| shield | account-scope (global) | `shield-advanced` |
| access_analyzer | 1 | `access-analyzer` |
| detective | 1 | `detective` |
| config | 4 | `config` |

**Two structural variants:**
- **shield** is a global account-scope service (no region scanner) → iam-style `failed_scopes` tracking. Shield-Advanced-not-subscribed stays a **graceful exit 0** (no marker); a real `collect_protections` API failure writes the `shield-advanced` FAILED marker + `exit 1`.
- **waf** surfaces its global CLOUDFRONT scan failure as a `('cloudfront-global', err)` scope merged with regional failures; NextMarker pagination untouched.

Enrichment (findings, members, IP/threat sets, rules, config rules/channels/packs beyond the primary) stays graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite; shield adds subscription-not-active→exit-0 and API-failure→exit-1 cases. moto covers guardduty/secrets_manager/config-recorders happy paths; the rest use monkeypatch where moto lacks the service. **Batch-C suites: 33 passed. Full suite: 880 passed, 2 skipped. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusions
`access_analyzer`, `detective`, `config` added to `_EXCLUDED` — moto has no backend for their primary APIs (`ListAnalyzers` 404, `ListGraphs` 404, `DescribeConformancePacks` NotImplementedError), so correct fail-loud behavior exits 1 against an empty mocked env. Same rationale as image_builder/ssm_fleet/bedrock; dedicated regression suites carry coverage. guardduty/secrets_manager/waf/shield pass smoke normally.

## Remaining
Tier-2 **D** networking, **E** messaging/cost/governance. Then Tier-3 (48 PARTIAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)