### PR TITLE
Silent collection failure: Tier-2d (networking exporters)

### DIFF
--- a/scripts/cloudfront_export.py
+++ b/scripts/cloudfront_export.py
@@ -48,14 +48,154 @@ except ImportError:
 args = utils.parse_script_args("Export CloudFront distributions to Excel")
 
 
-@utils.aws_error_handler("Collecting CloudFront distributions", default_return=[])
+def _build_distribution_row(cloudfront, dist_summary: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single CloudFront distribution.
+
+    Extracted so per-distribution processing can be wrapped in try/except by
+    the caller: a malformed distribution entry (or a per-distribution
+    ``get_distribution`` failure) must not sink the whole account-scope
+    collection. Required fields are read with ``.get()`` and a safe default
+    for the same reason.
+
+    Args:
+        cloudfront: The boto3 CloudFront client.
+        dist_summary: A single Items entry from list_distributions.
+
+    Returns:
+        dict: The assembled distribution row.
+    """
+    dist_id = dist_summary.get('Id', '')
+    domain_name = dist_summary.get('DomainName', '')
+
+    print(f"  Processing distribution: {dist_id} ({domain_name})")
+
+    dist_detail = cloudfront.get_distribution(Id=dist_id)
+    dist_config = dist_detail['Distribution']['DistributionConfig']
+    dist_info = dist_detail['Distribution']
+
+    # Extract basic information
+    status = dist_info.get('Status', '')
+    enabled = dist_config.get('Enabled', False)
+    comment = dist_config.get('Comment', '')
+    price_class = dist_config.get('PriceClass', '')
+
+    # Get alternate domain names (CNAMEs)
+    aliases = dist_config.get('Aliases', {}).get('Items', [])
+    alias_list = ', '.join(aliases) if aliases else 'N/A'
+
+    # Get default root object
+    default_root_object = dist_config.get('DefaultRootObject', 'N/A')
+
+    # Get origin information (count and types)
+    origins = dist_config.get('Origins', {}).get('Items', [])
+    origin_count = len(origins)
+
+    # Categorize origins
+    s3_origins = []
+    custom_origins = []
+    for origin in origins:
+        if '.s3' in origin.get('DomainName', ''):
+            s3_origins.append(origin.get('Id', ''))
+        else:
+            custom_origins.append(origin.get('Id', ''))
+
+    origin_summary = f"S3: {len(s3_origins)}, Custom: {len(custom_origins)}"
+
+    # Get cache behavior count
+    default_cache_behavior = dist_config.get('DefaultCacheBehavior', {})
+    cache_behaviors = dist_config.get('CacheBehaviors', {}).get('Items', [])
+    behavior_count = 1 + len(cache_behaviors)  # 1 default + custom behaviors
+
+    # Get SSL/TLS information
+    viewer_cert = dist_config.get('ViewerCertificate', {})
+    ssl_support = viewer_cert.get('SSLSupportMethod', 'N/A')
+    acm_cert_arn = viewer_cert.get('ACMCertificateArn', 'N/A')
+    iam_cert_id = viewer_cert.get('IAMCertificateId', 'N/A')
+    cert_source = 'CloudFront Default' if viewer_cert.get('CloudFrontDefaultCertificate') else 'Custom'
+
+    # Get WAF Web ACL ID
+    web_acl_id = dist_config.get('WebACLId', 'N/A')
+
+    # Get viewer protocol policy from default cache behavior
+    viewer_protocol_policy = default_cache_behavior.get('ViewerProtocolPolicy', 'N/A')
+
+    # Get HTTP versions
+    http_version = dist_config.get('HttpVersion', 'N/A')
+
+    # Get IPv6 enabled
+    ipv6_enabled = dist_config.get('IsIPV6Enabled', False)
+
+    # Get geographic restrictions
+    geo_restriction = dist_config.get('Restrictions', {}).get('GeoRestriction', {})
+    geo_restriction_type = geo_restriction.get('RestrictionType', 'none')
+    geo_locations = geo_restriction.get('Items', [])
+    geo_summary = f"{geo_restriction_type.upper()}: {len(geo_locations)} countries" if geo_locations else geo_restriction_type
+
+    # Get logging configuration
+    logging = dist_config.get('Logging', {})
+    logging_enabled = logging.get('Enabled', False)
+    log_bucket = logging.get('Bucket', 'N/A') if logging_enabled else 'Disabled'
+
+    # Get Lambda@Edge and CloudFront Functions
+    lambda_associations = default_cache_behavior.get('LambdaFunctionAssociations', {}).get('Items', [])
+    function_associations = default_cache_behavior.get('FunctionAssociations', {}).get('Items', [])
+    edge_functions = f"Lambda: {len(lambda_associations)}, Functions: {len(function_associations)}"
+
+    # Get last modified time
+    last_modified = dist_info.get('LastModifiedTime', '')
+    if last_modified:
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified, datetime.datetime) else str(last_modified)
+
+    return {
+        'Distribution ID': dist_id,
+        'Domain Name': domain_name,
+        'Status': status,
+        'Enabled': enabled,
+        'Aliases (CNAMEs)': alias_list,
+        'Comment': comment if comment else 'N/A',
+        'Price Class': price_class,
+        'Default Root Object': default_root_object,
+        'Origin Count': origin_count,
+        'Origin Types': origin_summary,
+        'Cache Behavior Count': behavior_count,
+        'Viewer Protocol Policy': viewer_protocol_policy,
+        'HTTP Version': http_version,
+        'IPv6 Enabled': ipv6_enabled,
+        'SSL/TLS Support': ssl_support,
+        'Certificate Source': cert_source,
+        'ACM Certificate ARN': acm_cert_arn,
+        'IAM Certificate ID': iam_cert_id,
+        'WAF Web ACL': web_acl_id,
+        'Geographic Restrictions': geo_summary,
+        'Logging': log_bucket,
+        'Edge Functions': edge_functions,
+        'Last Modified': last_modified
+    }
+
+
 def collect_cloudfront_distributions() -> list[dict[str, Any]]:
     """
     Collect CloudFront distribution information.
-    CloudFront is a global service, so we don't need to iterate regions.
+    CloudFront is a global, account-scope service (not multi-region — see
+    scripts/shield_export.py for the account-scope reference pattern this
+    follows).
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no distributions configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Account-scope failures (client creation, pagination) are
+    allowed to raise so the caller (main) can record this scope as *failed*
+    rather than *empty*. Per-distribution errors are contained internally
+    (logged and skipped) via ``_build_distribution_row``.
 
     Returns:
         list: List of dictionaries with distribution information
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     print("\n=== COLLECTING CLOUDFRONT DISTRIBUTIONS ===")
     utils.log_info("CloudFront is a global service - collecting from global endpoint")
@@ -72,135 +212,32 @@ def collect_cloudfront_distributions() -> list[dict[str, Any]]:
     paginator = cloudfront.get_paginator('list_distributions')
 
     total_count = 0
+    skipped = 0
     for page in paginator.paginate():
         dist_list = page.get('DistributionList', {})
         items = dist_list.get('Items', [])
         total_count += len(items)
 
         for dist_summary in items:
-            dist_id = dist_summary.get('Id', '')
-            domain_name = dist_summary.get('DomainName', '')
+            dist_id = dist_summary.get('Id', 'Unknown')
 
-            print(f"  Processing distribution: {dist_id} ({domain_name})")
-
-            # Get detailed distribution configuration
             try:
-                dist_detail = cloudfront.get_distribution(Id=dist_id)
-                dist_config = dist_detail['Distribution']['DistributionConfig']
-                dist_info = dist_detail['Distribution']
-
-                # Extract basic information
-                status = dist_info.get('Status', '')
-                enabled = dist_config.get('Enabled', False)
-                comment = dist_config.get('Comment', '')
-                price_class = dist_config.get('PriceClass', '')
-
-                # Get alternate domain names (CNAMEs)
-                aliases = dist_config.get('Aliases', {}).get('Items', [])
-                alias_list = ', '.join(aliases) if aliases else 'N/A'
-
-                # Get default root object
-                default_root_object = dist_config.get('DefaultRootObject', 'N/A')
-
-                # Get origin information (count and types)
-                origins = dist_config.get('Origins', {}).get('Items', [])
-                origin_count = len(origins)
-
-                # Categorize origins
-                s3_origins = []
-                custom_origins = []
-                for origin in origins:
-                    if '.s3' in origin.get('DomainName', ''):
-                        s3_origins.append(origin.get('Id', ''))
-                    else:
-                        custom_origins.append(origin.get('Id', ''))
-
-                origin_summary = f"S3: {len(s3_origins)}, Custom: {len(custom_origins)}"
-
-                # Get cache behavior count
-                default_cache_behavior = dist_config.get('DefaultCacheBehavior', {})
-                cache_behaviors = dist_config.get('CacheBehaviors', {}).get('Items', [])
-                behavior_count = 1 + len(cache_behaviors)  # 1 default + custom behaviors
-
-                # Get SSL/TLS information
-                viewer_cert = dist_config.get('ViewerCertificate', {})
-                ssl_support = viewer_cert.get('SSLSupportMethod', 'N/A')
-                acm_cert_arn = viewer_cert.get('ACMCertificateArn', 'N/A')
-                iam_cert_id = viewer_cert.get('IAMCertificateId', 'N/A')
-                cert_source = 'CloudFront Default' if viewer_cert.get('CloudFrontDefaultCertificate') else 'Custom'
-
-                # Get WAF Web ACL ID
-                web_acl_id = dist_config.get('WebACLId', 'N/A')
-
-                # Get viewer protocol policy from default cache behavior
-                viewer_protocol_policy = default_cache_behavior.get('ViewerProtocolPolicy', 'N/A')
-
-                # Get HTTP versions
-                http_version = dist_config.get('HttpVersion', 'N/A')
-
-                # Get IPv6 enabled
-                ipv6_enabled = dist_config.get('IsIPV6Enabled', False)
-
-                # Get geographic restrictions
-                geo_restriction = dist_config.get('Restrictions', {}).get('GeoRestriction', {})
-                geo_restriction_type = geo_restriction.get('RestrictionType', 'none')
-                geo_locations = geo_restriction.get('Items', [])
-                geo_summary = f"{geo_restriction_type.upper()}: {len(geo_locations)} countries" if geo_locations else geo_restriction_type
-
-                # Get logging configuration
-                logging = dist_config.get('Logging', {})
-                logging_enabled = logging.get('Enabled', False)
-                log_bucket = logging.get('Bucket', 'N/A') if logging_enabled else 'Disabled'
-
-                # Get Lambda@Edge and CloudFront Functions
-                lambda_associations = default_cache_behavior.get('LambdaFunctionAssociations', {}).get('Items', [])
-                function_associations = default_cache_behavior.get('FunctionAssociations', {}).get('Items', [])
-                edge_functions = f"Lambda: {len(lambda_associations)}, Functions: {len(function_associations)}"
-
-                # Get last modified time
-                last_modified = dist_info.get('LastModifiedTime', '')
-                if last_modified:
-                    last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified, datetime.datetime) else str(last_modified)
-
-                distributions.append({
-                    'Distribution ID': dist_id,
-                    'Domain Name': domain_name,
-                    'Status': status,
-                    'Enabled': enabled,
-                    'Aliases (CNAMEs)': alias_list,
-                    'Comment': comment if comment else 'N/A',
-                    'Price Class': price_class,
-                    'Default Root Object': default_root_object,
-                    'Origin Count': origin_count,
-                    'Origin Types': origin_summary,
-                    'Cache Behavior Count': behavior_count,
-                    'Viewer Protocol Policy': viewer_protocol_policy,
-                    'HTTP Version': http_version,
-                    'IPv6 Enabled': ipv6_enabled,
-                    'SSL/TLS Support': ssl_support,
-                    'Certificate Source': cert_source,
-                    'ACM Certificate ARN': acm_cert_arn,
-                    'IAM Certificate ID': iam_cert_id,
-                    'WAF Web ACL': web_acl_id,
-                    'Geographic Restrictions': geo_summary,
-                    'Logging': log_bucket,
-                    'Edge Functions': edge_functions,
-                    'Last Modified': last_modified
-                })
-
+                distributions.append(_build_distribution_row(cloudfront, dist_summary))
             except Exception as e:
-                utils.log_error(f"Error getting details for distribution {dist_id}", e)
-                # Add minimal info if we can't get full details
-                distributions.append({
-                    'Distribution ID': dist_id,
-                    'Domain Name': domain_name,
-                    'Status': dist_summary.get('Status', 'Unknown'),
-                    'Enabled': dist_summary.get('Enabled', 'Unknown'),
-                    'Error': f'Could not retrieve full details: {str(e)}'
-                })
+                skipped += 1
+                utils.log_error(
+                    f"Skipping CloudFront distribution '{dist_id}' due to a processing error", e
+                )
+                continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_count} CloudFront distribution(s) were skipped due to "
+            "processing errors (see log above); the remaining distributions were still collected."
+        )
 
     print(f"\nTotal distributions found: {total_count}")
-    utils.log_success(f"Total CloudFront distributions collected: {total_count}")
+    utils.log_success(f"Total CloudFront distributions collected: {len(distributions)}")
 
     return distributions
 
@@ -412,6 +449,16 @@ def export_cloudfront_data(account_id: str, account_name: str):
     """
     Export CloudFront distribution information to an Excel file.
 
+    CloudFront is a global, account-scope service (not multi-region), so
+    failures are tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py for the
+    account-scope reference pattern). A real API error on the ``distributions``
+    scope (the PRIMARY collector) is exported as a partial result (if any
+    enrichment data was collected) and always surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit — it must never be
+    silently collapsed into "no distributions" (07.15.2026 / 07.16.2026
+    audits).
+
     Args:
         account_id: The AWS account ID
         account_name: The AWS account name
@@ -428,32 +475,34 @@ def export_cloudfront_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect distribution overview
-    distributions = collect_cloudfront_distributions()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect distribution overview (PRIMARY scope — a real API error
+    # here must propagate to failed_scopes, never collapse into an empty list
+    # that reads as "no distributions configured").
+    try:
+        distributions = collect_cloudfront_distributions()
+    except Exception as e:
+        failed_scopes.append(('distributions', str(e)))
+        utils.log_error(f"CloudFront distributions collection failed: {e}")
+        distributions = []
     if distributions:
         data_frames['Distributions'] = pd.DataFrame(distributions)
 
-    # STEP 2: Collect origin details
+    # STEP 2+: Enrichment collectors — degrade gracefully to a safe default
+    # via their own aws_error_handler decorators; a failure here does not
+    # fail the whole export.
     origins = collect_origin_details()
     if origins:
         data_frames['Origins'] = pd.DataFrame(origins)
 
-    # STEP 3: Collect cache behaviors
     behaviors = collect_cache_behaviors()
     if behaviors:
         data_frames['Cache Behaviors'] = pd.DataFrame(behaviors)
 
-    # Check if we have any data
-    if not data_frames:
-        utils.log_warning("No CloudFront data was collected. Nothing to export.")
-        print("\nNo CloudFront distributions found in this account.")
-        return
-
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
+    # STEP 3: Create filename (used for both the export and the failure
+    # marker, so it must be computed even when there is no data to export).
     current_date = datetime.datetime.now().strftime("%m.%d.%Y")
     final_excel_file = utils.create_export_filename(
         account_name,
@@ -462,23 +511,49 @@ def export_cloudfront_data(account_id: str, account_name: str):
         current_date
     )
 
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+    # Export whatever succeeded — a partial export is required even when the
+    # distributions scope failed (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
 
-        if output_path:
-            utils.log_success("CloudFront data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
 
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+            if output_path:
+                utils.log_success("CloudFront data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_scopes:
+        # Genuinely empty: distributions scope succeeded, and there is simply
+        # nothing (no distributions, origins, or behaviors) in the account.
+        utils.log_warning("No CloudFront data was collected. Nothing to export.")
+        print("\nNo CloudFront distributions found in this account.")
+
+    # If the distributions scope failed, make it loud: write a marker and
+    # exit non-zero, even if a partial export (enrichment sheets) was
+    # written. A partial export that looks complete is exactly the failure
+    # mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'cloudfront', failed_scopes)
+        print(
+            "\nERROR: CloudFront export completed with failures — data is "
+            "incomplete. See the *-cloudfront-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -47,16 +47,129 @@ except ImportError:
 args = utils.parse_script_args("Export CloudTrail trails and event history to Excel")
 
 
-@utils.aws_error_handler("Collecting CloudTrail trails from region", default_return=[])
+def _build_trail_row(ct_client, trail_summary: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single CloudTrail trail.
+
+    Extracted so the per-trail processing can be wrapped in try/except by
+    the caller: a malformed/inaccessible trail is logged and skipped rather
+    than discarding the whole region's results. Every field is read with
+    ``.get()`` and a safe default for the same reason.
+
+    Args:
+        ct_client: boto3 CloudTrail client for the region.
+        trail_summary: A single Trails entry from list_trails.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled trail row.
+    """
+    trail_arn = trail_summary.get('TrailARN', '')
+    trail_name = trail_summary.get('Name', '')
+
+    utils.log_info(f"Processing trail: {trail_name} in {region}")
+
+    # Get trail status
+    status_response = ct_client.get_trail_status(Name=trail_arn)
+
+    is_logging = status_response.get('IsLogging', False)
+    latest_delivery_time = status_response.get('LatestDeliveryTime', '')
+    if latest_delivery_time:
+        latest_delivery_time = latest_delivery_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(latest_delivery_time, datetime.datetime) else str(latest_delivery_time)
+
+    latest_notification_time = status_response.get('LatestNotificationTime', '')
+    if latest_notification_time:
+        latest_notification_time = latest_notification_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(latest_notification_time, datetime.datetime) else str(latest_notification_time)
+
+    # Get trail details
+    trail_list = ct_client.describe_trails(trailNameList=[trail_name])
+    trail_details = (trail_list.get('trailList') or [{}])[0]
+
+    # S3 bucket
+    s3_bucket = trail_details.get('S3BucketName', '')
+
+    # S3 key prefix
+    s3_prefix = trail_details.get('S3KeyPrefix', 'N/A')
+
+    # SNS topic
+    sns_topic = trail_details.get('SnsTopicARN', 'N/A')
+
+    # CloudWatch Logs
+    log_group_arn = trail_details.get('CloudWatchLogsLogGroupArn', 'N/A')
+    log_role_arn = trail_details.get('CloudWatchLogsRoleArn', 'N/A')
+
+    # KMS key
+    kms_key_id = trail_details.get('KmsKeyId', 'N/A')
+
+    # Multi-region trail
+    is_multi_region = trail_details.get('IsMultiRegionTrail', False)
+
+    # Organization trail
+    is_organization_trail = trail_details.get('IsOrganizationTrail', False)
+
+    # Home region
+    home_region = trail_details.get('HomeRegion', region)
+
+    # Log file validation
+    log_file_validation = trail_details.get('LogFileValidationEnabled', False)
+
+    # Include global service events
+    include_global_events = trail_details.get('IncludeGlobalServiceEvents', False)
+
+    # Has custom event selectors
+    has_custom_selectors = trail_details.get('HasCustomEventSelectors', False)
+
+    # Has insight selectors
+    has_insight_selectors = trail_details.get('HasInsightSelectors', False)
+
+    return {
+        'Region': region,
+        'Trail Name': trail_name,
+        'Trail ARN': trail_arn,
+        'Home Region': home_region,
+        'Is Logging': is_logging,
+        'Multi-Region': is_multi_region,
+        'Organization Trail': is_organization_trail,
+        'S3 Bucket': s3_bucket,
+        'S3 Prefix': s3_prefix,
+        'Log File Validation': log_file_validation,
+        'KMS Encryption': 'Yes' if kms_key_id != 'N/A' else 'No',
+        'KMS Key ID': kms_key_id,
+        'CloudWatch Logs': 'Yes' if log_group_arn != 'N/A' else 'No',
+        'Log Group ARN': log_group_arn,
+        'Log Role ARN': log_role_arn,
+        'SNS Topic': sns_topic,
+        'Include Global Events': include_global_events,
+        'Has Custom Selectors': has_custom_selectors,
+        'Has Insight Selectors': has_insight_selectors,
+        'Latest Delivery': latest_delivery_time if latest_delivery_time else 'Never',
+        'Latest Notification': latest_notification_time if latest_notification_time else 'Never'
+    }
+
+
 def collect_trails_from_region(region: str) -> list[dict[str, Any]]:
     """
     Collect CloudTrail trail information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no CloudTrail trails" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/inaccessible trails are skipped (logged) rather than
+    aborting the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with trail information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
         utils.log_error(f"Skipping invalid AWS region: {region}")
@@ -71,114 +184,45 @@ def collect_trails_from_region(region: str) -> list[dict[str, Any]]:
     trails = trails_response.get('Trails', [])
 
     for trail_summary in trails:
-        trail_arn = trail_summary.get('TrailARN', '')
         trail_name = trail_summary.get('Name', '')
 
-        utils.log_info(f"Processing trail: {trail_name} in {region}")
-
         try:
-            # Get trail status
-            status_response = ct_client.get_trail_status(Name=trail_arn)
-
-            is_logging = status_response.get('IsLogging', False)
-            latest_delivery_time = status_response.get('LatestDeliveryTime', '')
-            if latest_delivery_time:
-                latest_delivery_time = latest_delivery_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(latest_delivery_time, datetime.datetime) else str(latest_delivery_time)
-
-            latest_notification_time = status_response.get('LatestNotificationTime', '')
-            if latest_notification_time:
-                latest_notification_time = latest_notification_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(latest_notification_time, datetime.datetime) else str(latest_notification_time)
-
-            # Get trail details
-            trail_list = ct_client.describe_trails(trailNameList=[trail_name])
-            trail_details = trail_list.get('trailList', [{}])[0]
-
-            # S3 bucket
-            s3_bucket = trail_details.get('S3BucketName', '')
-
-            # S3 key prefix
-            s3_prefix = trail_details.get('S3KeyPrefix', 'N/A')
-
-            # SNS topic
-            sns_topic = trail_details.get('SnsTopicARN', 'N/A')
-
-            # CloudWatch Logs
-            log_group_arn = trail_details.get('CloudWatchLogsLogGroupArn', 'N/A')
-            log_role_arn = trail_details.get('CloudWatchLogsRoleArn', 'N/A')
-
-            # KMS key
-            kms_key_id = trail_details.get('KmsKeyId', 'N/A')
-
-            # Multi-region trail
-            is_multi_region = trail_details.get('IsMultiRegionTrail', False)
-
-            # Organization trail
-            is_organization_trail = trail_details.get('IsOrganizationTrail', False)
-
-            # Home region
-            home_region = trail_details.get('HomeRegion', region)
-
-            # Log file validation
-            log_file_validation = trail_details.get('LogFileValidationEnabled', False)
-
-            # Include global service events
-            include_global_events = trail_details.get('IncludeGlobalServiceEvents', False)
-
-            # Has custom event selectors
-            has_custom_selectors = trail_details.get('HasCustomEventSelectors', False)
-
-            # Has insight selectors
-            has_insight_selectors = trail_details.get('HasInsightSelectors', False)
-
-            trails_data.append({
-                'Region': region,
-                'Trail Name': trail_name,
-                'Trail ARN': trail_arn,
-                'Home Region': home_region,
-                'Is Logging': is_logging,
-                'Multi-Region': is_multi_region,
-                'Organization Trail': is_organization_trail,
-                'S3 Bucket': s3_bucket,
-                'S3 Prefix': s3_prefix,
-                'Log File Validation': log_file_validation,
-                'KMS Encryption': 'Yes' if kms_key_id != 'N/A' else 'No',
-                'KMS Key ID': kms_key_id,
-                'CloudWatch Logs': 'Yes' if log_group_arn != 'N/A' else 'No',
-                'Log Group ARN': log_group_arn,
-                'Log Role ARN': log_role_arn,
-                'SNS Topic': sns_topic,
-                'Include Global Events': include_global_events,
-                'Has Custom Selectors': has_custom_selectors,
-                'Has Insight Selectors': has_insight_selectors,
-                'Latest Delivery': latest_delivery_time if latest_delivery_time else 'Never',
-                'Latest Notification': latest_notification_time if latest_notification_time else 'Never'
-            })
-
+            trails_data.append(_build_trail_row(ct_client, trail_summary, region))
         except Exception as e:
+            # One malformed/inaccessible trail is skipped, not fatal to the region.
             utils.log_warning(f"Could not get details for trail {trail_name}: {e}")
+            continue
 
     utils.log_info(f"Found {len(trails_data)} trails in {region}")
     return trails_data
 
 
-def collect_trails(regions: list[str]) -> list[dict[str, Any]]:
+def collect_trails(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
     """
     Collect CloudTrail trail information from AWS regions using concurrent scanning.
+
+    Uses ``collect_failures=True``: ``collect_trails_from_region`` raises on a
+    region-level failure so that failure is recorded and surfaced by the
+    caller, never silently collapsed into "no trails" (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with trail information (deduplicated by ARN)
+        tuple: (trails, failed_regions) where trails is deduplicated by Trail
+            ARN and failed_regions is a list of (region, error_message)
+            tuples for regions whose scan raised.
     """
     print("\n=== COLLECTING CLOUDTRAIL TRAILS ===")
     utils.log_info(f"Scanning {len(regions)} regions for CloudTrail trails...")
 
     # Use concurrent region scanning
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_trails_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results and deduplicate by Trail ARN (for multi-region trails)
@@ -196,7 +240,7 @@ def collect_trails(regions: list[str]) -> list[dict[str, Any]]:
                 all_trails.append(trail)
 
     utils.log_success(f"Total CloudTrail trails collected (deduplicated): {len(all_trails)}")
-    return all_trails
+    return all_trails, failed_regions
 
 
 @utils.aws_error_handler("Collecting event selectors from region", default_return=[])
@@ -475,63 +519,81 @@ def export_cloudtrail_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect trails
-    trails = collect_trails(regions)
+    # STEP 1: Collect trails (primary scope — region failures must propagate
+    # as failed_regions, never collapse into "empty").
+    trails, failed_regions = collect_trails(regions)
     if trails:
         data_frames['Trails'] = pd.DataFrame(trails)
 
-    # STEP 2: Collect event selectors
+    # STEP 2: Collect event selectors (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     selectors = collect_event_selectors(regions)
     if selectors:
         data_frames['Event Selectors'] = pd.DataFrame(selectors)
 
-    # STEP 3: Collect insight selectors
+    # STEP 3: Collect insight selectors (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     insights = collect_insight_selectors(regions)
     if insights:
         data_frames['Insight Selectors'] = pd.DataFrame(insights)
 
-    # STEP 4: Collect CloudTrail Lake event data stores
+    # STEP 4: Collect CloudTrail Lake event data stores (enrichment —
+    # degrades gracefully; a region-level failure here does not fail the
+    # whole export).
     event_data_stores = collect_event_data_stores(regions)
     if event_data_stores:
         data_frames['Event Data Stores'] = pd.DataFrame(event_data_stores)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'cloudtrail',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("CloudTrail data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No CloudTrail data was collected. Nothing to export.")
         print("\nNo CloudTrail trails found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'cloudtrail',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("CloudTrail data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary Trails scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was exported.
+    # A partial export that looks complete is exactly the failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'cloudtrail', failed_regions)
+        print(
+            "\nERROR: CloudTrail export completed with failures — data is incomplete. "
+            "See the *-cloudtrail-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/directconnect_export.py
+++ b/scripts/directconnect_export.py
@@ -52,81 +52,117 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Direct Connect connections and virtual interfaces to Excel")
 
 
+def _build_connection_row(conn: dict, region: str) -> dict[str, Any]:
+    """Build a single Direct Connect connection export row."""
+    connection_id = conn.get('connectionId', 'N/A')
+
+    # Extract connection details
+    connection_name = conn.get('connectionName', 'N/A')
+    connection_state = conn.get('connectionState', 'N/A')
+    location = conn.get('location', 'N/A')
+    bandwidth = conn.get('bandwidth', 'N/A')
+    vlan = conn.get('vlan', 'N/A')
+    partner_name = conn.get('partnerName', 'N/A')
+    lag_id = conn.get('lagId', 'N/A')
+    aws_device = conn.get('awsDevice', 'N/A')
+    aws_device_v2 = conn.get('awsDeviceV2', 'N/A')
+    provider_name = conn.get('providerName', 'N/A')
+    owner_account = conn.get('ownerAccount', 'N/A')
+    has_logical_redundancy = conn.get('hasLogicalRedundancy', 'unknown')
+    jumbo_frame_capable = conn.get('jumboFrameCapable', False)
+    aws_logical_device_id = conn.get('awsLogicalDeviceId', 'N/A')
+
+    # Get tags
+    tags = conn.get('tags', [])
+    tag_string = ', '.join([f"{tag.get('key', '')}={tag.get('value', '')}" for tag in tags]) if tags else 'N/A'
+
+    return {
+        'Region': region,
+        'Connection ID': connection_id,
+        'Connection Name': connection_name,
+        'State': connection_state,
+        'Location': location,
+        'Bandwidth': bandwidth,
+        'VLAN': vlan,
+        'Partner Name': partner_name,
+        'Provider Name': provider_name,
+        'LAG ID': lag_id,
+        'AWS Device': aws_device_v2 if aws_device_v2 != 'N/A' else aws_device,
+        'AWS Logical Device ID': aws_logical_device_id,
+        'Owner Account': owner_account,
+        'Has Logical Redundancy': has_logical_redundancy,
+        'Jumbo Frame Capable': jumbo_frame_capable,
+        'Tags': tag_string
+    }
+
+
 def _scan_connections_region(region: str) -> list[dict[str, Any]]:
-    """Scan Direct Connect connections in a single region."""
+    """
+    Scan Direct Connect connections in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Direct Connect connections"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed connections are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
     regional_connections = []
 
-    try:
-        dx = utils.get_boto3_client('directconnect', region_name=region)
+    dx = utils.get_boto3_client('directconnect', region_name=region)
 
-        # Get Direct Connect connections
-        response = dx.describe_connections()
-        connections = response.get('connections', [])
+    # Get Direct Connect connections
+    response = dx.describe_connections()
+    connections = response.get('connections', [])
 
-        for conn in connections:
-            connection_id = conn.get('connectionId', 'N/A')
+    for conn in connections:
+        try:
+            regional_connections.append(_build_connection_row(conn, region))
+        except Exception as e:
+            # One malformed connection is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed Direct Connect connection in {region}: "
+                f"{conn.get('connectionId', '<unknown>')}",
+                e,
+            )
+            continue
 
-            # Extract connection details
-            connection_name = conn.get('connectionName', 'N/A')
-            connection_state = conn.get('connectionState', 'N/A')
-            location = conn.get('location', 'N/A')
-            bandwidth = conn.get('bandwidth', 'N/A')
-            vlan = conn.get('vlan', 'N/A')
-            partner_name = conn.get('partnerName', 'N/A')
-            lag_id = conn.get('lagId', 'N/A')
-            aws_device = conn.get('awsDevice', 'N/A')
-            aws_device_v2 = conn.get('awsDeviceV2', 'N/A')
-            provider_name = conn.get('providerName', 'N/A')
-            owner_account = conn.get('ownerAccount', 'N/A')
-            has_logical_redundancy = conn.get('hasLogicalRedundancy', 'unknown')
-            jumbo_frame_capable = conn.get('jumboFrameCapable', False)
-            aws_logical_device_id = conn.get('awsLogicalDeviceId', 'N/A')
-
-            # Get tags
-            tags = conn.get('tags', [])
-            tag_string = ', '.join([f"{tag['key']}={tag['value']}" for tag in tags]) if tags else 'N/A'
-
-            regional_connections.append({
-                'Region': region,
-                'Connection ID': connection_id,
-                'Connection Name': connection_name,
-                'State': connection_state,
-                'Location': location,
-                'Bandwidth': bandwidth,
-                'VLAN': vlan,
-                'Partner Name': partner_name,
-                'Provider Name': provider_name,
-                'LAG ID': lag_id,
-                'AWS Device': aws_device_v2 if aws_device_v2 != 'N/A' else aws_device,
-                'AWS Logical Device ID': aws_logical_device_id,
-                'Owner Account': owner_account,
-                'Has Logical Redundancy': has_logical_redundancy,
-                'Jumbo Frame Capable': jumbo_frame_capable,
-                'Tags': tag_string
-            })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting Direct Connect connections in {region}", e)
-
+    print(f"  Found {len(connections)} Direct Connect connections")
     return regional_connections
 
 
-@utils.aws_error_handler("Collecting Direct Connect connections", default_return=[])
-def collect_connections(regions: list[str]) -> list[dict[str, Any]]:
+def collect_connections(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Direct Connect connection information from AWS regions.
+    Collect Direct Connect connection information across regions, surfacing
+    failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with connection information
+        tuple: ``(connections, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING DIRECT CONNECT CONNECTIONS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_connections_region)
-    all_connections = [conn for result in results for conn in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_connections_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_connections = [conn for result in region_results for conn in result]
     utils.log_success(f"Total Direct Connect connections collected: {len(all_connections)}")
-    return all_connections
+    return all_connections, failed_regions
 
 
 def _scan_virtual_interfaces_region(region: str) -> list[dict[str, Any]]:
@@ -619,12 +655,14 @@ def export_directconnect_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Connections
-    connections = collect_connections(regions)
+    # STEP 1: Collect Connections (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    connections, failed_regions = collect_connections(regions)
     if connections:
         data_frames['Connections'] = pd.DataFrame(connections)
 
-    # STEP 2: Collect Virtual Interfaces
+    # STEP 2: Collect Virtual Interfaces (enrichment — degrades gracefully;
+    # a region-level failure here does not fail the whole export).
     vifs = collect_virtual_interfaces(regions)
     if vifs:
         data_frames['Virtual Interfaces'] = pd.DataFrame(vifs)
@@ -649,50 +687,64 @@ def export_directconnect_data(account_id: str, account_name: str):
     if tgw_associations:
         data_frames['TGW Associations'] = pd.DataFrame(tgw_associations)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure
+    # blast-radius audit).
+    if data_frames:
+        # STEP 7: Create Summary
+        summary_data = create_summary(data_frames)
+        if summary_data:
+            data_frames['Summary'] = pd.DataFrame(summary_data)
+
+        # STEP 8: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 9: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'directconnect',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Direct Connect data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                print("\n=== EXPORT SUMMARY ===")
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Direct Connect data was collected. Nothing to export.")
         print("\nNo Direct Connect resources found in the selected region(s).")
         print("This is normal if Direct Connect is not configured in this account.")
-        return
 
-    # STEP 7: Create Summary
-    summary_data = create_summary(data_frames)
-    if summary_data:
-        data_frames['Summary'] = pd.DataFrame(summary_data)
-
-    # STEP 8: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 9: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'directconnect',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Direct Connect data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            print("\n=== EXPORT SUMMARY ===")
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the Direct Connect Connections scope collection,
+    # make it loud: write a marker and exit non-zero, even if some data (from
+    # this scope or the enrichment sheets) was exported. A partial export
+    # that looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'directconnect', failed_regions)
+        print(
+            "\nERROR: Direct Connect export completed with failures — data is incomplete. "
+            "See the *-directconnect-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/globalaccelerator_export.py
+++ b/scripts/globalaccelerator_export.py
@@ -57,13 +57,83 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Global Accelerator accelerators to Excel")
 
 
-@utils.aws_error_handler("Collecting Global Accelerators", default_return=[])
+def _build_accelerator_row(acc: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single Global Accelerator.
+
+    Extracted so the per-accelerator processing can be wrapped in
+    try/except by the caller: a malformed accelerator entry is logged and
+    skipped rather than discarding the whole account-scope collection.
+    Every field is read with ``.get()`` and a safe default for the same
+    reason.
+
+    Args:
+        acc: A single Accelerators entry from list_accelerators.
+
+    Returns:
+        dict: The assembled accelerator row.
+    """
+    acc_arn = acc.get('AcceleratorArn', 'N/A')
+    print(f"  Processing accelerator: {acc.get('Name', 'N/A')}")
+
+    # Extract accelerator details
+    name = acc.get('Name', 'N/A')
+    enabled = acc.get('Enabled', False)
+    status = acc.get('Status', 'N/A')
+    ip_address_type = acc.get('IpAddressType', 'N/A')
+    dns_name = acc.get('DnsName', 'N/A')
+    created_time = acc.get('CreatedTime', '')
+    last_modified_time = acc.get('LastModifiedTime', '')
+
+    # Format timestamps
+    if created_time:
+        created_time = created_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_time, datetime.datetime) else str(created_time)
+    if last_modified_time:
+        last_modified_time = last_modified_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified_time, datetime.datetime) else str(last_modified_time)
+
+    # Get IP addresses
+    ip_sets = acc.get('IpSets', [])
+    ip_addresses = []
+    for ip_set in ip_sets:
+        ip_addresses.extend(ip_set.get('IpAddresses', []))
+
+    ip_addresses_str = ', '.join(ip_addresses) if ip_addresses else 'N/A'
+
+    return {
+        'Accelerator ARN': acc_arn,
+        'Name': name,
+        'Status': status,
+        'Enabled': enabled,
+        'IP Address Type': ip_address_type,
+        'IP Addresses': ip_addresses_str,
+        'DNS Name': dns_name,
+        'Created Time': created_time,
+        'Last Modified Time': last_modified_time
+    }
+
+
 def collect_accelerators() -> list[dict[str, Any]]:
     """
     Collect Global Accelerator information.
 
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no accelerators configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Global Accelerator is a global, account-scope service (control
+    plane in us-west-2, no per-region scan -- see scripts/shield_export.py
+    for the account-scope reference pattern this follows). Account-scope
+    failures (client creation, pagination) are allowed to raise so the
+    caller (export_globalaccelerator_data) can record this scope as *failed*
+    rather than *empty*. Per-accelerator errors are contained internally
+    (logged and skipped) via ``_build_accelerator_row``.
+
     Returns:
         list: List of dictionaries with accelerator information
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     print("\n=== COLLECTING GLOBAL ACCELERATORS ===")
     all_accelerators = []
@@ -72,59 +142,37 @@ def collect_accelerators() -> list[dict[str, Any]]:
     region = 'us-west-2'
     print(f"\nQuerying Global Accelerators (global service via {region})")
 
-    try:
-        globalaccelerator = utils.get_boto3_client('globalaccelerator', region_name=region)
+    globalaccelerator = utils.get_boto3_client('globalaccelerator', region_name=region)
 
-        # Get accelerators
-        paginator = globalaccelerator.get_paginator('list_accelerators')
+    # Get accelerators
+    paginator = globalaccelerator.get_paginator('list_accelerators')
 
-        for page in paginator.paginate():
-            accelerators = page.get('Accelerators', [])
+    total = 0
+    skipped = 0
 
-            for acc in accelerators:
-                acc_arn = acc.get('AcceleratorArn', 'N/A')
-                print(f"  Processing accelerator: {acc.get('Name', 'N/A')}")
+    for page in paginator.paginate():
+        accelerators = page.get('Accelerators', [])
+        total += len(accelerators)
 
-                # Extract accelerator details
-                name = acc.get('Name', 'N/A')
-                enabled = acc.get('Enabled', False)
-                status = acc.get('Status', 'N/A')
-                ip_address_type = acc.get('IpAddressType', 'N/A')
-                dns_name = acc.get('DnsName', 'N/A')
-                created_time = acc.get('CreatedTime', '')
-                last_modified_time = acc.get('LastModifiedTime', '')
+        # Process each accelerator. One malformed accelerator must not sink
+        # the whole account-scope collection, so each is built inside
+        # try/except; failures are logged and skipped.
+        for acc in accelerators:
+            try:
+                all_accelerators.append(_build_accelerator_row(acc))
+            except Exception as e:
+                skipped += 1
+                acc_name = acc.get('Name', 'Unknown') if isinstance(acc, dict) else 'Unknown'
+                utils.log_error(f"Skipping Global Accelerator '{acc_name}' due to a processing error", e)
+                continue
 
-                # Format timestamps
-                if created_time:
-                    created_time = created_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_time, datetime.datetime) else str(created_time)
-                if last_modified_time:
-                    last_modified_time = last_modified_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_modified_time, datetime.datetime) else str(last_modified_time)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total} Global Accelerator(s) were skipped due to "
+            "processing errors (see log above); the remaining accelerators were still collected."
+        )
 
-                # Get IP addresses
-                ip_sets = acc.get('IpSets', [])
-                ip_addresses = []
-                for ip_set in ip_sets:
-                    ip_addresses.extend(ip_set.get('IpAddresses', []))
-
-                ip_addresses_str = ', '.join(ip_addresses) if ip_addresses else 'N/A'
-
-                all_accelerators.append({
-                    'Accelerator ARN': acc_arn,
-                    'Name': name,
-                    'Status': status,
-                    'Enabled': enabled,
-                    'IP Address Type': ip_address_type,
-                    'IP Addresses': ip_addresses_str,
-                    'DNS Name': dns_name,
-                    'Created Time': created_time,
-                    'Last Modified Time': last_modified_time
-                })
-
-        print(f"  Found {len(all_accelerators)} accelerators")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting Global Accelerators from {region}", e)
-
+    print(f"  Found {len(all_accelerators)} accelerators")
     utils.log_success(f"Total accelerators collected: {len(all_accelerators)}")
     return all_accelerators
 
@@ -613,6 +661,17 @@ def export_globalaccelerator_data(account_id: str, account_name: str):
     """
     Export Global Accelerator information to an Excel file.
 
+    Global Accelerator is a global, account-scope service (not multi-region),
+    so ``collect_accelerators()`` failures are tracked via a local
+    ``failed_scopes`` list rather than ``utils.scan_regions_concurrent`` (see
+    scripts/shield_export.py for the account-scope reference pattern, and
+    scripts/lambda_export.py for this finalize shape). A real API error on
+    the accelerators scope is exported as a partial result (if any other
+    data was collected) and always surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit -- it must never
+    be silently collapsed into "no accelerators" (07.15.2026 / 07.16.2026
+    audits).
+
     Args:
         account_id: The AWS account ID
         account_name: The AWS account name
@@ -638,99 +697,129 @@ def export_globalaccelerator_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Standard Accelerators
-    accelerators = collect_accelerators()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect Standard Accelerators (PRIMARY scope -- a real API
+    # error here must propagate to failed_scopes, never collapse into an
+    # empty list that reads as "no accelerators configured").
+    try:
+        accelerators = collect_accelerators()
+    except Exception as e:
+        failed_scopes.append(('accelerators', str(e)))
+        utils.log_error(f"Global Accelerator collection failed: {e}")
+        accelerators = []
+
     if accelerators:
         data_frames['Accelerators'] = pd.DataFrame(accelerators)
 
         # Get ARNs for further queries
-        accelerator_arns = [acc['Accelerator ARN'] for acc in accelerators]
+        accelerator_arns = [acc.get('Accelerator ARN', '') for acc in accelerators if acc.get('Accelerator ARN')]
 
-        # STEP 2: Collect Listeners
+        # STEP 2: Collect Listeners (enrichment -- degrades gracefully)
         listeners = collect_listeners(accelerator_arns)
         if listeners:
             data_frames['Listeners'] = pd.DataFrame(listeners)
 
             # Get listener ARNs
-            listener_arns = [listener['Listener ARN'] for listener in listeners]
+            listener_arns = [listener.get('Listener ARN', '') for listener in listeners if listener.get('Listener ARN')]
 
-            # STEP 3: Collect Endpoint Groups
+            # STEP 3: Collect Endpoint Groups (enrichment -- degrades gracefully)
             endpoint_groups = collect_endpoint_groups(listener_arns)
             if endpoint_groups:
                 data_frames['Endpoint Groups'] = pd.DataFrame(endpoint_groups)
 
                 # Get endpoint group ARNs
-                endpoint_group_arns = [eg['Endpoint Group ARN'] for eg in endpoint_groups]
+                endpoint_group_arns = [eg.get('Endpoint Group ARN', '') for eg in endpoint_groups if eg.get('Endpoint Group ARN')]
 
-                # STEP 4: Collect Endpoints
+                # STEP 4: Collect Endpoints (enrichment -- degrades gracefully)
                 endpoints = collect_endpoints(endpoint_group_arns)
                 if endpoints:
                     data_frames['Endpoints'] = pd.DataFrame(endpoints)
 
-    # STEP 5: Collect Custom Routing Accelerators
+    # STEP 5: Collect Custom Routing Accelerators (enrichment -- degrades gracefully)
     custom_accelerators = collect_custom_routing_accelerators()
     if custom_accelerators:
         data_frames['Custom Routing Accelerators'] = pd.DataFrame(custom_accelerators)
 
         # Get custom routing accelerator ARNs
-        custom_accelerator_arns = [acc['Accelerator ARN'] for acc in custom_accelerators]
+        custom_accelerator_arns = [acc.get('Accelerator ARN', '') for acc in custom_accelerators if acc.get('Accelerator ARN')]
 
-        # STEP 6: Collect Custom Routing Listeners
+        # STEP 6: Collect Custom Routing Listeners (enrichment -- degrades gracefully)
         custom_listeners = collect_custom_routing_listeners(custom_accelerator_arns)
         if custom_listeners:
             data_frames['Custom Routing Listeners'] = pd.DataFrame(custom_listeners)
 
             # Get custom routing listener ARNs
-            custom_listener_arns = [listener['Listener ARN'] for listener in custom_listeners]
+            custom_listener_arns = [listener.get('Listener ARN', '') for listener in custom_listeners if listener.get('Listener ARN')]
 
-            # STEP 7: Collect Custom Routing Endpoint Groups
+            # STEP 7: Collect Custom Routing Endpoint Groups (enrichment -- degrades gracefully)
             custom_endpoint_groups = collect_custom_routing_endpoint_groups(custom_listener_arns)
             if custom_endpoint_groups:
                 data_frames['Custom Routing Endpoint Groups'] = pd.DataFrame(custom_endpoint_groups)
 
-    # Check if we have any data
+    # Check if we have any data. Export whatever succeeded -- a partial
+    # export is required even when the accelerators scope failed (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
     if not data_frames:
-        utils.log_warning("No Global Accelerator data was collected. Nothing to export.")
-        print("\nNo Global Accelerator resources found in this account.")
-        print("This is normal if Global Accelerator is not configured.")
-        return
-
-    # STEP 8: Create Summary
-    summary_data = create_summary(data_frames)
-    if summary_data:
-        data_frames['Summary'] = pd.DataFrame(summary_data)
-
-    # STEP 9: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 10: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'globalaccelerator',
-        '',
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Global Accelerator data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-
-            # Summary of exported data
-            print("\n=== EXPORT SUMMARY ===")
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
+        if failed_scopes:
+            utils.log_error("Global Accelerator collection failed; no data was exported.")
         else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+            # Genuinely empty: the accelerators scope succeeded and there is
+            # simply nothing configured.
+            utils.log_warning("No Global Accelerator data was collected. Nothing to export.")
+            print("\nNo Global Accelerator resources found in this account.")
+            print("This is normal if Global Accelerator is not configured.")
+    else:
+        # STEP 8: Create Summary
+        summary_data = create_summary(data_frames)
+        if summary_data:
+            data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+        # STEP 9: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 10: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'globalaccelerator',
+            '',
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Global Accelerator data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+
+                # Summary of exported data
+                print("\n=== EXPORT SUMMARY ===")
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+
+    # If the accelerators scope failed, make it loud: write a marker and
+    # exit non-zero, even if a partial export (enrichment or custom routing
+    # sheets) was written. A partial export that looks complete is exactly
+    # the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'globalaccelerator', failed_scopes)
+        print(
+            "\nERROR: Global Accelerator export completed with failures — data is "
+            "incomplete. See the *-globalaccelerator-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/network_firewall_export.py
+++ b/scripts/network_firewall_export.py
@@ -47,18 +47,111 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Network Firewall policies and rule groups to Excel")
 
 
-@utils.aws_error_handler("Collecting Network Firewalls from region", default_return=[])
+def _build_firewall_row(item: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build a single Network Firewall export row from a describe_firewall response.
+
+    Args:
+        item: The describe_firewall response (contains 'Firewall' and
+            'FirewallStatus').
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled firewall row.
+    """
+    firewall = item.get('Firewall', {})
+    firewall_status = item.get('FirewallStatus', {})
+
+    # Basic information
+    firewall_name = firewall.get('FirewallName', '')
+    firewall_arn = firewall.get('FirewallArn', '')
+    firewall_id = firewall.get('FirewallId', '')
+    vpc_id = firewall.get('VpcId', '')
+    description = firewall.get('Description', 'N/A')
+    firewall_policy_arn = firewall.get('FirewallPolicyArn', '')
+    delete_protection = firewall.get('DeleteProtection', False)
+    subnet_change_protection = firewall.get('SubnetChangeProtection', False)
+    firewall_policy_change_protection = firewall.get('FirewallPolicyChangeProtection', False)
+
+    # Status information
+    status = firewall_status.get('Status', '')
+    configuration_sync_state = firewall_status.get('ConfigurationSyncStateSummary', 'N/A')
+
+    # Subnet mappings
+    subnet_mappings = firewall.get('SubnetMappings', [])
+    subnet_ids = [sm.get('SubnetId', '') for sm in subnet_mappings]
+    subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
+    subnet_count = len(subnet_ids)
+
+    # Firewall endpoints (one per AZ)
+    sync_states = firewall_status.get('SyncStates', {})
+    endpoint_ids = []
+    for az, sync_state in sync_states.items():
+        attachment = sync_state.get('Attachment', {})
+        endpoint_id = attachment.get('EndpointId', '')
+        if endpoint_id:
+            endpoint_ids.append(f"{az}:{endpoint_id}")
+
+    endpoints_str = ', '.join(endpoint_ids) if endpoint_ids else 'N/A'
+
+    # Get encryption configuration
+    encryption_config = firewall.get('EncryptionConfiguration', {})
+    encryption_type = encryption_config.get('Type', 'N/A')
+    kms_key_id = encryption_config.get('KeyId', 'N/A')
+
+    # Get tags
+    tags = firewall.get('Tags', [])
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    return {
+        'Region': region,
+        'Firewall Name': firewall_name,
+        'Firewall ID': firewall_id,
+        'Status': status,
+        'VPC ID': vpc_id,
+        'Subnet Count': subnet_count,
+        'Subnet IDs': subnet_ids_str,
+        'Endpoints': endpoints_str,
+        'Firewall Policy ARN': firewall_policy_arn,
+        'Configuration Sync State': configuration_sync_state,
+        'Delete Protection': delete_protection,
+        'Subnet Change Protection': subnet_change_protection,
+        'Policy Change Protection': firewall_policy_change_protection,
+        'Encryption Type': encryption_type,
+        'KMS Key ID': kms_key_id,
+        'Description': description,
+        'Tags': tags_str,
+        'Firewall ARN': firewall_arn
+    }
+
+
 def collect_network_firewalls_from_region(region: str) -> list[dict[str, Any]]:
     """
     Collect Network Firewall information from a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Network Firewalls" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed firewalls are skipped (logged) rather than aborting
+    the whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of dictionaries with firewall information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
     if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
         return []
 
     firewalls = []
@@ -79,94 +172,39 @@ def collect_network_firewalls_from_region(region: str) -> list[dict[str, Any]]:
             try:
                 # Get detailed firewall information
                 fw_response = nfw.describe_firewall(FirewallArn=firewall_arn)
-                firewall = fw_response.get('Firewall', {})
-                firewall_status = fw_response.get('FirewallStatus', {})
-
-                # Basic information
-                firewall_id = firewall.get('FirewallId', '')
-                vpc_id = firewall.get('VpcId', '')
-                description = firewall.get('Description', 'N/A')
-                firewall_policy_arn = firewall.get('FirewallPolicyArn', '')
-                delete_protection = firewall.get('DeleteProtection', False)
-                subnet_change_protection = firewall.get('SubnetChangeProtection', False)
-                firewall_policy_change_protection = firewall.get('FirewallPolicyChangeProtection', False)
-
-                # Status information
-                status = firewall_status.get('Status', '')
-                configuration_sync_state = firewall_status.get('ConfigurationSyncStateSummary', 'N/A')
-
-                # Subnet mappings
-                subnet_mappings = firewall.get('SubnetMappings', [])
-                subnet_ids = [sm.get('SubnetId', '') for sm in subnet_mappings]
-                subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
-                subnet_count = len(subnet_ids)
-
-                # Firewall endpoints (one per AZ)
-                sync_states = firewall_status.get('SyncStates', {})
-                endpoint_ids = []
-                for az, sync_state in sync_states.items():
-                    attachment = sync_state.get('Attachment', {})
-                    endpoint_id = attachment.get('EndpointId', '')
-                    if endpoint_id:
-                        endpoint_ids.append(f"{az}:{endpoint_id}")
-
-                endpoints_str = ', '.join(endpoint_ids) if endpoint_ids else 'N/A'
-
-                # Get encryption configuration
-                encryption_config = firewall.get('EncryptionConfiguration', {})
-                encryption_type = encryption_config.get('Type', 'N/A')
-                kms_key_id = encryption_config.get('KeyId', 'N/A')
-
-                # Get tags
-                tags = firewall.get('Tags', [])
-                tag_dict = {tag['Key']: tag['Value'] for tag in tags}
-                tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-                firewalls.append({
-                    'Region': region,
-                    'Firewall Name': firewall_name,
-                    'Firewall ID': firewall_id,
-                    'Status': status,
-                    'VPC ID': vpc_id,
-                    'Subnet Count': subnet_count,
-                    'Subnet IDs': subnet_ids_str,
-                    'Endpoints': endpoints_str,
-                    'Firewall Policy ARN': firewall_policy_arn,
-                    'Configuration Sync State': configuration_sync_state,
-                    'Delete Protection': delete_protection,
-                    'Subnet Change Protection': subnet_change_protection,
-                    'Policy Change Protection': firewall_policy_change_protection,
-                    'Encryption Type': encryption_type,
-                    'KMS Key ID': kms_key_id,
-                    'Description': description,
-                    'Tags': tags_str,
-                    'Firewall ARN': firewall_arn
-                })
-
+                firewalls.append(_build_firewall_row(fw_response, region))
             except Exception as e:
-                utils.log_error(f"Error getting details for firewall {firewall_name}", e)
+                # One malformed firewall is skipped, not fatal to the region.
+                utils.log_error(f"Skipping malformed Network Firewall in {region}: {firewall_name}", e)
+                continue
 
     utils.log_info(f"Found {len(firewalls)} Network Firewalls in {region}")
     return firewalls
 
 
-def collect_network_firewalls(regions: list[str]) -> list[dict[str, Any]]:
+def collect_network_firewalls(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Network Firewall information using concurrent scanning.
+    Collect Network Firewall information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with firewall information
+        tuple: ``(firewalls, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING NETWORK FIREWALLS ===")
     utils.log_info(f"Scanning {len(regions)} regions for Network Firewalls...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_network_firewalls_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -175,7 +213,7 @@ def collect_network_firewalls(regions: list[str]) -> list[dict[str, Any]]:
         all_firewalls.extend(firewalls_in_region)
 
     utils.log_success(f"Total Network Firewalls collected: {len(all_firewalls)}")
-    return all_firewalls
+    return all_firewalls, failed_regions
 
 
 @utils.aws_error_handler("Collecting firewall policies from region", default_return=[])
@@ -508,63 +546,81 @@ def export_network_firewall_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Network Firewalls
-    firewalls = collect_network_firewalls(regions)
+    # STEP 1: Collect Network Firewalls (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    firewalls, failed_regions = collect_network_firewalls(regions)
     if firewalls:
         data_frames['Firewalls'] = pd.DataFrame(firewalls)
 
-    # STEP 2: Collect firewall policies
+    # STEP 2: Collect firewall policies (enrichment — degrades gracefully;
+    # a region-level failure here does not fail the whole export).
     policies = collect_firewall_policies(regions)
     if policies:
         data_frames['Firewall Policies'] = pd.DataFrame(policies)
 
-    # STEP 3: Collect rule groups
+    # STEP 3: Collect rule groups (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     rule_groups = collect_rule_groups(regions)
     if rule_groups:
         data_frames['Rule Groups'] = pd.DataFrame(rule_groups)
 
-    # STEP 4: Collect logging configurations
+    # STEP 4: Collect logging configurations (enrichment — degrades
+    # gracefully; a region-level failure here does not fail the whole export).
     logging_configs = collect_logging_configurations(regions)
     if logging_configs:
         data_frames['Logging Configurations'] = pd.DataFrame(logging_configs)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure
+    # blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'network-firewall',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Network Firewall data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Network Firewall data was collected. Nothing to export.")
         print("\nNo Network Firewalls found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'network-firewall',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Network Firewall data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary Network Firewall scope collection,
+    # make it loud: write a marker and exit non-zero, even if some data was
+    # exported. A partial export that looks complete is exactly the failure
+    # mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'network-firewall', failed_regions)
+        print(
+            "\nERROR: Network Firewall export completed with failures — data is incomplete. "
+            "See the *-network-firewall-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/transit_gateway_export.py
+++ b/scripts/transit_gateway_export.py
@@ -47,9 +47,82 @@ except ImportError:
 args = utils.parse_script_args("Export Transit Gateways and attachments to Excel")
 
 
+def _build_tgw_row(tgw: dict, region: str) -> dict[str, Any]:
+    """Build a single Transit Gateway export row from a describe response."""
+    tgw_id = tgw.get('TransitGatewayId', '')
+    print(f"  Processing Transit Gateway: {tgw_id}")
+
+    # Extract basic information
+    state = tgw.get('State', '')
+    description = tgw.get('Description', 'N/A')
+    owner_id = tgw.get('OwnerId', '')
+    owner_name = utils.get_account_name_formatted(owner_id)
+
+    # Creation time
+    creation_time = tgw.get('CreationTime', '')
+    if creation_time:
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
+
+    # Options
+    options = tgw.get('Options', {})
+    amazon_side_asn = options.get('AmazonSideAsn', 'N/A')
+    default_route_table_association = options.get('DefaultRouteTableAssociation', 'N/A')
+    default_route_table_propagation = options.get('DefaultRouteTablePropagation', 'N/A')
+    vpn_ecmp_support = options.get('VpnEcmpSupport', 'N/A')
+    dns_support = options.get('DnsSupport', 'N/A')
+    auto_accept_shared_attachments = options.get('AutoAcceptSharedAttachments', 'N/A')
+    multicast_support = options.get('MulticastSupport', 'N/A')
+
+    # Default route table IDs
+    association_default_rt = options.get('AssociationDefaultRouteTableId', 'N/A')
+    propagation_default_rt = options.get('PropagationDefaultRouteTableId', 'N/A')
+
+    # CIDR blocks
+    transit_gateway_cidr_blocks = options.get('TransitGatewayCidrBlocks', [])
+    cidr_blocks_str = ', '.join(transit_gateway_cidr_blocks) if transit_gateway_cidr_blocks else 'N/A'
+
+    # Get tags
+    tags = tgw.get('Tags', [])
+    name_tag = 'N/A'
+    for tag in tags:
+        if tag.get('Key') == 'Name':
+            name_tag = tag.get('Value')
+            break
+
+    return {
+        'Region': region,
+        'Transit Gateway ID': tgw_id,
+        'Name': name_tag,
+        'State': state,
+        'Description': description,
+        'Owner Account': owner_name,
+        'Amazon Side ASN': amazon_side_asn,
+        'CIDR Blocks': cidr_blocks_str,
+        'Default Route Table Association': default_route_table_association,
+        'Default Route Table Propagation': default_route_table_propagation,
+        'Association Default RT ID': association_default_rt,
+        'Propagation Default RT ID': propagation_default_rt,
+        'VPN ECMP Support': vpn_ecmp_support,
+        'DNS Support': dns_support,
+        'Auto Accept Shared Attachments': auto_accept_shared_attachments,
+        'Multicast Support': multicast_support,
+        'Creation Time': creation_time
+    }
+
+
 def scan_transit_gateways_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan Transit Gateways in a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Transit Gateways" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed Transit Gateways are skipped (logged) rather than
+    aborting the whole region.
 
     Args:
         region: AWS region to scan
@@ -57,112 +130,68 @@ def scan_transit_gateways_in_region(region: str) -> list[dict[str, Any]]:
     Returns:
         list: List of Transit Gateway dictionaries for this region
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     region_tgws = []
 
-    try:
-        ec2 = utils.get_boto3_client('ec2', region_name=region)
+    ec2 = utils.get_boto3_client('ec2', region_name=region)
 
-        # Get Transit Gateways in the region
-        paginator = ec2.get_paginator('describe_transit_gateways')
-        tgw_count = 0
+    # Get Transit Gateways in the region
+    paginator = ec2.get_paginator('describe_transit_gateways')
+    tgw_count = 0
 
-        for page in paginator.paginate():
-            tgws = page.get('TransitGateways', [])
-            tgw_count += len(tgws)
+    for page in paginator.paginate():
+        tgws = page.get('TransitGateways', [])
+        tgw_count += len(tgws)
 
-            for tgw in tgws:
-                tgw_id = tgw.get('TransitGatewayId', '')
-                print(f"  Processing Transit Gateway: {tgw_id}")
+        for tgw in tgws:
+            try:
+                region_tgws.append(_build_tgw_row(tgw, region))
+            except Exception as e:
+                # One malformed Transit Gateway is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Transit Gateway in {region}: "
+                    f"{tgw.get('TransitGatewayId', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                # Extract basic information
-                state = tgw.get('State', '')
-                description = tgw.get('Description', 'N/A')
-                owner_id = tgw.get('OwnerId', '')
-                owner_name = utils.get_account_name_formatted(owner_id)
-
-                # Creation time
-                creation_time = tgw.get('CreationTime', '')
-                if creation_time:
-                    creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_time, datetime.datetime) else str(creation_time)
-
-                # Options
-                options = tgw.get('Options', {})
-                amazon_side_asn = options.get('AmazonSideAsn', 'N/A')
-                default_route_table_association = options.get('DefaultRouteTableAssociation', 'N/A')
-                default_route_table_propagation = options.get('DefaultRouteTablePropagation', 'N/A')
-                vpn_ecmp_support = options.get('VpnEcmpSupport', 'N/A')
-                dns_support = options.get('DnsSupport', 'N/A')
-                auto_accept_shared_attachments = options.get('AutoAcceptSharedAttachments', 'N/A')
-                multicast_support = options.get('MulticastSupport', 'N/A')
-
-                # Default route table IDs
-                association_default_rt = options.get('AssociationDefaultRouteTableId', 'N/A')
-                propagation_default_rt = options.get('PropagationDefaultRouteTableId', 'N/A')
-
-                # CIDR blocks
-                transit_gateway_cidr_blocks = options.get('TransitGatewayCidrBlocks', [])
-                cidr_blocks_str = ', '.join(transit_gateway_cidr_blocks) if transit_gateway_cidr_blocks else 'N/A'
-
-                # Get tags
-                tags = tgw.get('Tags', [])
-                name_tag = 'N/A'
-                for tag in tags:
-                    if tag['Key'] == 'Name':
-                        name_tag = tag['Value']
-                        break
-
-                region_tgws.append({
-                    'Region': region,
-                    'Transit Gateway ID': tgw_id,
-                    'Name': name_tag,
-                    'State': state,
-                    'Description': description,
-                    'Owner Account': owner_name,
-                    'Amazon Side ASN': amazon_side_asn,
-                    'CIDR Blocks': cidr_blocks_str,
-                    'Default Route Table Association': default_route_table_association,
-                    'Default Route Table Propagation': default_route_table_propagation,
-                    'Association Default RT ID': association_default_rt,
-                    'Propagation Default RT ID': propagation_default_rt,
-                    'VPN ECMP Support': vpn_ecmp_support,
-                    'DNS Support': dns_support,
-                    'Auto Accept Shared Attachments': auto_accept_shared_attachments,
-                    'Multicast Support': multicast_support,
-                    'Creation Time': creation_time
-                })
-
-        print(f"  Found {tgw_count} Transit Gateways")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for Transit Gateways", e)
+    print(f"  Found {tgw_count} Transit Gateways")
 
     utils.log_info(f"Found {len(region_tgws)} Transit Gateways in {region}")
     return region_tgws
 
 
-@utils.aws_error_handler("Collecting Transit Gateways", default_return=[])
-def collect_transit_gateways(regions: list[str]) -> list[dict[str, Any]]:
+def collect_transit_gateways(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Transit Gateway information from AWS regions.
+    Collect Transit Gateway information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with Transit Gateway information
+        tuple: ``(tgws, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING TRANSIT GATEWAYS ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    all_tgws = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_transit_gateways_in_region,
-    ):
-        all_tgws.extend(region_data)
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_tgws = [tgw for result in region_results for tgw in result]
 
     utils.log_success(f"Total Transit Gateways collected: {len(all_tgws)}")
-    return all_tgws
+    return all_tgws, failed_regions
 
 
 def scan_transit_gateway_attachments_in_region(region: str) -> list[dict[str, Any]]:
@@ -497,63 +526,77 @@ def export_transit_gateway_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Transit Gateways
-    tgws = collect_transit_gateways(regions)
+    # STEP 1: Collect Transit Gateways (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    tgws, failed_regions = collect_transit_gateways(regions)
     if tgws:
         data_frames['Transit Gateways'] = pd.DataFrame(tgws)
 
-    # STEP 2: Collect attachments
+    # STEP 2: Collect attachments (enrichment — degrades gracefully)
     attachments = collect_transit_gateway_attachments(regions)
     if attachments:
         data_frames['Attachments'] = pd.DataFrame(attachments)
 
-    # STEP 3: Collect route tables
+    # STEP 3: Collect route tables (enrichment — degrades gracefully)
     route_tables = collect_transit_gateway_route_tables(regions)
     if route_tables:
         data_frames['Route Tables'] = pd.DataFrame(route_tables)
 
-    # STEP 4: Collect routes
+    # STEP 4: Collect routes (enrichment — degrades gracefully)
     routes = collect_transit_gateway_routes(regions)
     if routes:
         data_frames['Routes'] = pd.DataFrame(routes)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'transit-gateway',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("Transit Gateway data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Transit Gateway data was collected. Nothing to export.")
         print("\nNo Transit Gateways found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'transit-gateway',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("Transit Gateway data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary Transit Gateway scope collection, make
+    # it loud: write a marker and exit non-zero, even if some data was
+    # exported. A partial export that looks complete is exactly the failure
+    # mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'transit-gateway', failed_regions)
+        print(
+            "\nERROR: Transit Gateway export completed with failures — data is incomplete. "
+            "See the *-transit-gateway-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/tests/test_exporters/test_cloudfront_export.py
+++ b/tests/test_exporters/test_cloudfront_export.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Tests for cloudfront_export.py.
+
+Covers:
+- collect_cloudfront_distributions() per-item guarding and account-scope
+  failure propagation
+- export_cloudfront_data()'s failed-scope tracking and exit-code behavior
+
+CloudFront is a global/account-scope service (not multi-region), so
+collect_cloudfront_distributions() is the account-scope PRIMARY collector --
+mirrors the scripts/shield_export.py account-scope pattern (see
+scripts/lambda_export.py for the finalize shape). moto supports
+cloudfront:create_distribution / list_distributions / get_distribution, so
+these tests are moto-backed where possible.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore.exceptions
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cloudfront_export  # noqa: E402
+from cloudfront_export import collect_cloudfront_distributions  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(cloudfront_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _distribution_config(caller_reference: str, comment: str = "test dist") -> dict:
+    """Minimal DistributionConfig accepted by moto's create_distribution."""
+    return {
+        "CallerReference": caller_reference,
+        "Comment": comment,
+        "Enabled": True,
+        "Origins": {
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "origin1",
+                    "DomainName": "example-bucket.s3.amazonaws.com",
+                    "S3OriginConfig": {"OriginAccessIdentity": ""},
+                }
+            ],
+        },
+        "DefaultCacheBehavior": {
+            "TargetOriginId": "origin1",
+            "ViewerProtocolPolicy": "allow-all",
+            "TrustedSigners": {"Enabled": False, "Quantity": 0},
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {"Forward": "none"},
+            },
+            "MinTTL": 0,
+        },
+    }
+
+
+def _create_distribution(client, caller_reference: str, comment: str = "test dist") -> str:
+    """Create a CloudFront distribution via moto and return its Id."""
+    response = client.create_distribution(
+        DistributionConfig=_distribution_config(caller_reference, comment)
+    )
+    return response["Distribution"]["Id"]
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to CloudFront: collect_cloudfront_distributions() -- the
+    PRIMARY, global/account-scope collector -- used to be wrapped in
+    ``@utils.aws_error_handler(default_return=[])``, swallowing a real API
+    error into an empty list indistinguishable from an account with no
+    distributions configured. export_cloudfront_data() also had no way to
+    signal that failure downstream. These tests cover: (a) a malformed
+    distribution is skipped, not fatal; (b)
+    collect_cloudfront_distributions() raises rather than swallowing a real
+    API error; (c) that failure surfaces through export_cloudfront_data() as
+    a non-zero exit plus a utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    @mock_aws
+    def test_malformed_distribution_is_skipped_not_fatal(self, monkeypatch):
+        """One distribution that fails to process must not discard the others."""
+        client = boto3.client("cloudfront", region_name=REGION)
+        good_id = _create_distribution(client, "good-ref", comment="good-distribution")
+        bad_id = _create_distribution(client, "bad-ref", comment="bad-distribution")
+
+        original = cloudfront_export._build_distribution_row
+
+        def raise_for_bad(cf_client, dist_summary):
+            if dist_summary.get("Id") == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(cf_client, dist_summary)
+
+        monkeypatch.setattr(cloudfront_export, "_build_distribution_row", raise_for_bad)
+
+        result = collect_cloudfront_distributions()
+
+        ids = {row["Distribution ID"] for row in result}
+        assert good_id in ids, "healthy distribution was lost when a sibling failed"
+        assert bad_id not in ids, "malformed distribution should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_cloudfront_distributions_raises_on_api_error_not_swallowed(
+        self, monkeypatch
+    ):
+        """A real CloudFront API error during collection must propagate, not
+        collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalError", "Message": "Something broke"}},
+                "ListDistributions",
+            )
+
+        client = type("FakeClient", (), {})()
+        client.get_paginator = boom
+        monkeypatch.setattr(cloudfront_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_cloudfront_distributions()
+
+    # -- (c) export_cloudfront_data(): failure surfaced, non-zero exit ------
+
+    def test_export_distributions_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A distributions API failure must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalError", "Message": "Something broke"}},
+                "ListDistributions",
+            )
+
+        monkeypatch.setattr(cloudfront_export, "collect_cloudfront_distributions", boom)
+        monkeypatch.setattr(cloudfront_export, "collect_origin_details", lambda: [])
+        monkeypatch.setattr(cloudfront_export, "collect_cache_behaviors", lambda: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(cloudfront_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cloudfront_export.export_cloudfront_data("123456789012", "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "cloudfront"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "distributions"
+
+    # -- (d) Genuinely empty account: no failure marker ----------------------
+
+    @mock_aws
+    def test_genuinely_empty_account_no_failure_marker(self, monkeypatch):
+        """An account with zero distributions (and a successful collection
+        scope) must not be reported as a failure."""
+        report_called = []
+        monkeypatch.setattr(
+            cloudfront_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # export_cloudfront_data() only calls sys.exit() on failure; a clean
+        # empty run returns normally.
+        cloudfront_export.export_cloudfront_data("123456789012", "test-account")
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_cloudtrail_export.py
+++ b/tests/test_exporters/test_cloudtrail_export.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for cloudtrail_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cloudtrail_export  # noqa: E402
+from cloudtrail_export import collect_trails_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_trail(ct_client, s3_client, name):
+    """Create an S3 bucket + CloudTrail trail named ``name``."""
+    bucket_name = f"{name}-bucket-12345"
+    s3_client.create_bucket(Bucket=bucket_name)
+    ct_client.create_trail(Name=name, S3BucketName=bucket_name)
+
+
+class TestCollectTrailsFromRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_trails(self):
+        ct_client = boto3.client("cloudtrail", region_name=REGION)
+        s3_client = boto3.client("s3", region_name=REGION)
+        _create_trail(ct_client, s3_client, "web-trail")
+
+        rows = collect_trails_from_region(REGION)
+
+        names = {row["Trail Name"] for row in rows}
+        assert "web-trail" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("cloudtrail", region_name=REGION)  # region exists, no trails
+
+        rows = collect_trails_from_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One trail that fails to process must not discard the whole region."""
+        ct_client = boto3.client("cloudtrail", region_name=REGION)
+        s3_client = boto3.client("s3", region_name=REGION)
+        _create_trail(ct_client, s3_client, "good-trail")
+        _create_trail(ct_client, s3_client, "bad-trail")
+
+        original = cloudtrail_export._build_trail_row
+
+        def raise_for_bad(ct_client, trail_summary, region):
+            if trail_summary.get("Name") == "bad-trail":
+                raise KeyError("SomeUnexpectedField")
+            return original(ct_client, trail_summary, region)
+
+        monkeypatch.setattr(cloudtrail_export, "_build_trail_row", raise_for_bad)
+
+        rows = collect_trails_from_region(REGION)
+
+        names = {row["Trail Name"] for row in rows}
+        assert "good-trail" in names, "healthy trail was lost when a sibling failed"
+        assert "bad-trail" not in names, "malformed trail should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListTrails",
+            )
+
+        monkeypatch.setattr(cloudtrail_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_trails_from_region(REGION)
+
+    @mock_aws
+    def test_collect_trails_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListTrails",
+            )
+
+        monkeypatch.setattr(cloudtrail_export, "collect_trails_from_region", boom)
+
+        trails, failed_regions = cloudtrail_export.collect_trails([REGION])
+
+        assert trails == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_directconnect_export.py
+++ b/tests/test_exporters/test_directconnect_export.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for directconnect_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import directconnect_export  # noqa: E402
+from directconnect_export import _scan_connections_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class FakeDirectConnectClient:
+    """
+    Minimal stand-in for a boto3 Direct Connect client.
+
+    moto's Direct Connect coverage does not let ``describe_connections`` be
+    shaped precisely enough to drive the malformed-item path (connections
+    created via moto always come back with every field populated), so this
+    test double is used instead of a real moto-backed client for that case.
+    """
+
+    def __init__(self, connections):
+        self._connections = connections
+
+    def describe_connections(self):
+        return {'connections': self._connections}
+
+
+class TestScanConnectionsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("directconnect", region_name=REGION)  # region exists, no connections
+
+        rows = _scan_connections_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+
+    Note: moto's Direct Connect support does not model connection resources
+    richly enough to reliably produce a malformed row or a raw API failure,
+    so these tests monkeypatch ``utils.get_boto3_client`` / module internals
+    directly rather than relying on moto-created resources.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One connection that fails to process must not discard the whole region."""
+        good_conn = {
+            'connectionId': 'dxcon-good',
+            'connectionName': 'good-conn',
+            'connectionState': 'available',
+        }
+        bad_conn = {
+            'connectionId': 'dxcon-bad',
+            'connectionName': 'bad-conn',
+            'connectionState': 'available',
+        }
+
+        monkeypatch.setattr(
+            directconnect_export.utils,
+            "get_boto3_client",
+            lambda *args, **kwargs: FakeDirectConnectClient([good_conn, bad_conn]),
+        )
+
+        original = directconnect_export._build_connection_row
+
+        def raise_for_bad(conn, region):
+            if conn.get("connectionId") == "dxcon-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(conn, region)
+
+        monkeypatch.setattr(directconnect_export, "_build_connection_row", raise_for_bad)
+
+        rows = _scan_connections_region(REGION)
+
+        ids = {row["Connection ID"] for row in rows}
+        assert "dxcon-good" in ids, "healthy connection was lost when a sibling failed"
+        assert "dxcon-bad" not in ids, "malformed connection should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeConnections",
+            )
+
+        monkeypatch.setattr(directconnect_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_connections_region(REGION)
+
+    @mock_aws
+    def test_collect_connections_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeConnections",
+            )
+
+        monkeypatch.setattr(directconnect_export, "_scan_connections_region", boom)
+
+        connections, failed_regions = directconnect_export.collect_connections([REGION])
+
+        assert connections == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_globalaccelerator_export.py
+++ b/tests/test_exporters/test_globalaccelerator_export.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Tests for globalaccelerator_export.py.
+
+Covers:
+- collect_accelerators() per-item guarding and account-scope failure propagation
+- export_globalaccelerator_data()'s failed-scope tracking, finalize, and
+  exit-code behavior
+
+Global Accelerator is a global/account-scope service (control plane in
+us-west-2, not multi-region), so collect_accelerators() is the account-scope
+PRIMARY collector -- mirrors the scripts/shield_export.py account-scope
+pattern (see scripts/lambda_export.py for the finalize shape). moto's
+Global Accelerator support is limited (no configurable accelerator/listener
+mutation state usable for failure-injection scenarios), so these tests drive
+the module through monkeypatched boto3 clients / module functions rather
+than real moto-backed Global Accelerator state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import globalaccelerator_export  # noqa: E402
+from globalaccelerator_export import collect_accelerators  # noqa: E402
+
+REGION = "us-west-2"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(globalaccelerator_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_globalaccelerator_client(accelerators=None):
+    """Build a MagicMock standing in for a boto3 Global Accelerator client."""
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Accelerators": accelerators or []}]
+    client.get_paginator.return_value = paginator
+    return client
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Global Accelerator: collect_accelerators() -- the
+    PRIMARY, global/account-scope collector -- used to be wrapped in
+    ``utils.aws_error_handler(default_return=[])`` and additionally swallowed
+    real API errors internally, returning an empty list indistinguishable
+    from an account with no accelerators configured.
+    export_globalaccelerator_data() also had no way to signal that failure
+    downstream. These tests cover: (a) a malformed accelerator is skipped,
+    not fatal; (b) collect_accelerators() raises rather than swallowing a
+    real API error; (c) that failure surfaces through
+    export_globalaccelerator_data() as a non-zero exit plus a
+    utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    def test_malformed_accelerator_is_skipped_not_fatal(self, monkeypatch):
+        """One accelerator that fails to process must not discard the others."""
+        good = {
+            "AcceleratorArn": "arn:aws:globalaccelerator::123456789012:accelerator/good-id",
+            "Name": "good-accelerator",
+            "Enabled": True,
+            "Status": "DEPLOYED",
+        }
+        bad = {
+            "AcceleratorArn": "arn:aws:globalaccelerator::123456789012:accelerator/bad-id",
+            "Name": "bad-accelerator",
+            "Enabled": True,
+            "Status": "DEPLOYED",
+        }
+
+        client = _fake_globalaccelerator_client(accelerators=[good, bad])
+        monkeypatch.setattr(globalaccelerator_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = globalaccelerator_export._build_accelerator_row
+
+        def raise_for_bad(acc):
+            if acc.get("Name") == "bad-accelerator":
+                raise KeyError("SomeUnexpectedField")
+            return original(acc)
+
+        monkeypatch.setattr(globalaccelerator_export, "_build_accelerator_row", raise_for_bad)
+
+        result = collect_accelerators()
+
+        arns = {row["Accelerator ARN"] for row in result}
+        assert "arn:aws:globalaccelerator::123456789012:accelerator/good-id" in arns, (
+            "healthy accelerator was lost when a sibling failed"
+        )
+        assert "arn:aws:globalaccelerator::123456789012:accelerator/bad-id" not in arns, (
+            "malformed accelerator should have been skipped"
+        )
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_accelerators_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Global Accelerator API error during collection must
+        propagate, not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServiceErrorException", "Message": "Something broke"}},
+                "ListAccelerators",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(globalaccelerator_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_accelerators()
+
+    # -- (c) export function: failure surfaced, non-zero exit ---------------
+
+    def test_export_accelerators_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An accelerators API failure must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+        monkeypatch.setattr(globalaccelerator_export.utils, "prompt_for_confirmation", lambda *a, **kw: True)
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServiceErrorException", "Message": "Something broke"}},
+                "ListAccelerators",
+            )
+
+        monkeypatch.setattr(globalaccelerator_export, "collect_accelerators", boom)
+        monkeypatch.setattr(globalaccelerator_export, "collect_custom_routing_accelerators", lambda: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(globalaccelerator_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            globalaccelerator_export.export_globalaccelerator_data("123456789012", "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "globalaccelerator"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "accelerators"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_network_firewall_export.py
+++ b/tests/test_exporters/test_network_firewall_export.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Tests for network_firewall_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2D / network exporters).
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto coverage: moto's network-firewall backend supports
+create_firewall / list_firewalls / describe_firewall, but not
+list_firewall_policies / describe_firewall_policy / list_rule_groups /
+describe_rule_group, and its describe_firewall response shape does not
+reliably round-trip tags. The regression tests below drive
+collect_network_firewalls_from_region through a small monkeypatched fake
+network-firewall client instead of moto so behavior is deterministic and
+independent of moto's partial NFW coverage.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import network_firewall_export  # noqa: E402
+from network_firewall_export import collect_network_firewalls_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in yielding a single page."""
+
+    def __init__(self, page):
+        self._page = page
+
+    def paginate(self, **kwargs):
+        yield self._page
+
+
+class _FakeNfwClient:
+    """Minimal fake network-firewall client driving two fake firewalls."""
+
+    def __init__(self, firewalls_metadata, describe_map, describe_error_for=None):
+        self._firewalls_metadata = firewalls_metadata
+        self._describe_map = describe_map
+        self._describe_error_for = describe_error_for or set()
+
+    def get_paginator(self, operation_name):
+        if operation_name == "list_firewalls":
+            return _FakePaginator({"Firewalls": self._firewalls_metadata})
+        raise NotImplementedError(operation_name)
+
+    def describe_firewall(self, **kwargs):
+        firewall_arn = kwargs["FirewallArn"]
+        if firewall_arn in self._describe_error_for:
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalError", "Message": "boom"}},
+                "DescribeFirewall",
+            )
+        return self._describe_map[firewall_arn]
+
+
+def _fw_response(name, arn, vpc_id="vpc-123"):
+    return {
+        "Firewall": {
+            "FirewallName": name,
+            "FirewallArn": arn,
+            "FirewallId": f"{name}-id",
+            "VpcId": vpc_id,
+            "SubnetMappings": [],
+            "Tags": [{"Key": "Env", "Value": "test"}],
+        },
+        "FirewallStatus": {
+            "Status": "READY",
+            "SyncStates": {},
+        },
+    }
+
+
+class TestCollectNetworkFirewallsFromRegion:
+    """Happy-path collection."""
+
+    def test_collects_firewalls(self, monkeypatch):
+        arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall/web-fw"
+        fake_client = _FakeNfwClient(
+            firewalls_metadata=[{"FirewallArn": arn, "FirewallName": "web-fw"}],
+            describe_map={arn: _fw_response("web-fw", arn)},
+        )
+        monkeypatch.setattr(
+            network_firewall_export.utils, "get_boto3_client", lambda service, region_name: fake_client
+        )
+
+        rows = collect_network_firewalls_from_region(REGION)
+
+        names = {row["Firewall Name"] for row in rows}
+        assert "web-fw" in names
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _FakeNfwClient(firewalls_metadata=[], describe_map={})
+        monkeypatch.setattr(
+            network_firewall_export.utils, "get_boto3_client", lambda service, region_name: fake_client
+        )
+
+        rows = collect_network_firewalls_from_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One firewall that fails to process must not discard the whole region."""
+        good_arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall/good-fw"
+        bad_arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall/bad-fw"
+
+        fake_client = _FakeNfwClient(
+            firewalls_metadata=[
+                {"FirewallArn": good_arn, "FirewallName": "good-fw"},
+                {"FirewallArn": bad_arn, "FirewallName": "bad-fw"},
+            ],
+            describe_map={
+                good_arn: _fw_response("good-fw", good_arn),
+                bad_arn: _fw_response("bad-fw", bad_arn),
+            },
+            describe_error_for={bad_arn},
+        )
+        monkeypatch.setattr(
+            network_firewall_export.utils, "get_boto3_client", lambda service, region_name: fake_client
+        )
+
+        rows = collect_network_firewalls_from_region(REGION)
+
+        names = {row["Firewall Name"] for row in rows}
+        assert "good-fw" in names, "healthy firewall was lost when a sibling failed"
+        assert "bad-fw" not in names, "malformed firewall should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListFirewalls",
+            )
+
+        monkeypatch.setattr(network_firewall_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_network_firewalls_from_region(REGION)
+
+    def test_collect_network_firewalls_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListFirewalls",
+            )
+
+        monkeypatch.setattr(network_firewall_export, "collect_network_firewalls_from_region", boom)
+
+        firewalls, failed_regions = network_firewall_export.collect_network_firewalls([REGION])
+
+        assert firewalls == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_transit_gateway_export.py
+++ b/tests/test_exporters/test_transit_gateway_export.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for transit_gateway_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import transit_gateway_export  # noqa: E402
+from transit_gateway_export import scan_transit_gateways_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_tgw(client, name):
+    """Create a Transit Gateway tagged with ``Name=name``."""
+    response = client.create_transit_gateway(
+        Description=f"{name}-tgw",
+        TagSpecifications=[
+            {
+                "ResourceType": "transit-gateway",
+                "Tags": [{"Key": "Name", "Value": name}],
+            }
+        ],
+    )
+    return response["TransitGateway"]["TransitGatewayId"]
+
+
+class TestScanTransitGatewaysRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_transit_gateways(self):
+        client = boto3.client("ec2", region_name=REGION)
+        _create_tgw(client, "web-tgw")
+
+        rows = scan_transit_gateways_in_region(REGION)
+
+        names = {row["Name"] for row in rows}
+        assert "web-tgw" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ec2", region_name=REGION)  # region exists, no TGWs
+
+        rows = scan_transit_gateways_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One Transit Gateway that fails to process must not discard the whole region."""
+        client = boto3.client("ec2", region_name=REGION)
+        _create_tgw(client, "good-tgw")
+        _create_tgw(client, "bad-tgw")
+
+        original = transit_gateway_export._build_tgw_row
+
+        def raise_for_bad(tgw, region):
+            if tgw.get("TransitGatewayId") and any(
+                tag.get("Key") == "Name" and tag.get("Value") == "bad-tgw"
+                for tag in tgw.get("Tags", [])
+            ):
+                raise KeyError("SomeUnexpectedField")
+            return original(tgw, region)
+
+        monkeypatch.setattr(transit_gateway_export, "_build_tgw_row", raise_for_bad)
+
+        rows = scan_transit_gateways_in_region(REGION)
+
+        names = {row["Name"] for row in rows}
+        assert "good-tgw" in names, "healthy Transit Gateway was lost when a sibling failed"
+        assert "bad-tgw" not in names, "malformed Transit Gateway should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeTransitGateways",
+            )
+
+        monkeypatch.setattr(transit_gateway_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_transit_gateways_in_region(REGION)
+
+    @mock_aws
+    def test_collect_transit_gateways_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeTransitGateways",
+            )
+
+        monkeypatch.setattr(transit_gateway_export, "scan_transit_gateways_in_region", boom)
+
+        tgws, failed_regions = transit_gateway_export.collect_transit_gateways([REGION])
+
+        assert tgws == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -69,12 +69,14 @@ _EXCLUDED = {
     #   accessanalyzer:ListAnalyzers        -> 404 "Not yet implemented"
     #   detective:ListGraphs                -> 404 "Not yet implemented"
     #   config:DescribeConformancePacks     -> NotImplementedError (one of its scopes)
+    #   globalaccelerator:ListAccelerators  -> 404 "Not yet implemented"
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
     "access_analyzer_export.py",
     "detective_export.py",
     "config_export.py",
+    "globalaccelerator_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. Fifth phase — **Batch D: networking (6 exporters)** — onto the shared plumbing from #234 (A=#237, B=#238, C=#239).

## What
| Exporter | Type | Slug |
|---|---|---|
| directconnect | multi-region | `directconnect` |
| transit_gateway | multi-region | `transit-gateway` |
| network_firewall | multi-region | `network-firewall` |
| cloudtrail | multi-region | `cloudtrail` |
| cloudfront | global/account-scope | `cloudfront` |
| globalaccelerator | global/account-scope | `globalaccelerator` |

Each primary scope collector RAISES on error → surfaced failures → per-item `_build_*_row` guard → partial export → `report_collection_failures` + `sys.exit(1)`. **cloudfront** and **globalaccelerator** are global services (no region scanner) → shield-style `failed_scopes` tracking (genuine-empty = graceful warning; real API failure = marker + exit 1). Hard subscripts guarded (`directconnect` `tag['key']`, `globalaccelerator` `listener['Listener ARN']` + ARN comprehensions). `cloudtrail` NextToken pagination untouched. Enrichment sheets stay graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite. moto covers transit_gateway/cloudtrail/cloudfront happy paths; the rest use monkeypatch. **Batch-D suites: 26 passed. Full suite: 905 passed, 2 skipped. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusion
`globalaccelerator_export` added to `_EXCLUDED` — moto's `ListAccelerators` → 404 'Not yet implemented', so correct fail-loud behavior exits 1 against an empty mocked env (same rationale as prior batches). Dedicated regression suite covers it; the other 5 pass smoke.

## Remaining
Final Tier-2 batch **E** (messaging/cost/governance, 8) next → completes all 36 Tier-2 VULNERABLE exporters. Then Tier-3 (48 PARTIAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)