### PR TITLE
Silent collection failure: Tier-2e (messaging, cost & governance) — completes Tier-2

### DIFF
--- a/scripts/budgets_export.py
+++ b/scripts/budgets_export.py
@@ -44,118 +44,163 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Budgets configuration to Excel")
 
 
-@utils.aws_error_handler("Collecting Budgets", default_return=[])
+def _build_budget_row(budget: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single AWS Budget.
+
+    Extracted so the per-budget processing can be wrapped in try/except by
+    the caller: a malformed budget entry is logged and skipped rather than
+    discarding the whole account-scope collection. Every field is read with
+    ``.get()`` and a safe default for the same reason.
+
+    Args:
+        budget: A single Budgets entry from describe_budgets.
+
+    Returns:
+        dict: The assembled budget row.
+    """
+    budget_name = budget.get('BudgetName', 'N/A')
+
+    print(f"  Processing budget: {budget_name}")
+
+    # Budget type
+    budget_type = budget.get('BudgetType', 'N/A')
+
+    # Time unit
+    time_unit = budget.get('TimeUnit', 'N/A')
+
+    # Time period
+    time_period = budget.get('TimePeriod', {}) or {}
+    start_date = time_period.get('Start', '')
+    if start_date:
+        start_date = start_date.strftime('%Y-%m-%d') if isinstance(start_date, datetime.datetime) else str(start_date)
+    end_date = time_period.get('End', '')
+    if end_date:
+        end_date = end_date.strftime('%Y-%m-%d') if isinstance(end_date, datetime.datetime) else str(end_date)
+
+    # Budget limit
+    budget_limit = budget.get('BudgetLimit', {}) or {}
+    limit_amount = budget_limit.get('Amount', '0')
+    try:
+        limit_amount = float(limit_amount)
+    except (ValueError, TypeError):
+        limit_amount = 0.0
+    limit_unit = budget_limit.get('Unit', 'USD')
+
+    # Calculated spend
+    calculated_spend = budget.get('CalculatedSpend', {}) or {}
+
+    # Actual spend
+    actual_spend = calculated_spend.get('ActualSpend', {}) or {}
+    actual_amount = actual_spend.get('Amount', '0')
+    try:
+        actual_amount = float(actual_amount)
+    except (ValueError, TypeError):
+        actual_amount = 0.0
+
+    # Forecasted spend
+    forecasted_spend = calculated_spend.get('ForecastedSpend', {}) or {}
+    forecasted_amount = forecasted_spend.get('Amount', '0')
+    try:
+        forecasted_amount = float(forecasted_amount)
+    except (ValueError, TypeError):
+        forecasted_amount = 0.0
+
+    # Cost filters
+    cost_filters = budget.get('CostFilters', {}) or {}
+    filters_str = ', '.join([f"{k}={','.join(v)}" for k, v in cost_filters.items()]) if cost_filters else 'None'
+
+    # Cost types
+    cost_types = budget.get('CostTypes', {}) or {}
+    include_tax = cost_types.get('IncludeTax', False)
+    include_subscription = cost_types.get('IncludeSubscription', False)
+    include_support = cost_types.get('IncludeSupport', False)
+    include_refund = cost_types.get('IncludeRefund', False)
+    include_credit = cost_types.get('IncludeCredit', False)
+
+    # Last updated
+    last_updated = budget.get('LastUpdatedTime', '')
+    if last_updated:
+        last_updated = last_updated.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_updated, datetime.datetime) else str(last_updated)
+
+    return {
+        'Budget Name': budget_name,
+        'Budget Type': budget_type,
+        'Time Unit': time_unit,
+        'Start Date': start_date if start_date else 'N/A',
+        'End Date': end_date if end_date else 'Ongoing',
+        'Budget Limit': limit_amount,
+        'Currency': limit_unit,
+        'Actual Spend': actual_amount,
+        'Forecasted Spend': forecasted_amount,
+        'Spend %': round((actual_amount / limit_amount * 100) if limit_amount > 0 else 0, 2),
+        'Cost Filters': filters_str,
+        'Include Tax': include_tax,
+        'Include Subscription': include_subscription,
+        'Include Support': include_support,
+        'Include Refund': include_refund,
+        'Include Credit': include_credit,
+        'Last Updated': last_updated if last_updated else 'N/A'
+    }
+
+
 def collect_budgets(account_id: str) -> list[dict[str, Any]]:
     """
     Collect AWS Budgets information.
+
+    Not wrapped in ``aws_error_handler``: a swallowed error here would return
+    an empty list that the caller cannot distinguish from a genuinely empty
+    account, producing silent data loss (see the 07.15.2026 / 07.16.2026
+    silent-collection-failure audits). Budgets is a global, account-scope
+    service (not multi-region — see scripts/shield_export.py for the
+    account-scope reference pattern this follows). Account-scope failures
+    (client creation, pagination) are allowed to raise so the caller (main)
+    can record this scope as *failed* rather than *empty*. Per-budget errors
+    are contained internally (logged and skipped) via ``_build_budget_row``.
 
     Args:
         account_id: AWS account ID
 
     Returns:
         list: List of dictionaries with budget information
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     print("\n=== COLLECTING AWS BUDGETS ===")
     all_budgets = []
+    skipped = 0
 
     # Budgets is a global service - use partition-aware home region
     home_region = utils.get_partition_default_region()
     budgets_client = utils.get_boto3_client('budgets', region_name=home_region)
 
-    try:
-        paginator = budgets_client.get_paginator('describe_budgets')
-        page_iterator = paginator.paginate(AccountId=account_id)
+    paginator = budgets_client.get_paginator('describe_budgets')
+    page_iterator = paginator.paginate(AccountId=account_id)
 
-        for page in page_iterator:
-            budgets = page.get('Budgets', [])
+    total_budgets = 0
+    for page in page_iterator:
+        budgets = page.get('Budgets', [])
+        total_budgets += len(budgets)
 
-            for budget in budgets:
-                budget_name = budget.get('BudgetName', 'N/A')
+        # Process each budget. One malformed budget must not sink the whole
+        # account-scope collection, so each is built inside try/except;
+        # failures are logged and skipped.
+        for budget in budgets:
+            try:
+                all_budgets.append(_build_budget_row(budget))
+            except Exception as e:
+                skipped += 1
+                budget_name = budget.get('BudgetName', 'Unknown') if isinstance(budget, dict) else 'Unknown'
+                utils.log_error(f"Skipping budget '{budget_name}' due to a processing error", e)
+                continue
 
-                print(f"  Processing budget: {budget_name}")
-
-                # Budget type
-                budget_type = budget.get('BudgetType', 'N/A')
-
-                # Time unit
-                time_unit = budget.get('TimeUnit', 'N/A')
-
-                # Time period
-                time_period = budget.get('TimePeriod', {})
-                start_date = time_period.get('Start', '')
-                if start_date:
-                    start_date = start_date.strftime('%Y-%m-%d') if isinstance(start_date, datetime.datetime) else str(start_date)
-                end_date = time_period.get('End', '')
-                if end_date:
-                    end_date = end_date.strftime('%Y-%m-%d') if isinstance(end_date, datetime.datetime) else str(end_date)
-
-                # Budget limit
-                budget_limit = budget.get('BudgetLimit', {})
-                limit_amount = budget_limit.get('Amount', '0')
-                try:
-                    limit_amount = float(limit_amount)
-                except (ValueError, TypeError):
-                    limit_amount = 0.0
-                limit_unit = budget_limit.get('Unit', 'USD')
-
-                # Calculated spend
-                calculated_spend = budget.get('CalculatedSpend', {})
-
-                # Actual spend
-                actual_spend = calculated_spend.get('ActualSpend', {})
-                actual_amount = actual_spend.get('Amount', '0')
-                try:
-                    actual_amount = float(actual_amount)
-                except (ValueError, TypeError):
-                    actual_amount = 0.0
-
-                # Forecasted spend
-                forecasted_spend = calculated_spend.get('ForecastedSpend', {})
-                forecasted_amount = forecasted_spend.get('Amount', '0')
-                try:
-                    forecasted_amount = float(forecasted_amount)
-                except (ValueError, TypeError):
-                    forecasted_amount = 0.0
-
-                # Cost filters
-                cost_filters = budget.get('CostFilters', {})
-                filters_str = ', '.join([f"{k}={','.join(v)}" for k, v in cost_filters.items()]) if cost_filters else 'None'
-
-                # Cost types
-                cost_types = budget.get('CostTypes', {})
-                include_tax = cost_types.get('IncludeTax', False)
-                include_subscription = cost_types.get('IncludeSubscription', False)
-                include_support = cost_types.get('IncludeSupport', False)
-                include_refund = cost_types.get('IncludeRefund', False)
-                include_credit = cost_types.get('IncludeCredit', False)
-
-                # Last updated
-                last_updated = budget.get('LastUpdatedTime', '')
-                if last_updated:
-                    last_updated = last_updated.strftime('%Y-%m-%d %H:%M:%S') if isinstance(last_updated, datetime.datetime) else str(last_updated)
-
-                all_budgets.append({
-                    'Budget Name': budget_name,
-                    'Budget Type': budget_type,
-                    'Time Unit': time_unit,
-                    'Start Date': start_date if start_date else 'N/A',
-                    'End Date': end_date if end_date else 'Ongoing',
-                    'Budget Limit': limit_amount,
-                    'Currency': limit_unit,
-                    'Actual Spend': actual_amount,
-                    'Forecasted Spend': forecasted_amount,
-                    'Spend %': round((actual_amount / limit_amount * 100) if limit_amount > 0 else 0, 2),
-                    'Cost Filters': filters_str,
-                    'Include Tax': include_tax,
-                    'Include Subscription': include_subscription,
-                    'Include Support': include_support,
-                    'Include Refund': include_refund,
-                    'Include Credit': include_credit,
-                    'Last Updated': last_updated if last_updated else 'N/A'
-                })
-
-    except Exception as e:
-        utils.log_error("Error collecting budgets", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_budgets} budget(s) were skipped due to "
+            "processing errors (see log above); the remaining budgets were still collected."
+        )
 
     utils.log_success(f"Total budgets collected: {len(all_budgets)}")
     return all_budgets
@@ -244,6 +289,15 @@ def export_budgets_data(account_id: str, account_name: str):
     """
     Export AWS Budgets information to an Excel file.
 
+    Budgets is a global, account-scope service (not multi-region), so
+    failures are tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py for the
+    account-scope reference pattern). A real collection failure on the
+    ``budgets`` scope is exported as a partial result (if any data was
+    collected) and always surfaced via ``utils.report_collection_failures``
+    + a non-zero exit — it must never be silently collapsed into "no
+    budgets" (07.15.2026 / 07.16.2026 audits).
+
     Args:
         account_id: The AWS account ID
         account_name: The AWS account name
@@ -257,8 +311,19 @@ def export_budgets_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect budgets
-    budgets = collect_budgets(account_id)
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect budgets (PRIMARY scope — a real API error here must
+    # propagate to failed_scopes, never collapse into an empty list that
+    # reads as "no budgets configured").
+    try:
+        budgets = collect_budgets(account_id)
+    except Exception as e:
+        failed_scopes.append(('budgets', str(e)))
+        utils.log_error(f"Budgets collection failed: {e}")
+        budgets = []
+
     if budgets:
         data_frames['Budgets'] = pd.DataFrame(budgets)
 
@@ -303,42 +368,58 @@ def export_budgets_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
+    # Check if we have any data. A genuinely empty result (collection
+    # succeeded, account simply has no budgets) is a plain warning — never
+    # confused with a failed collection (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
     if not data_frames:
-        utils.log_warning("No Budgets data was collected. Nothing to export.")
-        print("\nNo Budgets found in this account.")
-        return
+        if not failed_scopes:
+            utils.log_warning("No Budgets data was collected. Nothing to export.")
+            print("\nNo Budgets found in this account.")
+    else:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+        # STEP 5: Create filename and export — export whatever succeeded,
+        # a partial export is required even when the budgets scope failed.
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'budgets',
+            '',
+            current_date
+        )
 
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'budgets',
-        '',
-        current_date
-    )
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
 
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+            if output_path:
+                utils.log_success("Budgets data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
 
-        if output_path:
-            utils.log_success("Budgets data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
 
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If the budgets scope failed, make it loud: write a marker and exit
+    # non-zero, even if a partial export was written. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'budgets', failed_scopes)
+        print(
+            "\nERROR: Budgets export completed with failures — data is "
+            "incomplete. See the *-budgets-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/codecommit_export.py
+++ b/scripts/codecommit_export.py
@@ -26,80 +26,124 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export CodeCommit repositories to Excel")
 
-@utils.aws_error_handler("Collecting CodeCommit repositories", default_return=[])
-def collect_repositories(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect CodeCommit repository information from AWS regions."""
-    all_repositories = []
+def _build_repository_row(item: dict, region: str) -> dict[str, Any]:
+    """
+    Build a single CodeCommit repository export row from a
+    ``get_repository`` response's ``repositoryMetadata``.
 
-    for region in regions:
-        utils.log_info(f"Collecting CodeCommit repositories in {region}...")
-        codecommit_client = utils.get_boto3_client('codecommit', region_name=region)
+    Extracted so the per-repository processing can be wrapped in
+    try/except by the caller: a malformed repository entry is logged and
+    skipped rather than discarding the whole region's results. Every field
+    is read with ``.get()`` and a safe default for the same reason.
+    """
+    repo_name = item.get('repositoryName', 'N/A')
+    repo_id = item.get('repositoryId', 'N/A')
+    arn = item.get('Arn', 'N/A')
+    description = item.get('repositoryDescription', 'None')
 
+    created = item.get('creationDate', 'N/A')
+    if created != 'N/A':
+        created = created.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_modified = item.get('lastModifiedDate', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Clone URLs
+    clone_url_http = item.get('cloneUrlHttp', 'N/A')
+    clone_url_ssh = item.get('cloneUrlSsh', 'N/A')
+
+    # Default branch
+    default_branch = item.get('defaultBranch', 'N/A')
+
+    # KMS encryption
+    kms_key_id = item.get('kmsKeyId', 'None')
+
+    return {
+        'Region': region,
+        'Repository Name': repo_name,
+        'Repository ID': repo_id,
+        'ARN': arn,
+        'Description': description,
+        'Created': created,
+        'Last Modified': last_modified,
+        'Default Branch': default_branch,
+        'Clone URL (HTTP)': clone_url_http,
+        'Clone URL (SSH)': clone_url_ssh,
+        'KMS Key ID': kms_key_id
+    }
+
+
+def _scan_repositories_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect CodeCommit repositories from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no repositories" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed repositories are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Collecting CodeCommit repositories in {region}...")
+    codecommit_client = utils.get_boto3_client('codecommit', region_name=region)
+
+    # List all repositories
+    paginator = codecommit_client.get_paginator('list_repositories')
+    repository_names = []
+    for page in paginator.paginate():
+        repos = page.get('repositories', [])
+        repository_names.extend([r.get('repositoryName') for r in repos])
+
+    if not repository_names:
+        return []
+
+    utils.log_info(f"Found {len(repository_names)} repositories in {region}")
+
+    region_repositories = []
+    for repo_name in repository_names:
         try:
-            # List all repositories
-            paginator = codecommit_client.get_paginator('list_repositories')
-            repository_names = []
-            for page in paginator.paginate():
-                repos = page.get('repositories', [])
-                repository_names.extend([r.get('repositoryName') for r in repos])
-
-            if not repository_names:
-                continue
-
-            utils.log_info(f"Found {len(repository_names)} repositories in {region}")
-
-            # Batch get repository metadata
-            for repo_name in repository_names:
-                try:
-                    repo_response = codecommit_client.get_repository(repositoryName=repo_name)
-                    repo_metadata = repo_response.get('repositoryMetadata', {})
-
-                    repo_id = repo_metadata.get('repositoryId', 'N/A')
-                    arn = repo_metadata.get('Arn', 'N/A')
-                    description = repo_metadata.get('repositoryDescription', 'None')
-
-                    created = repo_metadata.get('creationDate', 'N/A')
-                    if created != 'N/A':
-                        created = created.strftime('%Y-%m-%d %H:%M:%S')
-
-                    last_modified = repo_metadata.get('lastModifiedDate', 'N/A')
-                    if last_modified != 'N/A':
-                        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Clone URLs
-                    clone_url_http = repo_metadata.get('cloneUrlHttp', 'N/A')
-                    clone_url_ssh = repo_metadata.get('cloneUrlSsh', 'N/A')
-
-                    # Default branch
-                    default_branch = repo_metadata.get('defaultBranch', 'N/A')
-
-                    # KMS encryption
-                    kms_key_id = repo_metadata.get('kmsKeyId', 'None')
-
-                    all_repositories.append({
-                        'Region': region,
-                        'Repository Name': repo_name,
-                        'Repository ID': repo_id,
-                        'ARN': arn,
-                        'Description': description,
-                        'Created': created,
-                        'Last Modified': last_modified,
-                        'Default Branch': default_branch,
-                        'Clone URL (HTTP)': clone_url_http,
-                        'Clone URL (SSH)': clone_url_ssh,
-                        'KMS Key ID': kms_key_id
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get metadata for repository {repo_name}: {str(e)}")
-                    continue
-
+            repo_response = codecommit_client.get_repository(repositoryName=repo_name)
+            repo_metadata = repo_response.get('repositoryMetadata', {})
+            region_repositories.append(_build_repository_row(repo_metadata, region))
         except Exception as e:
-            utils.log_warning(f"Error collecting CodeCommit repositories in {region}: {str(e)}")
+            # One malformed/unreachable repository is skipped, not fatal to
+            # the region.
+            utils.log_warning(f"Could not get metadata for repository {repo_name}: {str(e)}")
             continue
 
+    return region_repositories
+
+
+def collect_repositories(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect CodeCommit repository information across regions, surfacing
+    failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(repositories, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_repositories_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_repositories = [repo for result in region_results for repo in result]
     utils.log_info(f"Collected {len(all_repositories)} CodeCommit repositories")
-    return all_repositories
+    return all_repositories, failed_regions
 
 
 @utils.aws_error_handler("Collecting repository branches", default_return=[])
@@ -367,7 +411,11 @@ def main():
     # Collect data
     print("\nCollecting AWS CodeCommit data...")
 
-    repositories = collect_repositories(regions)
+    # STEP 1: Collect repositories (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    repositories, failed_regions = collect_repositories(regions)
+    # STEP 2/3: Collect branches and pull requests (enrichment — degrade
+    # gracefully; a region-level failure here does not fail the whole export).
     branches = collect_branches(regions)
     pull_requests = collect_pull_requests(regions)
     summary = generate_summary(repositories, branches, pull_requests)
@@ -397,19 +445,30 @@ def main():
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    # Export to Excel — a partial export is required even when some regions
+    # failed (see the silent-collection-failure blast-radius audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'codecommit', region_suffix)
 
         utils.log_info(f"Exporting to {filename}...")
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
-
-        # Log summary
-    else:
+        utils.log_success("AWS CodeCommit export completed successfully")
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No AWS CodeCommit data found to export")
 
-    utils.log_success("AWS CodeCommit export completed successfully")
+    # If ANY region failed the primary repositories scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was exported.
+    # A partial export that looks complete is exactly the failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'codecommit', failed_regions)
+        print(
+            "\nERROR: CodeCommit export completed with failures — data is incomplete. "
+            "See the *-codecommit-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/codedeploy_export.py
+++ b/scripts/codedeploy_export.py
@@ -26,55 +26,102 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export CodeDeploy applications and deployments to Excel")
 
-@utils.aws_error_handler("Collecting CodeDeploy applications", default_return=[])
-def collect_applications(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect CodeDeploy application information from AWS regions."""
-    all_applications = []
+def _build_application_row(app: dict, region: str) -> dict[str, Any]:
+    """Build a single CodeDeploy application export row from a batch_get response entry."""
+    app_name = app.get('applicationName', 'N/A')
+    app_id = app.get('applicationId', 'N/A')
+    compute_platform = app.get('computePlatform', 'N/A')
 
-    for region in regions:
-        utils.log_info(f"Collecting CodeDeploy applications in {region}...")
-        codedeploy_client = utils.get_boto3_client('codedeploy', region_name=region)
+    created_time = app.get('createTime', 'N/A')
+    if created_time != 'N/A':
+        created_time = created_time.strftime('%Y-%m-%d %H:%M:%S')
 
-        try:
-            # List all applications
-            paginator = codedeploy_client.get_paginator('list_applications')
-            for page in paginator.paginate():
-                app_names = page.get('applications', [])
+    # Linked to GitHub
+    linked_to_github = app.get('linkedToGitHub', False)
+    github_account_name = app.get('gitHubAccountName', 'N/A')
 
-                # Batch get application details
-                if app_names:
-                    apps_response = codedeploy_client.batch_get_applications(applicationNames=app_names)
-                    applications = apps_response.get('applicationsInfo', [])
+    return {
+        'Region': region,
+        'Application Name': app_name,
+        'Application ID': app_id,
+        'Compute Platform': compute_platform,
+        'Created': created_time,
+        'Linked to GitHub': linked_to_github,
+        'GitHub Account': github_account_name
+    }
 
-                    for app in applications:
-                        app_name = app.get('applicationName', 'N/A')
-                        app_id = app.get('applicationId', 'N/A')
-                        compute_platform = app.get('computePlatform', 'N/A')
 
-                        created_time = app.get('createTime', 'N/A')
-                        if created_time != 'N/A':
-                            created_time = created_time.strftime('%Y-%m-%d %H:%M:%S')
+def _scan_applications_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect CodeDeploy applications from a single region.
 
-                        # Linked to GitHub
-                        linked_to_github = app.get('linkedToGitHub', False)
-                        github_account_name = app.get('gitHubAccountName', 'N/A')
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no applications" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
-                        all_applications.append({
-                            'Region': region,
-                            'Application Name': app_name,
-                            'Application ID': app_id,
-                            'Compute Platform': compute_platform,
-                            'Created': created_time,
-                            'Linked to GitHub': linked_to_github,
-                            'GitHub Account': github_account_name
-                        })
+    Individual malformed applications are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-        except Exception as e:
-            utils.log_warning(f"Error collecting CodeDeploy applications in {region}: {str(e)}")
+    utils.log_info(f"Collecting CodeDeploy applications in {region}...")
+    codedeploy_client = utils.get_boto3_client('codedeploy', region_name=region)
+
+    region_applications = []
+
+    # List all applications
+    paginator = codedeploy_client.get_paginator('list_applications')
+    for page in paginator.paginate():
+        app_names = page.get('applications', [])
+
+        # Batch get application details
+        if not app_names:
             continue
 
+        apps_response = codedeploy_client.batch_get_applications(applicationNames=app_names)
+        applications = apps_response.get('applicationsInfo', [])
+
+        for app in applications:
+            try:
+                region_applications.append(_build_application_row(app, region))
+            except Exception as e:
+                # One malformed application is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed CodeDeploy application in {region}: "
+                    f"{app.get('applicationName', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    return region_applications
+
+
+def collect_applications(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect CodeDeploy application information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(applications, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_applications_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_applications = [app for result in region_results for app in result]
     utils.log_info(f"Collected {len(all_applications)} CodeDeploy applications")
-    return all_applications
+    return all_applications, failed_regions
 
 
 @utils.aws_error_handler("Collecting deployment groups", default_return=[])
@@ -403,8 +450,15 @@ def main():
     # Collect data
     print("\nCollecting AWS CodeDeploy data...")
 
-    applications = collect_applications(regions)
+    # STEP 1: Collect applications (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    applications, failed_regions = collect_applications(regions)
+
+    # STEP 2: Collect deployment groups (enrichment — degrades gracefully;
+    # a region-level failure here does not fail the whole export).
     deployment_groups = collect_deployment_groups(regions)
+
+    # STEP 3: Collect deployments (enrichment — degrades gracefully).
     deployments = collect_deployments(regions)
     summary = generate_summary(applications, deployment_groups, deployments)
 
@@ -433,7 +487,8 @@ def main():
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'codedeploy', region_suffix)
@@ -442,8 +497,22 @@ def main():
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
         # Log summary
-    else:
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No AWS CodeDeploy data found to export")
+        print("\nNo AWS CodeDeploy data found to export.")
+
+    # If ANY region failed the applications scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data (from this scope or
+    # the enrichment sheets) was exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'codedeploy', failed_regions)
+        print(
+            "\nERROR: CodeDeploy export completed with failures — data is incomplete. "
+            "See the *-codedeploy-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("AWS CodeDeploy export completed successfully")
 

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -44,44 +44,89 @@ args = utils.parse_script_args("Export EventBridge event buses and rules to Exce
 
 
 def _scan_event_buses_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for EventBridge event buses."""
+    """
+    Collect EventBridge event buses from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no event buses" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed event buses are skipped (logged) rather than
+    aborting the whole region.
+    """
     buses_data = []
     if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
         return buses_data
 
-    try:
-        events_client = utils.get_boto3_client('events', region_name=region)
-        next_token = None
-        while True:
-            params = {}
-            if next_token:
-                params['NextToken'] = next_token
-            page = events_client.list_event_buses(**params)
-            for bus in page.get('EventBuses', []):
-                buses_data.append({
-                    'Region': region,
-                    'Event Bus Name': bus.get('Name', 'N/A'),
-                    'Event Bus ARN': bus.get('Arn', 'N/A'),
-                    'Has Policy': 'Yes' if bus.get('Policy') else 'No'
-                })
+    print(f"\nProcessing region: {region}")
 
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-    except Exception as e:
-        utils.log_error(f"Error scanning event buses in {region}", e)
+    events_client = utils.get_boto3_client('events', region_name=region)
+    next_token = None
+    bus_count = 0
+    while True:
+        params = {}
+        if next_token:
+            params['NextToken'] = next_token
+        page = events_client.list_event_buses(**params)
+        page_buses = page.get('EventBuses', [])
+        bus_count += len(page_buses)
 
+        for bus in page_buses:
+            try:
+                buses_data.append(_build_event_bus_row(bus, region))
+            except Exception as e:
+                # One malformed event bus is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed event bus in {region}: "
+                    f"{bus.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
+
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
+
+    print(f"  Found {bus_count} event buses")
     return buses_data
 
 
-@utils.aws_error_handler("Collecting event buses", default_return=[])
-def collect_event_buses(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect EventBridge event bus information from AWS regions."""
+def _build_event_bus_row(item: dict, region: str) -> dict[str, Any]:
+    """Build a single event bus export row from a list_event_buses entry."""
+    return {
+        'Region': region,
+        'Event Bus Name': item.get('Name', 'N/A'),
+        'Event Bus ARN': item.get('Arn', 'N/A'),
+        'Has Policy': 'Yes' if item.get('Policy') else 'No'
+    }
+
+
+def collect_event_buses(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect EventBridge event bus information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(buses, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING EVENT BUSES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_event_buses_region)
-    all_buses = [b for result in results for b in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_event_buses_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_buses = [b for result in region_results for b in result]
     utils.log_success(f"Total event buses collected: {len(all_buses)}")
-    return all_buses
+    return all_buses, failed_regions
 
 
 def _scan_event_rules_region(region: str) -> list[dict[str, Any]]:
@@ -245,17 +290,20 @@ def export_eventbridge_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect event buses
-    buses = collect_event_buses(regions)
+    # STEP 1: Collect event buses (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    buses, failed_regions = collect_event_buses(regions)
     if buses:
         data_frames['Event Buses'] = pd.DataFrame(buses)
 
-    # STEP 2: Collect event rules
+    # STEP 2: Collect event rules (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     rules = collect_event_rules(regions)
     if rules:
         data_frames['Event Rules'] = pd.DataFrame(rules)
 
-    # STEP 3: Collect rule targets
+    # STEP 3: Collect rule targets (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     targets = collect_rule_targets(regions)
     if targets:
         data_frames['Rule Targets'] = pd.DataFrame(targets)
@@ -269,12 +317,12 @@ def export_eventbridge_data(account_id: str, account_name: str):
         total_targets = len(targets)
 
         # Rules by state
-        enabled_rules = sum(1 for r in rules if r['State'] == 'ENABLED')
-        disabled_rules = sum(1 for r in rules if r['State'] == 'DISABLED')
+        enabled_rules = sum(1 for r in rules if r.get('State') == 'ENABLED')
+        disabled_rules = sum(1 for r in rules if r.get('State') == 'DISABLED')
 
         # Rules by type
-        pattern_rules = sum(1 for r in rules if r['Rule Type'] == 'Event Pattern')
-        schedule_rules = sum(1 for r in rules if r['Rule Type'] == 'Schedule')
+        pattern_rules = sum(1 for r in rules if r.get('Rule Type') == 'Event Pattern')
+        schedule_rules = sum(1 for r in rules if r.get('Rule Type') == 'Schedule')
 
         summary_data.append({'Metric': 'Total Event Buses', 'Value': total_buses})
         summary_data.append({'Metric': 'Total Event Rules', 'Value': total_rules})
@@ -286,43 +334,55 @@ def export_eventbridge_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even when
+    # some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'eventbridge',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("EventBridge data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No EventBridge data was collected. Nothing to export.")
         print("\nNo EventBridge resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'eventbridge',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("EventBridge data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the Event Buses scope collection, make it loud:
+    # write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'eventbridge', failed_regions)
+        print(
+            "\nERROR: EventBridge export completed with failures — data is incomplete. "
+            "See the *-eventbridge-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/organizations_export.py
+++ b/scripts/organizations_export.py
@@ -109,9 +109,9 @@ def get_organization_info():
 
         # Describe organization
         org_response = org_client.describe_organization()
-        organization = org_response['Organization']
+        organization = org_response.get('Organization', {})
 
-        utils.log_success(f"Found AWS Organization: {organization['Id']}")
+        utils.log_success(f"Found AWS Organization: {organization.get('Id', 'Unknown')}")
         return organization
 
     except ClientError as e:
@@ -131,53 +131,115 @@ def collect_organizational_units():
     """
     Collect all organizational units (OUs) in the organization.
 
+    This is a PRIMARY, account-scope collector (see
+    scripts/shield_export.py for the account-scope reference pattern). It
+    does not swallow errors to an empty list: a swallowed error here would
+    be indistinguishable from an organization with no child OUs, producing
+    silent data loss (see the 07.15.2026 / 07.16.2026 silent-collection-
+    failure audits). Account-scope failures (client creation, root lookup,
+    pagination) are allowed to raise so the caller (main) can record this
+    scope as *failed* rather than *empty*. Per-OU errors are contained in
+    ``collect_ous_recursive`` (logged and skipped).
+
     Returns:
         list: List of OU information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     ou_data = []
 
-    try:
-        org_client = utils.get_boto3_client('organizations')
+    org_client = utils.get_boto3_client('organizations')
 
-        # Get root first
-        roots = org_client.list_roots()['Roots']
-        if not roots:
-            utils.log_error("No organization root found")
-            return []
+    # Get root first
+    roots = org_client.list_roots().get('Roots', [])
+    if not roots:
+        utils.log_error("No organization root found")
+        return []
 
-        root = roots[0]  # There should only be one root
-        root_id = root['Id']
+    root = roots[0]  # There should only be one root
+    root_id = root.get('Id')
 
-        utils.log_info("Collecting organizational units...")
+    utils.log_info("Collecting organizational units...")
 
-        # Process root as an OU
-        root_info = {
-            'OU ID': root_id,
-            'OU Name': root.get('Name', 'Root'),
-            'OU Type': 'ROOT',
-            'Parent ID': 'N/A',
-            'Parent Name': 'N/A',
-            'Level': 0,
-            'Path': 'Root',
-            'Policy Types': ', '.join([pt['Type'] for pt in root.get('PolicyTypes', [])]),
-            'ARN': root.get('Arn', 'N/A')
-        }
-        ou_data.append(root_info)
+    # Process root as an OU
+    root_info = {
+        'OU ID': root_id or 'N/A',
+        'OU Name': root.get('Name', 'Root'),
+        'OU Type': 'ROOT',
+        'Parent ID': 'N/A',
+        'Parent Name': 'N/A',
+        'Level': 0,
+        'Path': 'Root',
+        'Policy Types': ', '.join([pt.get('Type', 'Unknown') for pt in root.get('PolicyTypes', [])]),
+        'ARN': root.get('Arn', 'N/A')
+    }
+    ou_data.append(root_info)
 
-        # Recursively collect all OUs
-        collected_ous = collect_ous_recursive(org_client, root_id, "Root", 1)
-        ou_data.extend(collected_ous)
+    # Recursively collect all OUs
+    collected_ous = collect_ous_recursive(org_client, root_id, "Root", 1)
+    ou_data.extend(collected_ous)
 
-        utils.log_success(f"Collected {len(ou_data)} organizational units")
-
-    except Exception as e:
-        utils.log_error("Error collecting organizational units", e)
+    utils.log_success(f"Collected {len(ou_data)} organizational units")
 
     return ou_data
+
+def _build_ou_row(org_client, ou, parent_id, parent_path, level):
+    """
+    Build the export row for a single organizational unit.
+
+    Extracted so per-OU processing can be wrapped in try/except by the
+    caller: a malformed OU entry must not sink the whole recursive branch.
+    Required fields are read with ``.get()`` and a safe default for the
+    same reason.
+
+    Args:
+        org_client: boto3 organizations client
+        ou (dict): A single OrganizationalUnits entry.
+        parent_id: Parent OU/root ID.
+        parent_path: Full path to parent.
+        level: Current nesting level.
+
+    Returns:
+        tuple: (ou_info dict, ou_id, ou_path) for the caller to use when
+            recursing into this OU's children.
+    """
+    ou_id = ou.get('Id')
+    ou_name = ou.get('Name', 'Unnamed OU')
+    ou_path = f"{parent_path}/{ou_name}"
+
+    # Get parent name
+    try:
+        if parent_id.startswith('r-'):  # Root
+            parent_name = 'Root'
+        else:
+            parent_response = org_client.describe_organizational_unit(OrganizationalUnitId=parent_id)
+            parent_name = parent_response.get('OrganizationalUnit', {}).get('Name', 'Unknown')
+    except Exception:
+        parent_name = 'Unknown'
+
+    ou_info = {
+        'OU ID': ou_id or 'N/A',
+        'OU Name': ou_name,
+        'OU Type': 'ORGANIZATIONAL_UNIT',
+        'Parent ID': parent_id,
+        'Parent Name': parent_name,
+        'Level': level,
+        'Path': ou_path,
+        'Policy Types': 'N/A',  # Will be filled later if needed
+        'ARN': ou.get('Arn', 'N/A')
+    }
+
+    return ou_info, ou_id, ou_path
 
 def collect_ous_recursive(org_client, parent_id, parent_path, level):
     """
     Recursively collect OUs under a parent.
+
+    Pagination/API errors propagate to the caller (the recursion is part of
+    the ``collect_organizational_units`` PRIMARY scope). A single malformed
+    OU entry is logged and skipped rather than aborting the whole branch.
 
     Args:
         org_client: boto3 organizations client
@@ -187,116 +249,143 @@ def collect_ous_recursive(org_client, parent_id, parent_path, level):
 
     Returns:
         list: List of OU information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error (caller records the parent
+            scope as failed; it is never masked as empty).
     """
     ou_data = []
 
-    try:
-        # Get direct children OUs
-        paginator = org_client.get_paginator('list_organizational_units_for_parent')
+    # Get direct children OUs
+    paginator = org_client.get_paginator('list_organizational_units_for_parent')
 
-        for page in paginator.paginate(ParentId=parent_id):
-            for ou in page.get('OrganizationalUnits', []):
-                ou_id = ou['Id']
-                ou_name = ou.get('Name', 'Unnamed OU')
-                ou_path = f"{parent_path}/{ou_name}"
+    for page in paginator.paginate(ParentId=parent_id):
+        for ou in page.get('OrganizationalUnits', []):
+            try:
+                ou_info, ou_id, ou_path = _build_ou_row(org_client, ou, parent_id, parent_path, level)
+            except Exception as e:
+                ou_ref = ou.get('Id', 'Unknown') if isinstance(ou, dict) else 'Unknown'
+                utils.log_warning(f"Skipping malformed OU '{ou_ref}' under parent {parent_id} due to a processing error: {e}")
+                continue
 
-                # Get parent name
-                try:
-                    if parent_id.startswith('r-'):  # Root
-                        parent_name = 'Root'
-                    else:
-                        parent_response = org_client.describe_organizational_unit(OrganizationalUnitId=parent_id)
-                        parent_name = parent_response['OrganizationalUnit'].get('Name', 'Unknown')
-                except Exception:
-                    parent_name = 'Unknown'
+            ou_data.append(ou_info)
 
-                ou_info = {
-                    'OU ID': ou_id,
-                    'OU Name': ou_name,
-                    'OU Type': 'ORGANIZATIONAL_UNIT',
-                    'Parent ID': parent_id,
-                    'Parent Name': parent_name,
-                    'Level': level,
-                    'Path': ou_path,
-                    'Policy Types': 'N/A',  # Will be filled later if needed
-                    'ARN': ou.get('Arn', 'N/A')
-                }
-                ou_data.append(ou_info)
+            utils.log_info(f"Found OU: {ou_path}")
 
-                utils.log_info(f"Found OU: {ou_path}")
-
-                # Recursively get children
-                children = collect_ous_recursive(org_client, ou_id, ou_path, level + 1)
-                ou_data.extend(children)
-
-    except Exception as e:
-        utils.log_warning(f"Error collecting OUs for parent {parent_id}: {e}")
+            # Recursively get children
+            children = collect_ous_recursive(org_client, ou_id, ou_path, level + 1)
+            ou_data.extend(children)
 
     return ou_data
+
+def _build_account_row(org_client, account, processed, total_accounts):
+    """
+    Build the export row for a single organization account.
+
+    Extracted so per-account processing can be wrapped in try/except by the
+    caller: a malformed account entry must not sink the whole account-scope
+    collection. Required fields are read with ``.get()`` and a safe default
+    for the same reason.
+
+    Args:
+        org_client: boto3 organizations client
+        account (dict): A single Accounts entry from list_accounts.
+        processed: 1-based index of this account within the current run.
+        total_accounts: Total account count, for progress logging.
+
+    Returns:
+        dict: The assembled account row.
+    """
+    progress = (processed / total_accounts) * 100 if total_accounts > 0 else 0
+    account_id = account.get('Id')
+    account_name = account.get('Name', 'Unnamed Account')
+
+    utils.log_info(f"[{progress:.1f}%] Processing account {processed}/{total_accounts}: {account_name}")
+
+    # Get account's parent OU
+    parent_info = get_account_parent(org_client, account_id)
+
+    # Get account tags if available
+    account_tags = get_account_tags(org_client, account_id)
+
+    return {
+        'Account ID': account_id or 'N/A',
+        'Account Name': account_name,
+        'Email': account.get('Email', 'N/A'),
+        'Status': account.get('Status', 'N/A'),
+        'Join Method': account.get('JoinedMethod', 'N/A'),
+        'Joined Date': convert_datetime_to_string(account.get('JoinedTimestamp')),
+        'Parent ID': parent_info['parent_id'],
+        'Parent Name': parent_info['parent_name'],
+        'Parent Type': parent_info['parent_type'],
+        'Full Path': parent_info['full_path'],
+        'ARN': account.get('Arn', 'N/A'),
+        'Tags': account_tags
+    }
 
 def collect_accounts():
     """
     Collect all accounts in the organization.
 
+    This is a PRIMARY, account-scope collector (see
+    scripts/shield_export.py for the account-scope reference pattern). It
+    does not swallow errors to an empty list: a swallowed error here would
+    be indistinguishable from an organization with no member accounts,
+    producing silent data loss (see the 07.15.2026 / 07.16.2026 silent-
+    collection-failure audits). Account-scope failures (client creation,
+    pagination) are allowed to raise so the caller (main) can record this
+    scope as *failed* rather than *empty*. Per-account errors are contained
+    internally (logged and skipped).
+
     Returns:
         list: List of account information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     accounts_data = []
 
-    try:
-        org_client = utils.get_boto3_client('organizations')
+    org_client = utils.get_boto3_client('organizations')
 
-        utils.log_info("Collecting organization accounts...")
+    utils.log_info("Collecting organization accounts...")
 
-        # Get all accounts
-        paginator = org_client.get_paginator('list_accounts')
-        total_accounts = 0
+    # Get all accounts
+    paginator = org_client.get_paginator('list_accounts')
+    total_accounts = 0
 
-        # Count accounts first
-        for page in paginator.paginate():
-            total_accounts += len(page.get('Accounts', []))
+    # Count accounts first
+    for page in paginator.paginate():
+        total_accounts += len(page.get('Accounts', []))
 
-        utils.log_info(f"Found {total_accounts} accounts to process")
+    utils.log_info(f"Found {total_accounts} accounts to process")
 
-        # Reset paginator and process accounts
-        paginator = org_client.get_paginator('list_accounts')
-        processed = 0
+    # Reset paginator and process accounts
+    paginator = org_client.get_paginator('list_accounts')
+    processed = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            accounts = page.get('Accounts', [])
+    for page in paginator.paginate():
+        accounts = page.get('Accounts', [])
 
-            for account in accounts:
-                processed += 1
-                progress = (processed / total_accounts) * 100 if total_accounts > 0 else 0
-                account_name = account.get('Name', 'Unnamed Account')
+        for account in accounts:
+            processed += 1
 
-                utils.log_info(f"[{progress:.1f}%] Processing account {processed}/{total_accounts}: {account_name}")
+            try:
+                account_info = _build_account_row(org_client, account, processed, total_accounts)
+            except Exception as e:
+                skipped += 1
+                account_ref = account.get('Id', 'Unknown') if isinstance(account, dict) else 'Unknown'
+                utils.log_error(f"Skipping account '{account_ref}' due to a processing error", e)
+                continue
 
-                # Get account's parent OU
-                parent_info = get_account_parent(org_client, account['Id'])
+            accounts_data.append(account_info)
 
-                # Get account tags if available
-                account_tags = get_account_tags(org_client, account['Id'])
-
-                account_info = {
-                    'Account ID': account.get('Id', 'N/A'),
-                    'Account Name': account_name,
-                    'Email': account.get('Email', 'N/A'),
-                    'Status': account.get('Status', 'N/A'),
-                    'Join Method': account.get('JoinedMethod', 'N/A'),
-                    'Joined Date': convert_datetime_to_string(account.get('JoinedTimestamp')),
-                    'Parent ID': parent_info['parent_id'],
-                    'Parent Name': parent_info['parent_name'],
-                    'Parent Type': parent_info['parent_type'],
-                    'Full Path': parent_info['full_path'],
-                    'ARN': account.get('Arn', 'N/A'),
-                    'Tags': account_tags
-                }
-
-                accounts_data.append(account_info)
-
-    except Exception as e:
-        utils.log_error("Error collecting accounts", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_accounts} account(s) were skipped due to "
+            "processing errors (see log above); the remaining accounts were still collected."
+        )
 
     return accounts_data
 
@@ -414,7 +503,7 @@ def get_account_tags(org_client, account_id):
         tags = response.get('Tags', [])
 
         if tags:
-            tag_strings = [f"{tag['Key']}={tag['Value']}" for tag in tags]
+            tag_strings = [f"{tag.get('Key', 'Unknown')}={tag.get('Value', 'Unknown')}" for tag in tags]
             return ', '.join(tag_strings)
         else:
             return 'No Tags'
@@ -422,81 +511,123 @@ def get_account_tags(org_client, account_id):
     except Exception:
         return 'Unable to retrieve tags'
 
+def _build_policy_row(org_client, policy, policy_type):
+    """
+    Build the export row for a single policy, including content analysis
+    and attachment targets.
+
+    Extracted so per-policy processing can be wrapped in try/except by the
+    caller: a malformed policy entry (or a transient describe_policy
+    failure) must not sink collection of the remaining policies. Required
+    fields are read with ``.get()`` and a safe default for the same reason.
+
+    Args:
+        org_client: boto3 organizations client
+        policy (dict): A single Policies summary entry from list_policies.
+        policy_type: The policy type being processed (e.g. SERVICE_CONTROL_POLICY).
+
+    Returns:
+        dict: The assembled policy row.
+    """
+    policy_id = policy.get('Id')
+    policy_name = policy.get('Name', 'Unnamed Policy')
+
+    utils.log_info(f"Processing {policy_type}: {policy_name}")
+
+    policy_response = org_client.describe_policy(PolicyId=policy_id)
+    policy_details = policy_response.get('Policy', {})
+
+    # Get policy content if it's an SCP
+    policy_content = ''
+    policy_summary = ''
+    if policy_type == 'SERVICE_CONTROL_POLICY':
+        policy_content = policy_details.get('Content', '')
+        policy_summary = analyze_scp_content(policy_content)
+
+    # Get policy targets (what it's attached to)
+    targets = get_policy_targets(org_client, policy_id)
+
+    return {
+        'Policy ID': policy_id or 'N/A',
+        'Policy Name': policy_name,
+        'Policy Type': policy_type,
+        'Description': policy_details.get('PolicySummary', {}).get('Description', 'N/A'),
+        'AWS Managed': 'Yes' if policy_details.get('PolicySummary', {}).get('AwsManaged', False) else 'No',
+        'Content Size': len(policy_content) if policy_content else 0,
+        'Policy Summary': policy_summary[:500] if policy_summary else 'N/A',
+        'Attached To Count': len(targets),
+        'Attached To': ', '.join(targets)[:500] if targets else 'Not Attached',
+        'ARN': policy_details.get('PolicySummary', {}).get('Arn', 'N/A')
+    }
+
 def collect_policies():
     """
     Collect all service control policies (SCPs) and other policies.
 
+    This is a PRIMARY, account-scope collector (see
+    scripts/shield_export.py for the account-scope reference pattern). It
+    does not swallow errors to an empty list: a swallowed error here would
+    be indistinguishable from an organization with no custom policies,
+    producing silent data loss (see the 07.15.2026 / 07.16.2026 silent-
+    collection-failure audits). ``PolicyTypeNotEnabledException`` for a
+    single policy type is a legitimate, expected condition (that policy
+    type simply is not turned on for this organization) and is skipped
+    gracefully; any other API/pagination error propagates so the caller
+    (main) can record this scope as *failed* rather than *empty*.
+    Per-policy errors are contained internally (logged and skipped).
+
     Returns:
         list: List of policy information dictionaries
+
+    Raises:
+        Exception: Any AWS/pagination error other than a not-enabled
+            policy type (caller records it as a failed scope; it is never
+            masked as empty).
     """
     policies_data = []
+    skipped = 0
 
-    try:
-        org_client = utils.get_boto3_client('organizations')
+    org_client = utils.get_boto3_client('organizations')
 
-        utils.log_info("Collecting organization policies...")
+    utils.log_info("Collecting organization policies...")
 
-        # Get all policy types
-        policy_types = ['SERVICE_CONTROL_POLICY', 'TAG_POLICY', 'BACKUP_POLICY', 'AISERVICES_OPT_OUT_POLICY']
+    # Get all policy types
+    policy_types = ['SERVICE_CONTROL_POLICY', 'TAG_POLICY', 'BACKUP_POLICY', 'AISERVICES_OPT_OUT_POLICY']
 
-        for policy_type in policy_types:
-            try:
-                paginator = org_client.get_paginator('list_policies')
+    for policy_type in policy_types:
+        try:
+            paginator = org_client.get_paginator('list_policies')
 
-                for page in paginator.paginate(Filter=policy_type):
-                    policies = page.get('Policies', [])
+            for page in paginator.paginate(Filter=policy_type):
+                policies = page.get('Policies', [])
 
-                    for policy in policies:
-                        policy_id = policy['Id']
-                        policy_name = policy.get('Name', 'Unnamed Policy')
+                for policy in policies:
+                    try:
+                        policy_info = _build_policy_row(org_client, policy, policy_type)
+                    except Exception as e:
+                        skipped += 1
+                        policy_ref = policy.get('Id', 'Unknown') if isinstance(policy, dict) else 'Unknown'
+                        utils.log_warning(f"Skipping policy '{policy_ref}' due to a processing error: {e}")
+                        continue
 
-                        utils.log_info(f"Processing {policy_type}: {policy_name}")
+                    policies_data.append(policy_info)
 
-                        # Get detailed policy information
-                        try:
-                            policy_response = org_client.describe_policy(PolicyId=policy_id)
-                            policy_details = policy_response['Policy']
+        except ClientError as e:
+            if 'PolicyTypeNotEnabledException' in str(e):
+                # Legitimate, expected condition: this policy type is not
+                # enabled for the organization. Skip it, keep collecting
+                # the remaining policy types.
+                utils.log_info(f"Policy type {policy_type} is not enabled in this organization")
+            else:
+                raise
 
-                            # Get policy content if it's an SCP
-                            policy_content = ''
-                            policy_summary = ''
-                            if policy_type == 'SERVICE_CONTROL_POLICY':
-                                policy_content = policy_details.get('Content', '')
-                                policy_summary = analyze_scp_content(policy_content)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} policy(ies) were skipped due to processing errors "
+            "(see log above); the remaining policies were still collected."
+        )
 
-                            # Get policy targets (what it's attached to)
-                            targets = get_policy_targets(org_client, policy_id)
-
-                            policy_info = {
-                                'Policy ID': policy_id,
-                                'Policy Name': policy_name,
-                                'Policy Type': policy_type,
-                                'Description': policy_details.get('PolicySummary', {}).get('Description', 'N/A'),
-                                'AWS Managed': 'Yes' if policy_details.get('PolicySummary', {}).get('AwsManaged', False) else 'No',
-                                'Content Size': len(policy_content) if policy_content else 0,
-                                'Policy Summary': policy_summary[:500] if policy_summary else 'N/A',
-                                'Attached To Count': len(targets),
-                                'Attached To': ', '.join(targets)[:500] if targets else 'Not Attached',
-                                'ARN': policy_details.get('PolicySummary', {}).get('Arn', 'N/A')
-                            }
-
-                            policies_data.append(policy_info)
-
-                        except Exception as e:
-                            utils.log_warning(f"Error getting details for policy {policy_id}: {e}")
-
-            except ClientError as e:
-                if 'PolicyTypeNotEnabledException' in str(e):
-                    utils.log_info(f"Policy type {policy_type} is not enabled in this organization")
-                else:
-                    utils.log_warning(f"Error collecting {policy_type} policies: {e}")
-            except Exception as e:
-                utils.log_warning(f"Error collecting {policy_type} policies: {e}")
-
-        utils.log_success(f"Collected {len(policies_data)} policies")
-
-    except Exception as e:
-        utils.log_error("Error collecting policies", e)
+    utils.log_success(f"Collected {len(policies_data)} policies")
 
     return policies_data
 
@@ -576,22 +707,22 @@ def get_policy_targets(org_client, policy_id):
 
         for page in paginator.paginate(PolicyId=policy_id):
             for target in page.get('Targets', []):
-                target_id = target['TargetId']
-                target_type = target['Type']
+                target_id = target.get('TargetId')
+                target_type = target.get('Type')
 
                 if target_type == 'ROOT':
                     targets.append('Root')
                 elif target_type == 'ORGANIZATIONAL_UNIT':
                     try:
                         ou_response = org_client.describe_organizational_unit(OrganizationalUnitId=target_id)
-                        ou_name = ou_response['OrganizationalUnit'].get('Name', target_id)
+                        ou_name = ou_response.get('OrganizationalUnit', {}).get('Name', target_id)
                         targets.append(f"OU: {ou_name}")
                     except Exception:
                         targets.append(f"OU: {target_id}")
                 elif target_type == 'ACCOUNT':
                     try:
                         account_response = org_client.describe_account(AccountId=target_id)
-                        account_name = account_response['Account'].get('Name', target_id)
+                        account_name = account_response.get('Account', {}).get('Name', target_id)
                         targets.append(f"Account: {account_name}")
                     except Exception:
                         targets.append(f"Account: {target_id}")
@@ -761,6 +892,21 @@ def export_to_excel(org_info, ou_data, accounts_data, policies_data, account_id,
 def main():
     """
     Main function to orchestrate the Organizations information collection.
+
+    AWS Organizations is a global, account-scope service run from the
+    management account (there is no region scan) -- failures are tracked
+    per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py /
+    scripts/lambda_export.py for the account-scope reference pattern).
+    "AWS Organizations is not in use" / "this is not the management
+    account" is a legitimate, graceful "service not enabled" state (exit 0,
+    no marker) -- handled by ``get_organization_info()`` -- and must not be
+    confused with a real collection failure on the organizational-units,
+    accounts, or policies scopes, which are exported as a partial result
+    (whatever succeeded) and always surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit. A failed scope
+    must never be silently collapsed into "nothing to report" (07.15.2026 /
+    07.16.2026 audits).
     """
     try:
         # Check dependencies first
@@ -797,29 +943,53 @@ def main():
         org_info = get_organization_info()
 
         if not org_info:
+            # Graceful skip: AWS Organizations is not enabled in this
+            # account, or this is not the management account. This is a
+            # legitimate, expected state -- NOT a collection failure -- so
+            # no failure marker is written and the process exits 0.
             utils.log_error("Could not access AWS Organizations. This script must be run from the management account.")
             utils.log_info("Please ensure you have the necessary permissions and are running from the management account.")
             return
 
-        # Collect organizational data
+        # Account-scope failure tracking (see scripts/shield_export.py).
+        failed_scopes = []
+
+        # PRIMARY scope 1/3: organizational units. A real API error here
+        # must propagate to failed_scopes, never collapse into an empty
+        # list that reads as "no OUs configured".
         utils.log_info("Collecting organizational units...")
-        ou_data = collect_organizational_units()
+        try:
+            ou_data = collect_organizational_units()
+        except Exception as e:
+            failed_scopes.append(('organizational_units', str(e)))
+            utils.log_error(f"Organizational units collection failed: {e}")
+            ou_data = []
 
+        # PRIMARY scope 2/3: accounts.
         utils.log_info("Collecting accounts...")
-        accounts_data = collect_accounts()
+        try:
+            accounts_data = collect_accounts()
+        except Exception as e:
+            failed_scopes.append(('accounts', str(e)))
+            utils.log_error(f"Accounts collection failed: {e}")
+            accounts_data = []
 
+        # PRIMARY scope 3/3: policies.
         utils.log_info("Collecting policies...")
-        policies_data = collect_policies()
-
-        if not ou_data and not accounts_data and not policies_data:
-            utils.log_warning("No Organizations data collected. Exiting.")
-            return
+        try:
+            policies_data = collect_policies()
+        except Exception as e:
+            failed_scopes.append(('policies', str(e)))
+            utils.log_error(f"Policies collection failed: {e}")
+            policies_data = []
 
         print("\n====================================================================")
         print("COLLECTION COMPLETE")
         print("====================================================================")
 
-        # Export to Excel
+        # Export whatever succeeded -- a partial export is required even
+        # when some scopes failed (see
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
         filename = export_to_excel(org_info, ou_data, accounts_data, policies_data, account_id, account_name)
 
         if filename:
@@ -839,8 +1009,25 @@ def main():
                 utils.log_info(f"Service Control Policies: {scps}")
 
             print("\nScript execution completed.")
+        elif not failed_scopes:
+            # Genuinely empty: every scope succeeded and there is simply
+            # nothing to export.
+            utils.log_warning("No Organizations data collected. Nothing to export.")
         else:
             utils.log_error("Export failed. Please check the logs.")
+
+        # If any primary scope failed, make it loud: write a marker and
+        # exit non-zero, even if a partial export was written. A partial
+        # export that looks complete is exactly the failure mode this
+        # guards against.
+        if failed_scopes:
+            utils.report_collection_failures(account_name, 'organizations', failed_scopes)
+            print(
+                "\nERROR: Organizations export completed with failures — data is "
+                "incomplete. See the *-organizations-FAILED-*.txt marker in the "
+                "output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/savings_plans_export.py
+++ b/scripts/savings_plans_export.py
@@ -46,19 +46,127 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Savings Plans to Excel")
 
 
-@utils.aws_error_handler("Collecting Savings Plans", default_return=[])
+def _build_savings_plan_row(plan: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single Savings Plan.
+
+    Extracted so per-plan processing can be wrapped in try/except by the
+    caller: a malformed plan entry must not sink the whole account-scope
+    collection. All fields are read with ``.get()`` and a safe default for
+    the same reason (the ``plan['Hourly Commitment']`` style hard subscript
+    flagged in .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+    is a deterministic ``KeyError`` candidate on divergent plan variants).
+
+    Args:
+        plan: A single savingsPlans entry from describe_savings_plans.
+
+    Returns:
+        dict: The assembled savings plan row.
+    """
+    plan_id = plan.get('savingsPlanId', 'N/A')
+    plan_arn = plan.get('savingsPlanArn', 'N/A')
+
+    print(f"  Processing savings plan: {plan_id}")
+
+    # Basic info
+    plan_type = plan.get('savingsPlanType', 'N/A')
+    payment_option = plan.get('paymentOption', 'N/A')
+    state_val = plan.get('state', 'N/A')
+
+    # Commitment
+    commitment = plan.get('commitment', '0')
+    currency = plan.get('currency', 'USD')
+
+    # Convert Decimal to float for Excel
+    if isinstance(commitment, Decimal):
+        commitment = float(commitment)
+
+    # Term
+    term_duration = plan.get('termDurationInSeconds', 0)
+    # Convert seconds to years
+    term_years = term_duration / (365.25 * 24 * 60 * 60)
+
+    # Dates
+    start = plan.get('start', '')
+    if start:
+        start = start.strftime('%Y-%m-%d %H:%M:%S') if isinstance(start, datetime.datetime) else str(start)
+
+    end = plan.get('end', '')
+    if end:
+        end = end.strftime('%Y-%m-%d %H:%M:%S') if isinstance(end, datetime.datetime) else str(end)
+
+    # EC2 instance family (if applicable)
+    ec2_instance_family = plan.get('ec2InstanceFamily', 'N/A')
+
+    # Region (if applicable)
+    region = plan.get('region', 'N/A')
+
+    # Upfront payment
+    upfront = plan.get('upfrontPaymentAmount', '0')
+    if isinstance(upfront, Decimal):
+        upfront = float(upfront)
+
+    # Recurring payment
+    recurring = plan.get('recurringPaymentAmount', '0')
+    if isinstance(recurring, Decimal):
+        recurring = float(recurring)
+
+    # Description/offering ID
+    offering_id = plan.get('offeringId', 'N/A')
+
+    # Tags
+    tags = plan.get('tags', {}) or {}
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
+
+    return {
+        'Savings Plan ID': plan_id,
+        'State': state_val,
+        'Savings Plan Type': plan_type,
+        'Payment Option': payment_option,
+        'Hourly Commitment': commitment,
+        'Currency': currency,
+        'Term (Years)': round(term_years, 1),
+        'Start Date': start if start else 'N/A',
+        'End Date': end if end else 'N/A',
+        'EC2 Instance Family': ec2_instance_family,
+        'Region': region,
+        'Upfront Payment': upfront,
+        'Recurring Payment': recurring,
+        'Offering ID': offering_id,
+        'Tags': tags_str,
+        'Savings Plan ARN': plan_arn
+    }
+
+
 def collect_savings_plans(states: list[str]) -> list[dict[str, Any]]:
     """
     Collect Savings Plans information.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no savings plans purchased), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Savings Plans is a global, account-scope service (not
+    multi-region — see scripts/shield_export.py for the account-scope
+    reference pattern this follows). Account-scope failures (client
+    creation, pagination) are allowed to raise so the caller (main) can
+    record this scope as *failed* rather than *empty*. Per-plan errors are
+    contained internally (logged and skipped).
 
     Args:
         states: List of states to filter (e.g., ['active', 'queued'])
 
     Returns:
-        list: List of dictionaries with savings plan information
+        list: List of dictionaries with savings plan information.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     print(f"\n=== COLLECTING SAVINGS PLANS (States: {', '.join(states)}) ===")
     all_plans = []
+    total_processed = 0
+    skipped = 0
 
     # Savings Plans is a global service but requires a region
     # Savings Plans is a global service - use partition-aware home region
@@ -68,98 +176,39 @@ def collect_savings_plans(states: list[str]) -> list[dict[str, Any]]:
     for state in states:
         print(f"\nProcessing state: {state}")
 
-        try:
-            # describe_savings_plans has no boto3 paginator; page manually via nextToken.
-            next_token = None
-            while True:
-                params: dict[str, Any] = {'states': [state], 'maxResults': 100}
-                if next_token:
-                    params['nextToken'] = next_token
+        # describe_savings_plans has no boto3 paginator; page manually via nextToken.
+        next_token = None
+        while True:
+            params: dict[str, Any] = {'states': [state], 'maxResults': 100}
+            if next_token:
+                params['nextToken'] = next_token
 
-                page = sp_client.describe_savings_plans(**params)
-                savings_plans = page.get('savingsPlans', [])
+            page = sp_client.describe_savings_plans(**params)
+            savings_plans = page.get('savingsPlans', [])
 
-                for plan in savings_plans:
-                    plan_id = plan.get('savingsPlanId', 'N/A')
-                    plan_arn = plan.get('savingsPlanArn', 'N/A')
+            # Process each plan. One malformed plan must not sink the whole
+            # scope, so each is built inside try/except; failures are logged
+            # and skipped.
+            for plan in savings_plans:
+                total_processed += 1
 
-                    print(f"  Processing savings plan: {plan_id}")
+                try:
+                    all_plans.append(_build_savings_plan_row(plan))
+                except Exception as e:
+                    skipped += 1
+                    plan_id = plan.get('savingsPlanId', 'Unknown') if isinstance(plan, dict) else 'Unknown'
+                    utils.log_error(f"Skipping savings plan '{plan_id}' due to a processing error", e)
+                    continue
 
-                    # Basic info
-                    plan_type = plan.get('savingsPlanType', 'N/A')
-                    payment_option = plan.get('paymentOption', 'N/A')
-                    state_val = plan.get('state', 'N/A')
+            next_token = page.get('nextToken')
+            if not next_token:
+                break
 
-                    # Commitment
-                    commitment = plan.get('commitment', '0')
-                    currency = plan.get('currency', 'USD')
-
-                    # Convert Decimal to float for Excel
-                    if isinstance(commitment, Decimal):
-                        commitment = float(commitment)
-
-                    # Term
-                    term_duration = plan.get('termDurationInSeconds', 0)
-                    # Convert seconds to years
-                    term_years = term_duration / (365.25 * 24 * 60 * 60)
-
-                    # Dates
-                    start = plan.get('start', '')
-                    if start:
-                        start = start.strftime('%Y-%m-%d %H:%M:%S') if isinstance(start, datetime.datetime) else str(start)
-
-                    end = plan.get('end', '')
-                    if end:
-                        end = end.strftime('%Y-%m-%d %H:%M:%S') if isinstance(end, datetime.datetime) else str(end)
-
-                    # EC2 instance family (if applicable)
-                    ec2_instance_family = plan.get('ec2InstanceFamily', 'N/A')
-
-                    # Region (if applicable)
-                    region = plan.get('region', 'N/A')
-
-                    # Upfront payment
-                    upfront = plan.get('upfrontPaymentAmount', '0')
-                    if isinstance(upfront, Decimal):
-                        upfront = float(upfront)
-
-                    # Recurring payment
-                    recurring = plan.get('recurringPaymentAmount', '0')
-                    if isinstance(recurring, Decimal):
-                        recurring = float(recurring)
-
-                    # Description/offering ID
-                    offering_id = plan.get('offeringId', 'N/A')
-
-                    # Tags
-                    tags = plan.get('tags', {})
-                    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
-
-                    all_plans.append({
-                        'Savings Plan ID': plan_id,
-                        'State': state_val,
-                        'Savings Plan Type': plan_type,
-                        'Payment Option': payment_option,
-                        'Hourly Commitment': commitment,
-                        'Currency': currency,
-                        'Term (Years)': round(term_years, 1),
-                        'Start Date': start if start else 'N/A',
-                        'End Date': end if end else 'N/A',
-                        'EC2 Instance Family': ec2_instance_family,
-                        'Region': region,
-                        'Upfront Payment': upfront,
-                        'Recurring Payment': recurring,
-                        'Offering ID': offering_id,
-                        'Tags': tags_str,
-                        'Savings Plan ARN': plan_arn
-                    })
-
-                next_token = page.get('nextToken')
-                if not next_token:
-                    break
-
-        except Exception as e:
-            utils.log_error(f"Error collecting savings plans in state {state}", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_processed} savings plan(s) were skipped due to "
+            "processing errors (see log above); the remaining plans were still collected."
+        )
 
     utils.log_success(f"Total savings plans collected: {len(all_plans)}")
     return all_plans
@@ -168,6 +217,15 @@ def collect_savings_plans(states: list[str]) -> list[dict[str, Any]]:
 def export_savings_plans_data(account_id: str, account_name: str):
     """
     Export Savings Plans information to an Excel file.
+
+    Savings Plans is a global, account-scope service (not multi-region), so
+    failures are tracked per account-scope collector call rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py for the
+    account-scope reference pattern). Each ``collect_savings_plans`` call
+    (PRIMARY scope) is allowed to raise; a real API error is recorded in
+    ``failed_scopes`` and the export continues with whatever data was
+    already collected — it is never silently collapsed into "no savings
+    plans" (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
 
     Args:
         account_id: The AWS account ID
@@ -182,13 +240,29 @@ def export_savings_plans_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect active savings plans
-    active_plans = collect_savings_plans(['active'])
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes: list[tuple[str, str]] = []
+
+    # STEP 1: Collect active savings plans (PRIMARY scope — a real API error
+    # here must propagate to failed_scopes, never collapse into an empty
+    # list that reads as "no active savings plans").
+    try:
+        active_plans = collect_savings_plans(['active'])
+    except Exception as e:
+        failed_scopes.append(('savings_plans', str(e)))
+        utils.log_error(f"Active savings plans collection failed: {e}")
+        active_plans = []
     if active_plans:
         data_frames['Active Savings Plans'] = pd.DataFrame(active_plans)
 
-    # STEP 2: Collect queued (pending) savings plans
-    queued_plans = collect_savings_plans(['queued'])
+    # STEP 2: Collect queued (pending) savings plans (PRIMARY scope — same
+    # failure handling as STEP 1).
+    try:
+        queued_plans = collect_savings_plans(['queued'])
+    except Exception as e:
+        failed_scopes.append(('savings_plans', str(e)))
+        utils.log_error(f"Queued savings plans collection failed: {e}")
+        queued_plans = []
     if queued_plans:
         data_frames['Queued Savings Plans'] = pd.DataFrame(queued_plans)
 
@@ -201,9 +275,9 @@ def export_savings_plans_data(account_id: str, account_name: str):
         total_queued = len(queued_plans)
 
         # Commitment totals by type
-        compute_commitment = sum(float(p['Hourly Commitment']) for p in active_plans if p['Savings Plan Type'] == 'Compute')
-        ec2_commitment = sum(float(p['Hourly Commitment']) for p in active_plans if p['Savings Plan Type'] == 'EC2Instance')
-        sagemaker_commitment = sum(float(p['Hourly Commitment']) for p in active_plans if p['Savings Plan Type'] == 'SageMaker')
+        compute_commitment = sum(float(p.get('Hourly Commitment', 0)) for p in active_plans if p.get('Savings Plan Type') == 'Compute')
+        ec2_commitment = sum(float(p.get('Hourly Commitment', 0)) for p in active_plans if p.get('Savings Plan Type') == 'EC2Instance')
+        sagemaker_commitment = sum(float(p.get('Hourly Commitment', 0)) for p in active_plans if p.get('Savings Plan Type') == 'SageMaker')
 
         summary_data.append({
             'Metric': 'Total Active Savings Plans',
@@ -232,42 +306,57 @@ def export_savings_plans_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
+    # Check if we have any data. A genuinely empty result (no data AND no
+    # failed scopes) gets a plain warning; a failed scope is handled below
+    # regardless of whether a partial export was written.
     if not data_frames:
-        utils.log_warning("No Savings Plans data was collected. Nothing to export.")
-        print("\nNo Savings Plans found in this account.")
-        return
+        if not failed_scopes:
+            utils.log_warning("No Savings Plans data was collected. Nothing to export.")
+            print("\nNo Savings Plans found in this account.")
+    else:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'savings-plans',
+            '',
+            current_date
+        )
 
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'savings-plans',
-        '',
-        current_date
-    )
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
 
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+            if output_path:
+                utils.log_success("Savings Plans data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
 
-        if output_path:
-            utils.log_success("Savings Plans data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
 
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If any primary-scope collection failed, make it loud: write a marker
+    # and exit non-zero, even if a partial export (the other scope, or the
+    # Summary sheet) was written. A partial export that looks complete is
+    # exactly the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'savings-plans', failed_scopes)
+        print(
+            "\nERROR: Savings Plans export completed with failures — data is "
+            "incomplete. See the *-savings-plans-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/sqs_sns_export.py
+++ b/scripts/sqs_sns_export.py
@@ -44,128 +44,279 @@ except ImportError:
 args = utils.parse_script_args("Export SQS queues and SNS topics to Excel")
 
 
+def _build_queue_row(queue_url: str, attributes: dict, region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single SQS queue.
+
+    Extracted so the per-queue processing can be wrapped in try/except by the
+    caller: a malformed queue entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        queue_url: The queue's URL (from list_queues).
+        attributes: The 'Attributes' dict from get_queue_attributes.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled queue row.
+    """
+    queue_name = queue_url.split('/')[-1]
+
+    queue_arn = attributes.get('QueueArn', 'N/A')
+    is_fifo = queue_name.endswith('.fifo')
+    queue_type = 'FIFO' if is_fifo else 'Standard'
+
+    created_timestamp = attributes.get('CreatedTimestamp', '')
+    created_date_str = datetime.datetime.fromtimestamp(int(float(created_timestamp))).strftime('%Y-%m-%d %H:%M:%S') if created_timestamp else 'N/A'
+
+    retention_period = attributes.get('MessageRetentionPeriod', '345600')
+    retention_days = int(retention_period) / 86400
+    redrive_policy = attributes.get('RedrivePolicy')
+    kms_master_key_id = attributes.get('KmsMasterKeyId')
+    content_dedup = attributes.get('ContentBasedDeduplication', 'false') if is_fifo else 'N/A'
+
+    return {
+        'Region': region,
+        'Queue Name': queue_name,
+        'Queue Type': queue_type,
+        'Queue URL': queue_url,
+        'Queue ARN': queue_arn,
+        'Created Date': created_date_str,
+        'Messages Available': attributes.get('ApproximateNumberOfMessages', '0'),
+        'Messages In Flight': attributes.get('ApproximateNumberOfMessagesNotVisible', '0'),
+        'Messages Delayed': attributes.get('ApproximateNumberOfMessagesDelayed', '0'),
+        'Retention Period (days)': round(retention_days, 1),
+        'Visibility Timeout (sec)': attributes.get('VisibilityTimeout', '30'),
+        'Delay (sec)': attributes.get('DelaySeconds', '0'),
+        'Max Message Size (bytes)': attributes.get('MaximumMessageSize', '262144'),
+        'Receive Wait Time (sec)': attributes.get('ReceiveMessageWaitTimeSeconds', '0'),
+        'Has Dead Letter Queue': 'Yes' if redrive_policy else 'No',
+        'Encrypted': 'Yes' if kms_master_key_id else 'No',
+        'Content-Based Deduplication': content_dedup
+    }
+
+
 def _scan_sqs_queues_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for SQS queues."""
-    queues_data = []
+    """
+    Collect SQS queue information from a single AWS region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    region-level errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no SQS queues" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/unreadable queues are skipped (logged) rather than
+    aborting the whole region.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        list: List of dictionaries with SQS queue information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
+    """
     if not utils.is_aws_region(region):
-        return queues_data
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-    try:
-        sqs_client = utils.get_boto3_client('sqs', region_name=region)
-        queue_urls = []
-        paginator = sqs_client.get_paginator('list_queues')
-        for page in paginator.paginate():
-            queue_urls.extend(page.get('QueueUrls', []))
+    print(f"\nProcessing region: {region}")
 
-        for queue_url in queue_urls:
-            queue_name = queue_url.split('/')[-1]
-            try:
-                attrs_response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['All'])
-                attributes = attrs_response.get('Attributes', {})
+    sqs_client = utils.get_boto3_client('sqs', region_name=region)
+    queue_urls = []
+    paginator = sqs_client.get_paginator('list_queues')
+    for page in paginator.paginate():
+        queue_urls.extend(page.get('QueueUrls', []))
 
-                queue_arn = attributes.get('QueueArn', 'N/A')
-                is_fifo = queue_name.endswith('.fifo')
-                queue_type = 'FIFO' if is_fifo else 'Standard'
+    region_queues = []
+    queue_count = len(queue_urls)
+    skipped = 0
 
-                created_timestamp = attributes.get('CreatedTimestamp', '')
-                created_date_str = datetime.datetime.fromtimestamp(int(created_timestamp)).strftime('%Y-%m-%d %H:%M:%S') if created_timestamp else 'N/A'
+    for queue_url in queue_urls:
+        queue_name = queue_url.split('/')[-1]
 
-                retention_period = attributes.get('MessageRetentionPeriod', '345600')
-                retention_days = int(retention_period) / 86400
-                redrive_policy = attributes.get('RedrivePolicy', None)
-                kms_master_key_id = attributes.get('KmsMasterKeyId', None)
-                content_dedup = attributes.get('ContentBasedDeduplication', 'false') if is_fifo else 'N/A'
+        try:
+            attrs_response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['All'])
+            attributes = attrs_response.get('Attributes', {})
+            region_queues.append(_build_queue_row(queue_url, attributes, region))
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping SQS queue '{queue_name}' in {region} due to a processing error", e
+            )
+            continue
 
-                queues_data.append({
-                    'Region': region,
-                    'Queue Name': queue_name,
-                    'Queue Type': queue_type,
-                    'Queue URL': queue_url,
-                    'Queue ARN': queue_arn,
-                    'Created Date': created_date_str,
-                    'Messages Available': attributes.get('ApproximateNumberOfMessages', '0'),
-                    'Messages In Flight': attributes.get('ApproximateNumberOfMessagesNotVisible', '0'),
-                    'Messages Delayed': attributes.get('ApproximateNumberOfMessagesDelayed', '0'),
-                    'Retention Period (days)': round(retention_days, 1),
-                    'Visibility Timeout (sec)': attributes.get('VisibilityTimeout', '30'),
-                    'Delay (sec)': attributes.get('DelaySeconds', '0'),
-                    'Max Message Size (bytes)': attributes.get('MaximumMessageSize', '262144'),
-                    'Receive Wait Time (sec)': attributes.get('ReceiveMessageWaitTimeSeconds', '0'),
-                    'Has Dead Letter Queue': 'Yes' if redrive_policy else 'No',
-                    'Encrypted': 'Yes' if kms_master_key_id else 'No',
-                    'Content-Based Deduplication': content_dedup
-                })
-            except Exception as e:
-                utils.log_warning(f"Could not get attributes for queue {queue_name}: {e}")
-    except Exception as e:
-        utils.log_error(f"Error scanning SQS queues in {region}", e)
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {queue_count} SQS queue(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining queues were still collected."
+        )
 
-    return queues_data
+    print(f"  Found {queue_count} SQS queues")
+    return region_queues
 
 
-@utils.aws_error_handler("Collecting SQS queues", default_return=[])
-def collect_sqs_queues(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SQS queue information from AWS regions."""
+def collect_sqs_queues(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect SQS queue information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: ``(queues, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING SQS QUEUES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_sqs_queues_region)
-    all_queues = [q for result in results for q in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_sqs_queues_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_queues = [q for result in region_results for q in result]
     utils.log_success(f"Total SQS queues collected: {len(all_queues)}")
-    return all_queues
+    return all_queues, failed_regions
+
+
+def _build_topic_row(topic_arn: str, attributes: dict, region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single SNS topic.
+
+    Extracted so the per-topic processing can be wrapped in try/except by the
+    caller: a malformed topic entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason.
+
+    Args:
+        topic_arn: The topic's ARN (from list_topics).
+        attributes: The 'Attributes' dict from get_topic_attributes.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled topic row.
+    """
+    topic_name = topic_arn.split(':')[-1]
+    is_fifo = topic_name.endswith('.fifo')
+    kms_master_key_id = attributes.get('KmsMasterKeyId')
+    delivery_policy = attributes.get('DeliveryPolicy')
+
+    return {
+        'Region': region,
+        'Topic Name': topic_name,
+        'Topic Type': 'FIFO' if is_fifo else 'Standard',
+        'Display Name': attributes.get('DisplayName', 'N/A'),
+        'Subscriptions Confirmed': attributes.get('SubscriptionsConfirmed', '0'),
+        'Subscriptions Pending': attributes.get('SubscriptionsPending', '0'),
+        'Subscriptions Deleted': attributes.get('SubscriptionsDeleted', '0'),
+        'Has Delivery Policy': 'Yes' if delivery_policy else 'No',
+        'Encrypted': 'Yes' if kms_master_key_id else 'No',
+        'Content-Based Deduplication': attributes.get('ContentBasedDeduplication', 'false') if is_fifo else 'N/A',
+        'Owner': attributes.get('Owner', 'N/A'),
+        'Topic ARN': topic_arn
+    }
 
 
 def _scan_sns_topics_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for SNS topics."""
-    topics_data = []
+    """
+    Collect SNS topic information from a single AWS region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    region-level errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no SNS topics" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/unreadable topics are skipped (logged) rather than
+    aborting the whole region.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        list: List of dictionaries with SNS topic information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
+    """
     if not utils.is_aws_region(region):
-        return topics_data
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-    try:
-        sns_client = utils.get_boto3_client('sns', region_name=region)
-        paginator = sns_client.get_paginator('list_topics')
+    print(f"\nProcessing region: {region}")
 
-        for page in paginator.paginate():
-            topics = page.get('Topics', [])
-            for topic in topics:
-                topic_arn = topic.get('TopicArn', 'N/A')
-                topic_name = topic_arn.split(':')[-1]
-                try:
-                    attrs_response = sns_client.get_topic_attributes(TopicArn=topic_arn)
-                    attributes = attrs_response.get('Attributes', {})
+    sns_client = utils.get_boto3_client('sns', region_name=region)
+    paginator = sns_client.get_paginator('list_topics')
 
-                    is_fifo = topic_name.endswith('.fifo')
-                    kms_master_key_id = attributes.get('KmsMasterKeyId', None)
-                    delivery_policy = attributes.get('DeliveryPolicy', None)
+    region_topics = []
+    topic_count = 0
+    skipped = 0
 
-                    topics_data.append({
-                        'Region': region,
-                        'Topic Name': topic_name,
-                        'Topic Type': 'FIFO' if is_fifo else 'Standard',
-                        'Display Name': attributes.get('DisplayName', 'N/A'),
-                        'Subscriptions Confirmed': attributes.get('SubscriptionsConfirmed', '0'),
-                        'Subscriptions Pending': attributes.get('SubscriptionsPending', '0'),
-                        'Subscriptions Deleted': attributes.get('SubscriptionsDeleted', '0'),
-                        'Has Delivery Policy': 'Yes' if delivery_policy else 'No',
-                        'Encrypted': 'Yes' if kms_master_key_id else 'No',
-                        'Content-Based Deduplication': attributes.get('ContentBasedDeduplication', 'false') if is_fifo else 'N/A',
-                        'Owner': attributes.get('Owner', 'N/A'),
-                        'Topic ARN': topic_arn
-                    })
-                except Exception as e:
-                    utils.log_warning(f"Could not get attributes for topic {topic_name}: {e}")
-    except Exception as e:
-        utils.log_error(f"Error scanning SNS topics in {region}", e)
+    for page in paginator.paginate():
+        topics = page.get('Topics', [])
+        topic_count += len(topics)
 
-    return topics_data
+        for topic in topics:
+            topic_arn = topic.get('TopicArn', 'N/A')
+            topic_name = topic_arn.split(':')[-1]
+
+            try:
+                attrs_response = sns_client.get_topic_attributes(TopicArn=topic_arn)
+                attributes = attrs_response.get('Attributes', {})
+                region_topics.append(_build_topic_row(topic_arn, attributes, region))
+            except Exception as e:
+                skipped += 1
+                utils.log_error(
+                    f"Skipping SNS topic '{topic_name}' in {region} due to a processing error", e
+                )
+                continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {topic_count} SNS topic(s) in {region} were skipped due to "
+            "processing errors (see log above); the remaining topics were still collected."
+        )
+
+    print(f"  Found {topic_count} SNS topics")
+    return region_topics
 
 
-@utils.aws_error_handler("Collecting SNS topics", default_return=[])
-def collect_sns_topics(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SNS topic information from AWS regions."""
+def collect_sns_topics(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect SNS topic information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: ``(topics, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING SNS TOPICS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_sns_topics_region)
-    all_topics = [t for result in results for t in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_sns_topics_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_topics = [t for result in region_results for t in result]
     utils.log_success(f"Total SNS topics collected: {len(all_topics)}")
-    return all_topics
+    return all_topics, failed_regions
 
 
 def _scan_sns_subscriptions_region(region: str) -> list[dict[str, Any]]:
@@ -229,17 +380,24 @@ def export_sqs_sns_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect SQS queues
-    queues = collect_sqs_queues(regions)
+    # STEP 1: Collect SQS queues (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    queues, failed_regions_sqs = collect_sqs_queues(regions)
     if queues:
         data_frames['SQS Queues'] = pd.DataFrame(queues)
 
-    # STEP 2: Collect SNS topics
-    topics = collect_sns_topics(regions)
+    # STEP 2: Collect SNS topics (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    topics, failed_regions_sns = collect_sns_topics(regions)
     if topics:
         data_frames['SNS Topics'] = pd.DataFrame(topics)
 
-    # STEP 3: Collect SNS subscriptions
+    # Both scopes are primary: merge their failed regions into ONE combined
+    # list that drives a single marker + non-zero exit below.
+    failed_regions = failed_regions_sqs + failed_regions_sns
+
+    # STEP 3: Collect SNS subscriptions (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     subscriptions = collect_sns_subscriptions(regions)
     if subscriptions:
         data_frames['SNS Subscriptions'] = pd.DataFrame(subscriptions)
@@ -253,22 +411,22 @@ def export_sqs_sns_data(account_id: str, account_name: str):
         total_subscriptions = len(subscriptions)
 
         # Queue types
-        standard_queues = sum(1 for q in queues if q['Queue Type'] == 'Standard')
-        fifo_queues = sum(1 for q in queues if q['Queue Type'] == 'FIFO')
+        standard_queues = sum(1 for q in queues if q.get('Queue Type') == 'Standard')
+        fifo_queues = sum(1 for q in queues if q.get('Queue Type') == 'FIFO')
 
         # Encrypted queues
-        encrypted_queues = sum(1 for q in queues if q['Encrypted'] == 'Yes')
+        encrypted_queues = sum(1 for q in queues if q.get('Encrypted') == 'Yes')
 
         # Topic types
-        standard_topics = sum(1 for t in topics if t['Topic Type'] == 'Standard')
-        fifo_topics = sum(1 for t in topics if t['Topic Type'] == 'FIFO')
+        standard_topics = sum(1 for t in topics if t.get('Topic Type') == 'Standard')
+        fifo_topics = sum(1 for t in topics if t.get('Topic Type') == 'FIFO')
 
         # Encrypted topics
-        encrypted_topics = sum(1 for t in topics if t['Encrypted'] == 'Yes')
+        encrypted_topics = sum(1 for t in topics if t.get('Encrypted') == 'Yes')
 
         # Subscription status
-        confirmed_subs = sum(1 for s in subscriptions if s['Status'] == 'Confirmed')
-        pending_subs = sum(1 for s in subscriptions if s['Status'] == 'Pending')
+        confirmed_subs = sum(1 for s in subscriptions if s.get('Status') == 'Confirmed')
+        pending_subs = sum(1 for s in subscriptions if s.get('Status') == 'Pending')
 
         summary_data.append({'Metric': 'Total SQS Queues', 'Value': total_queues})
         summary_data.append({'Metric': 'Standard Queues', 'Value': standard_queues})
@@ -284,43 +442,56 @@ def export_sqs_sns_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see .collab/audit/07.16.2026-...).
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'sqs-sns',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("SQS/SNS data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No SQS/SNS data was collected. Nothing to export.")
         print("\nNo SQS/SNS resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'sqs-sns',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("SQS/SNS data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed either primary scope collection (SQS queues or SNS
+    # topics), make it loud: write a marker and exit non-zero, even if some
+    # data was exported. A partial export that looks complete is exactly the
+    # failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'sqs-sns', failed_regions)
+        print(
+            "\nERROR: SQS/SNS export completed with failures — data is incomplete. "
+            "See the *-sqs-sns-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/transfer_family_export.py
+++ b/scripts/transfer_family_export.py
@@ -69,94 +69,167 @@ def format_json_field(field_value: Any, max_length: int = 200) -> str:
     return str(field_value)
 
 
-@utils.aws_error_handler("Collecting Transfer Family servers", default_return=[])
-def collect_transfer_servers(region: str) -> list[dict[str, Any]]:
+def _build_server_row(item: dict, region: str) -> dict[str, Any]:
     """
-    Collect Transfer Family server information from a specific region.
+    Build a single Transfer Family server export row.
+
+    ``item`` is the ``describe_server`` response's ``Server`` dict, augmented
+    with ``ServerId`` and ``UserCount`` by the caller. Every field is read
+    with ``.get()`` and a safe default so a malformed/divergent server
+    variant is skipped by the caller's try/except rather than raising here
+    with a hard subscript (the RDS-Custom KeyError pattern — see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    """
+    server_id = item.get('ServerId', '')
+
+    return {
+        'Server ID': server_id,
+        'Region': region,
+        'ARN': item.get('Arn', 'N/A'),
+        'State': item.get('State', 'N/A'),
+        'Protocols': format_protocols(item.get('Protocols', [])),
+        'Endpoint Type': item.get('EndpointType', 'N/A'),
+        'Identity Provider Type': item.get('IdentityProviderType', 'N/A'),
+        'Domain': item.get('Domain', 'N/A'),
+        'Logging Role ARN': item.get('LoggingRole', 'None'),
+        'Security Policy': item.get('SecurityPolicyName', 'N/A'),
+        'Custom Hostname': item.get('HostKeyFingerprint', 'None'),
+        'Certificate ARN': item.get('Certificate', 'None'),
+        'VPC Endpoint ID': item.get('EndpointDetails', {}).get('VpcEndpointId', 'None'),
+        'VPC ID': item.get('EndpointDetails', {}).get('VpcId', 'None'),
+        'Subnet IDs': format_list_field(item.get('EndpointDetails', {}).get('SubnetIds', [])),
+        'Security Group IDs': format_list_field(item.get('EndpointDetails', {}).get('SecurityGroupIds', [])),
+        'Address Allocation IDs': format_list_field(item.get('EndpointDetails', {}).get('AddressAllocationIds', [])),
+        'Availability Zone': item.get('EndpointDetails', {}).get('AvailabilityZone', 'N/A'),
+        'User Count': item.get('UserCount', 0),
+        'Workflow Details': format_json_field(item.get('WorkflowDetails', {})),
+        'Structured Availability Zone': item.get('StructuredLogDestinations', 'None'),
+        'Tags': format_list_field([f"{tag.get('Key', '')}={tag.get('Value', '')}" for tag in item.get('Tags', [])])
+    }
+
+
+def _scan_transfer_servers_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Transfer Family server information from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Transfer Family servers" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed servers are skipped (logged) rather than aborting
+    the whole region.
 
     Args:
         region: AWS region name
 
     Returns:
         List of dictionaries containing server information
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Collecting Transfer Family servers in {region}...")
 
     transfer_client = utils.get_boto3_client('transfer', region_name=region)
     servers_data = []
 
-    try:
-        # List all servers in the region
-        paginator = transfer_client.get_paginator('list_servers')
-        server_ids = []
+    # List all servers in the region
+    paginator = transfer_client.get_paginator('list_servers')
+    server_ids = []
 
-        for page in paginator.paginate():
-            for server in page.get('Servers', []):
-                server_ids.append(server['ServerId'])
+    for page in paginator.paginate():
+        for server in page.get('Servers', []):
+            sid = server.get('ServerId')
+            if sid:
+                server_ids.append(sid)
 
-        if not server_ids:
-            utils.log_info(f"No Transfer Family servers found in {region}")
-            return []
+    if not server_ids:
+        utils.log_info(f"No Transfer Family servers found in {region}")
+        return []
 
-        utils.log_info(f"Found {len(server_ids)} Transfer Family servers in {region}")
+    utils.log_info(f"Found {len(server_ids)} Transfer Family servers in {region}")
 
-        # Get detailed information for each server
-        for idx, server_id in enumerate(server_ids, 1):
-            progress = (idx / len(server_ids)) * 100
-            utils.log_info(f"[{progress:.1f}%] Processing server {idx}/{len(server_ids)}: {server_id}")
+    # Get detailed information for each server. One malformed server must not
+    # sink the region, so each is built inside try/except; failures are
+    # logged and skipped.
+    skipped = 0
+    for idx, server_id in enumerate(server_ids, 1):
+        progress = (idx / len(server_ids)) * 100
+        utils.log_info(f"[{progress:.1f}%] Processing server {idx}/{len(server_ids)}: {server_id}")
 
+        try:
+            # Get server details
+            response = transfer_client.describe_server(ServerId=server_id)
+            server = dict(response.get('Server', {}))
+            server['ServerId'] = server_id
+
+            # Count users for this server (graceful enrichment — does not
+            # fail the row if it errors)
+            user_count = 0
             try:
-                # Get server details
-                response = transfer_client.describe_server(ServerId=server_id)
-                server = response['Server']
-
-                # Count users for this server
-                user_count = 0
-                try:
-                    user_paginator = transfer_client.get_paginator('list_users')
-                    for user_page in user_paginator.paginate(ServerId=server_id):
-                        user_count += len(user_page.get('Users', []))
-                except Exception as e:
-                    utils.log_warning(f"Could not count users for server {server_id}: {e}")
-
-                # Extract server information
-                server_info = {
-                    'Server ID': server_id,
-                    'Region': region,
-                    'ARN': server.get('Arn', 'N/A'),
-                    'State': server.get('State', 'N/A'),
-                    'Protocols': format_protocols(server.get('Protocols', [])),
-                    'Endpoint Type': server.get('EndpointType', 'N/A'),
-                    'Identity Provider Type': server.get('IdentityProviderType', 'N/A'),
-                    'Domain': server.get('Domain', 'N/A'),
-                    'Logging Role ARN': server.get('LoggingRole', 'None'),
-                    'Security Policy': server.get('SecurityPolicyName', 'N/A'),
-                    'Custom Hostname': server.get('HostKeyFingerprint', 'None'),
-                    'Certificate ARN': server.get('Certificate', 'None'),
-                    'VPC Endpoint ID': server.get('EndpointDetails', {}).get('VpcEndpointId', 'None'),
-                    'VPC ID': server.get('EndpointDetails', {}).get('VpcId', 'None'),
-                    'Subnet IDs': format_list_field(server.get('EndpointDetails', {}).get('SubnetIds', [])),
-                    'Security Group IDs': format_list_field(server.get('EndpointDetails', {}).get('SecurityGroupIds', [])),
-                    'Address Allocation IDs': format_list_field(server.get('EndpointDetails', {}).get('AddressAllocationIds', [])),
-                    'Availability Zone': server.get('EndpointDetails', {}).get('AvailabilityZone', 'N/A'),
-                    'User Count': user_count,
-                    'Workflow Details': format_json_field(server.get('WorkflowDetails', {})),
-                    'Structured Availability Zone': server.get('StructuredLogDestinations', 'None'),
-                    'Tags': format_list_field([f"{tag['Key']}={tag['Value']}" for tag in server.get('Tags', [])])
-                }
-
-                servers_data.append(server_info)
-
+                user_paginator = transfer_client.get_paginator('list_users')
+                for user_page in user_paginator.paginate(ServerId=server_id):
+                    user_count += len(user_page.get('Users', []))
             except Exception as e:
-                utils.log_error(f"Error collecting details for server {server_id} in {region}: {e}")
-                continue
+                utils.log_warning(f"Could not count users for server {server_id}: {e}")
+            server['UserCount'] = user_count
 
-        utils.log_success(f"Collected {len(servers_data)} servers from {region}")
+            servers_data.append(_build_server_row(server, region))
 
-    except Exception as e:
-        utils.log_error(f"Error listing servers in {region}: {e}")
+        except Exception as e:
+            skipped += 1
+            utils.log_error(
+                f"Skipping malformed Transfer Family server '{server_id}' in {region} due to a "
+                "processing error", e,
+            )
+            continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(server_ids)} Transfer Family server(s) in {region} were skipped due "
+            "to processing errors (see log above); the remaining servers were still collected."
+        )
+
+    utils.log_success(f"Collected {len(servers_data)} servers from {region}")
 
     return servers_data
+
+
+def collect_transfer_servers_all_regions(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Transfer Family server information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: ``(servers, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    print("\n=== COLLECTING TRANSFER FAMILY SERVERS ===")
+
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_transfer_servers_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_servers = [server for result in region_results for server in result]
+
+    utils.log_success(f"Total Transfer Family servers collected: {len(all_servers)}")
+    return all_servers, failed_regions
 
 
 @utils.aws_error_handler("Collecting Transfer Family users", default_return=[])
@@ -755,8 +828,19 @@ def main():
         # Prompt for region selection
         # Detect partition for region examples
         regions = utils.prompt_region_selection()
-        # Collect data from all regions
-        all_servers = []
+
+        # STEP 1: Collect servers (primary scope — region failures must
+        # propagate as failed_regions, never collapse into "empty"). See
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md.
+        all_servers, failed_regions = collect_transfer_servers_all_regions(regions)
+
+        # Group server IDs by region for the per-region enrichment steps
+        # below (users, agreements). Built from our own row dicts, so
+        # ``.get()`` is used defensively rather than a hard subscript.
+        servers_by_region: dict[str, list[str]] = {}
+        for s in all_servers:
+            servers_by_region.setdefault(s.get('Region', ''), []).append(s.get('Server ID', ''))
+
         all_users = []
         all_connectors = []
         all_workflows = []
@@ -767,14 +851,10 @@ def main():
             utils.log_info(f"\nProcessing region: {region}")
             utils.log_info("=" * 60)
 
-            # Collect servers
-            servers = collect_transfer_servers(region)
-            all_servers.extend(servers)
+            server_ids = [sid for sid in servers_by_region.get(region, []) if sid]
 
-            # Extract server IDs for user and agreement collection
-            server_ids = [s['Server ID'] for s in servers]
-
-            # Collect users for each server
+            # Collect users for each server (enrichment — degrades
+            # gracefully; a failure here does not fail the whole export)
             if server_ids:
                 users = collect_transfer_users(region, server_ids)
                 all_users.extend(users)
@@ -808,33 +888,49 @@ def main():
         utils.log_info(f"Total certificates collected: {len(all_certificates)}")
         utils.log_info(f"Total agreements collected: {len(all_agreements)}")
 
-        if not any([all_servers, all_users, all_connectors, all_workflows, all_certificates, all_agreements]):
-            utils.log_warning("No Transfer Family resources found in selected regions.")
-            return
-
-        # Export to Excel
-        print("\n====================================================================")
-        utils.log_info("Exporting data to Excel...")
-        print("====================================================================\n")
-
-        filename = export_to_excel(
-            all_servers,
-            all_users,
-            all_connectors,
-            all_workflows,
-            all_certificates,
-            all_agreements,
-            account_name
-        )
-
-        if filename:
+        # Export whatever succeeded first — a partial export is required even
+        # when some regions failed (see the silent-collection-failure
+        # blast-radius audit).
+        if any([all_servers, all_users, all_connectors, all_workflows, all_certificates, all_agreements]):
+            # Export to Excel
             print("\n====================================================================")
-            print("EXPORT COMPLETE")
-            print("====================================================================")
-            utils.log_success("Transfer Family export completed successfully!")
-            utils.log_info(f"Output file: {filename}")
-        else:
-            utils.log_error("Export failed. Please check the logs.")
+            utils.log_info("Exporting data to Excel...")
+            print("====================================================================\n")
+
+            filename = export_to_excel(
+                all_servers,
+                all_users,
+                all_connectors,
+                all_workflows,
+                all_certificates,
+                all_agreements,
+                account_name
+            )
+
+            if filename:
+                print("\n====================================================================")
+                print("EXPORT COMPLETE")
+                print("====================================================================")
+                utils.log_success("Transfer Family export completed successfully!")
+                utils.log_info(f"Output file: {filename}")
+            else:
+                utils.log_error("Export failed. Please check the logs.")
+        elif not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
+            utils.log_warning("No Transfer Family resources found in selected regions.")
+            print("\nNo Transfer Family resources found in the selected region(s).")
+
+        # If ANY region failed the Servers scope collection, make it loud:
+        # write a marker and exit non-zero, even if some data was exported. A
+        # partial export that looks complete is exactly the failure mode this
+        # guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'transfer-family', failed_regions)
+            print(
+                "\nERROR: Transfer Family export completed with failures — data is incomplete. "
+                "See the *-transfer-family-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/tests/test_exporters/test_budgets_export.py
+++ b/tests/test_exporters/test_budgets_export.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Tests for budgets_export.py.
+
+Covers:
+- collect_budgets() per-item guarding and account-scope failure propagation
+- export_budgets_data()'s failed-scope tracking, finalize, and exit-code behavior
+
+Budgets is a global/account-scope service (not multi-region), so
+collect_budgets() is the account-scope PRIMARY collector -- mirrors the
+scripts/shield_export.py account-scope pattern (see scripts/lambda_export.py
+for the finalize shape). moto has reasonable AWS Budgets support (create/
+describe budgets), which is used for the per-item guard test; the API-error
+and main()-level tests drive the module through monkeypatched boto3 clients /
+module functions instead, since moto has no way to inject a mid-pagination
+failure.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import boto3
+import botocore.exceptions
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import budgets_export  # noqa: E402
+from budgets_export import collect_budgets  # noqa: E402
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(budgets_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _create_budget(client, name, amount="100"):
+    client.create_budget(
+        AccountId=ACCOUNT_ID,
+        Budget={
+            "BudgetName": name,
+            "BudgetType": "COST",
+            "TimeUnit": "MONTHLY",
+            "BudgetLimit": {"Amount": amount, "Unit": "USD"},
+        },
+    )
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to AWS Budgets: collect_budgets() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error into
+    an empty list, indistinguishable from an account with no budgets
+    configured. export_budgets_data() also used to have no way to signal
+    that failure downstream. These tests cover: (a) a malformed budget is
+    skipped, not fatal; (b) collect_budgets() raises rather than swallowing
+    a real API error; (c) that failure surfaces through export_budgets_data()
+    as a non-zero exit plus a utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    @mock_aws
+    def test_malformed_budget_is_skipped_not_fatal(self, monkeypatch):
+        """One budget that fails to process must not discard the others."""
+        client = boto3.client("budgets", region_name=REGION)
+        _create_budget(client, "good-budget")
+        _create_budget(client, "bad-budget")
+
+        original = budgets_export._build_budget_row
+
+        def raise_for_bad(budget):
+            if budget.get("BudgetName") == "bad-budget":
+                raise KeyError("SomeUnexpectedField")
+            return original(budget)
+
+        monkeypatch.setattr(budgets_export, "_build_budget_row", raise_for_bad)
+
+        result = collect_budgets(ACCOUNT_ID)
+
+        names = {row["Budget Name"] for row in result}
+        assert "good-budget" in names, "healthy budget was lost when a sibling failed"
+        assert "bad-budget" not in names, "malformed budget should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_budgets_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Budgets API error during collection must propagate, not
+        collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "DescribeBudgets",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(budgets_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_budgets(ACCOUNT_ID)
+
+    # -- (c) export_budgets_data(): failure surfaced, non-zero exit ---------
+
+    def test_export_budgets_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A budgets API failure in export_budgets_data() must exit non-zero
+        and call utils.report_collection_failures -- never silently collapse
+        into an empty export."""
+
+        def boom(account_id):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "DescribeBudgets",
+            )
+
+        monkeypatch.setattr(budgets_export, "collect_budgets", boom)
+        monkeypatch.setattr(budgets_export, "collect_budget_notifications", lambda *a, **kw: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(budgets_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            budgets_export.export_budgets_data(ACCOUNT_ID, "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "budgets"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "budgets"
+
+    def test_export_budgets_success_does_not_exit_or_report(self, monkeypatch):
+        """A successful (even genuinely empty) collection must not exit
+        non-zero or write a failure marker."""
+        monkeypatch.setattr(budgets_export, "collect_budgets", lambda account_id: [])
+        monkeypatch.setattr(budgets_export, "collect_budget_notifications", lambda *a, **kw: [])
+
+        report_called = []
+        monkeypatch.setattr(
+            budgets_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # Should return normally (no SystemExit) for a genuinely empty account.
+        budgets_export.export_budgets_data(ACCOUNT_ID, "test-account")
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_codecommit_export.py
+++ b/tests/test_exporters/test_codecommit_export.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Tests for codecommit_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's CodeCommit support implements create_repository/get_repository
+but not list_repositories (``NotImplementedError`` at call time as of
+moto 5.1). Since the primary scope collector (``_scan_repositories_region``)
+fans out via ``list_repositories``, these tests monkeypatch
+``utils.get_boto3_client`` to return a hand-rolled fake CodeCommit client
+instead of relying on ``@mock_aws`` end-to-end.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import codecommit_export  # noqa: E402
+from codecommit_export import _scan_repositories_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakePaginator:
+    """Minimal paginator stub that yields a single page."""
+
+    def __init__(self, page):
+        self._page = page
+
+    def paginate(self, **kwargs):
+        yield self._page
+
+
+class _FakeCodeCommitClient:
+    """
+    Minimal CodeCommit client stub standing in for moto's missing
+    ``list_repositories`` support.
+    """
+
+    def __init__(self, repo_names, get_repository_errors=None):
+        self._repo_names = repo_names
+        self._get_repository_errors = get_repository_errors or {}
+
+    def get_paginator(self, operation_name):
+        if operation_name == "list_repositories":
+            return _FakePaginator(
+                {"repositories": [{"repositoryName": name} for name in self._repo_names]}
+            )
+        raise NotImplementedError(operation_name)
+
+    def get_repository(self, **kwargs):
+        repo_name = kwargs["repositoryName"]
+        if repo_name in self._get_repository_errors:
+            raise self._get_repository_errors[repo_name]
+        return {
+            "repositoryMetadata": {
+                "repositoryName": repo_name,
+                "repositoryId": f"{repo_name}-id",
+            }
+        }
+
+
+class TestScanRepositoriesRegion:
+    """Happy-path collection."""
+
+    def test_collects_repositories(self, monkeypatch):
+        fake_client = _FakeCodeCommitClient(["web-repo"])
+        monkeypatch.setattr(
+            codecommit_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_repositories_region(REGION)
+
+        names = {row["Repository Name"] for row in rows}
+        assert "web-repo" in names
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _FakeCodeCommitClient([])
+        monkeypatch.setattr(
+            codecommit_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_repositories_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One repository that fails to process must not discard the whole region."""
+        fake_client = _FakeCodeCommitClient(
+            ["good-repo", "bad-repo"],
+            get_repository_errors={
+                "bad-repo": botocore.exceptions.ClientError(
+                    {
+                        "Error": {
+                            "Code": "RepositoryDoesNotExistException",
+                            "Message": "gone",
+                        }
+                    },
+                    "GetRepository",
+                )
+            },
+        )
+        monkeypatch.setattr(
+            codecommit_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_repositories_region(REGION)
+
+        names = {row["Repository Name"] for row in rows}
+        assert "good-repo" in names, "healthy repository was lost when a sibling failed"
+        assert "bad-repo" not in names, "malformed repository should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListRepositories",
+            )
+
+        monkeypatch.setattr(codecommit_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_repositories_region(REGION)
+
+    def test_collect_repositories_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListRepositories",
+            )
+
+        monkeypatch.setattr(codecommit_export, "_scan_repositories_region", boom)
+
+        repositories, failed_regions = codecommit_export.collect_repositories([REGION])
+
+        assert repositories == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_codedeploy_export.py
+++ b/tests/test_exporters/test_codedeploy_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for codedeploy_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2e). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import codedeploy_export  # noqa: E402
+from codedeploy_export import _scan_applications_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_application(client, name):
+    """Create a CodeDeploy application named ``name``."""
+    client.create_application(applicationName=name, computePlatform="Server")
+
+
+class TestScanApplicationsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_applications(self):
+        client = boto3.client("codedeploy", region_name=REGION)
+        _create_application(client, "web-app")
+
+        rows = _scan_applications_region(REGION)
+
+        names = {row["Application Name"] for row in rows}
+        assert "web-app" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("codedeploy", region_name=REGION)  # region exists, no apps
+
+        rows = _scan_applications_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One application that fails to process must not discard the whole region."""
+        client = boto3.client("codedeploy", region_name=REGION)
+        _create_application(client, "good-app")
+        _create_application(client, "bad-app")
+
+        original = codedeploy_export._build_application_row
+
+        def raise_for_bad(app, region):
+            if app.get("applicationName") == "bad-app":
+                raise KeyError("SomeUnexpectedField")
+            return original(app, region)
+
+        monkeypatch.setattr(codedeploy_export, "_build_application_row", raise_for_bad)
+
+        rows = _scan_applications_region(REGION)
+
+        names = {row["Application Name"] for row in rows}
+        assert "good-app" in names, "healthy application was lost when a sibling failed"
+        assert "bad-app" not in names, "malformed application should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListApplications",
+            )
+
+        monkeypatch.setattr(codedeploy_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_applications_region(REGION)
+
+    @mock_aws
+    def test_collect_applications_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListApplications",
+            )
+
+        monkeypatch.setattr(codedeploy_export, "_scan_applications_region", boom)
+
+        applications, failed_regions = codedeploy_export.collect_applications([REGION])
+
+        assert applications == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_eventbridge_export.py
+++ b/tests/test_exporters/test_eventbridge_export.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for eventbridge_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import eventbridge_export  # noqa: E402
+from eventbridge_export import _scan_event_buses_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_event_bus(client, name):
+    """Create a custom event bus named ``name``."""
+    client.create_event_bus(Name=name)
+
+
+class TestScanEventBusesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_event_buses(self):
+        client = boto3.client("events", region_name=REGION)
+        _create_event_bus(client, "my-bus")
+
+        rows = _scan_event_buses_region(REGION)
+
+        names = {row["Event Bus Name"] for row in rows}
+        assert "my-bus" in names
+
+    @mock_aws
+    def test_default_bus_only_still_returns_rows(self):
+        boto3.client("events", region_name=REGION)  # region exists, no custom buses
+
+        rows = _scan_event_buses_region(REGION)
+
+        # moto always seeds the "default" event bus.
+        names = {row["Event Bus Name"] for row in rows}
+        assert "default" in names
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One event bus that fails to process must not discard the whole region."""
+        client = boto3.client("events", region_name=REGION)
+        _create_event_bus(client, "good-bus")
+        _create_event_bus(client, "bad-bus")
+
+        original = eventbridge_export._build_event_bus_row
+
+        def raise_for_bad(item, region):
+            if item.get("Name") == "bad-bus":
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(eventbridge_export, "_build_event_bus_row", raise_for_bad)
+
+        rows = _scan_event_buses_region(REGION)
+
+        names = {row["Event Bus Name"] for row in rows}
+        assert "good-bus" in names, "healthy event bus was lost when a sibling failed"
+        assert "bad-bus" not in names, "malformed event bus should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListEventBuses",
+            )
+
+        monkeypatch.setattr(eventbridge_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_event_buses_region(REGION)
+
+    @mock_aws
+    def test_collect_event_buses_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListEventBuses",
+            )
+
+        monkeypatch.setattr(eventbridge_export, "_scan_event_buses_region", boom)
+
+        buses, failed_regions = eventbridge_export.collect_event_buses([REGION])
+
+        assert buses == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_organizations_export.py
+++ b/tests/test_exporters/test_organizations_export.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""
+Tests for organizations_export.py.
+
+Covers:
+- get_organization_info() as a graceful availability probe
+- collect_organizational_units() / collect_accounts() / collect_policies()
+  per-item guarding and account-scope failure propagation
+- main()'s failed-scope tracking, finalize, and exit-code behavior
+
+AWS Organizations is a global, account-scope service run from the
+management account (no region scan) -- collect_organizational_units(),
+collect_accounts(), and collect_policies() are the PRIMARY account-scope
+collectors -- mirrors the scripts/shield_export.py account-scope pattern
+(see scripts/lambda_export.py for the finalize shape). moto's Organizations
+support is partial (create_organization exists but does not model
+policies/targets/tags realistically for this script's flows), so these
+tests drive the module through monkeypatched boto3 clients / module
+functions rather than real moto-backed Organizations state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import organizations_export  # noqa: E402
+from organizations_export import (  # noqa: E402
+    collect_accounts,
+    collect_organizational_units,
+    collect_policies,
+    get_organization_info,
+)
+
+REGION = "us-east-1"
+
+POLICY_TYPES = [
+    "SERVICE_CONTROL_POLICY",
+    "TAG_POLICY",
+    "BACKUP_POLICY",
+    "AISERVICES_OPT_OUT_POLICY",
+]
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(organizations_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_org_client(roots=None, ou_pages=None, account_pages=None, policy_pages_by_type=None):
+    """Build a MagicMock standing in for a boto3 Organizations client."""
+    client = MagicMock()
+
+    root_entries = (
+        roots
+        if roots is not None
+        else [
+            {
+                "Id": "r-root",
+                "Name": "Root",
+                "Arn": "arn:aws:organizations::123456789012:root/o-abc/r-root",
+                "PolicyTypes": [],
+            }
+        ]
+    )
+    client.list_roots.return_value = {"Roots": root_entries}
+    root_id = root_entries[0]["Id"] if root_entries else None
+
+    # Only the top-level (root) call returns the configured OU page(s) --
+    # every recursive call for a child OU's own children returns empty, so
+    # a fixture OU never appears as a child of itself (infinite recursion).
+    ou_paginator = MagicMock()
+
+    def paginate_ous(ParentId=None, **kwargs):  # noqa: N803
+        if ou_pages is not None and ParentId == root_id:
+            return ou_pages
+        return [{"OrganizationalUnits": []}]
+
+    ou_paginator.paginate.side_effect = paginate_ous
+
+    accounts_paginator = MagicMock()
+    accounts_paginator.paginate.return_value = (
+        account_pages if account_pages is not None else [{"Accounts": []}]
+    )
+
+    pages_by_type = policy_pages_by_type or {}
+
+    policies_paginator = MagicMock()
+
+    def paginate_policies(Filter=None, **kwargs):  # noqa: N803
+        return pages_by_type.get(Filter, [{"Policies": []}])
+
+    policies_paginator.paginate.side_effect = paginate_policies
+
+    targets_paginator = MagicMock()
+    targets_paginator.paginate.return_value = [{"Targets": []}]
+
+    paginators = {
+        "list_organizational_units_for_parent": ou_paginator,
+        "list_accounts": accounts_paginator,
+        "list_policies": policies_paginator,
+        "list_targets_for_policy": targets_paginator,
+    }
+
+    client.get_paginator.side_effect = lambda op_name: paginators.get(op_name, MagicMock())
+
+    # Sensible defaults for per-field enrichment helpers (get_account_parent,
+    # get_account_tags, _build_ou_row's parent-name lookup, _build_policy_row).
+    client.list_parents.return_value = {"Parents": []}
+    client.list_tags_for_resource.return_value = {"Tags": []}
+    client.describe_organizational_unit.return_value = {"OrganizationalUnit": {"Name": "Unknown"}}
+    client.describe_policy.return_value = {
+        "Policy": {
+            "PolicySummary": {"Description": "N/A", "AwsManaged": False, "Arn": "arn:policy"},
+            "Content": "{}",
+        }
+    }
+
+    return client
+
+
+class TestGetOrganizationInfo:
+    """
+    get_organization_info() is a graceful availability probe:
+    AWSOrganizationsNotInUseException / AccessDeniedException are
+    legitimate, expected states and return None rather than raising.
+    """
+
+    def test_org_not_in_use_returns_none(self, monkeypatch):
+        client = MagicMock()
+        client.describe_organization.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AWSOrganizationsNotInUseException", "Message": "not in use"}},
+            "DescribeOrganization",
+        )
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert get_organization_info() is None
+
+    def test_active_organization_returns_dict(self, monkeypatch):
+        client = MagicMock()
+        client.describe_organization.return_value = {
+            "Organization": {"Id": "o-abc123", "MasterAccountId": "123456789012"}
+        }
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        result = get_organization_info()
+
+        assert result == {"Id": "o-abc123", "MasterAccountId": "123456789012"}
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Organizations: collect_organizational_units(),
+    collect_accounts(), and collect_policies() -- the PRIMARY, global/
+    account-scope collectors -- used to swallow real API errors into empty
+    lists, indistinguishable from an organization with no OUs/accounts/
+    policies. main() also used to have no way to signal that failure
+    downstream. These tests cover: (a) a malformed account/OU is skipped,
+    not fatal; (b) a primary collector raises rather than swallowing a real
+    API error; (c) that failure surfaces through main() as a non-zero exit
+    plus a utils.report_collection_failures() call; (d) a genuine
+    "Organizations not in use" state is a graceful exit 0 with no failure
+    marker.
+    """
+
+    # -- (a) Per-item guards -------------------------------------------------
+
+    def test_malformed_account_is_skipped_not_fatal(self, monkeypatch):
+        """One account that fails to process must not discard the others."""
+        good = {
+            "Id": "111111111111",
+            "Name": "good-account",
+            "Email": "good@example.com",
+            "Status": "ACTIVE",
+        }
+        bad = {
+            "Id": "222222222222",
+            "Name": "bad-account",
+            "Email": "bad@example.com",
+            "Status": "ACTIVE",
+        }
+
+        client = _fake_org_client(account_pages=[{"Accounts": [good, bad]}])
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = organizations_export._build_account_row
+
+        def raise_for_bad(org_client, account, processed, total):
+            if account.get("Id") == "222222222222":
+                raise KeyError("SomeUnexpectedField")
+            return original(org_client, account, processed, total)
+
+        monkeypatch.setattr(organizations_export, "_build_account_row", raise_for_bad)
+
+        result = collect_accounts()
+
+        ids = {row["Account ID"] for row in result}
+        assert "111111111111" in ids, "healthy account was lost when a sibling failed"
+        assert "222222222222" not in ids, "malformed account should have been skipped"
+
+    def test_malformed_ou_is_skipped_not_fatal(self, monkeypatch):
+        """One OU that fails to process must not discard its siblings."""
+        good_ou = {
+            "Id": "ou-good",
+            "Name": "good-ou",
+            "Arn": "arn:aws:organizations::123456789012:ou/o-abc/ou-good",
+        }
+        bad_ou = {
+            "Id": "ou-bad",
+            "Name": "bad-ou",
+            "Arn": "arn:aws:organizations::123456789012:ou/o-abc/ou-bad",
+        }
+
+        client = _fake_org_client(ou_pages=[{"OrganizationalUnits": [good_ou, bad_ou]}])
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = organizations_export._build_ou_row
+
+        def raise_for_bad(org_client, ou, parent_id, parent_path, level):
+            if ou.get("Id") == "ou-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(org_client, ou, parent_id, parent_path, level)
+
+        monkeypatch.setattr(organizations_export, "_build_ou_row", raise_for_bad)
+
+        result = collect_organizational_units()
+
+        ids = {row["OU ID"] for row in result}
+        assert "ou-good" in ids, "healthy OU was lost when a sibling failed"
+        assert "ou-bad" not in ids, "malformed OU should have been skipped"
+
+    # -- (b) Account-scope failure propagation --------------------------------
+
+    def test_collect_organizational_units_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Organizations API error while listing the root must
+        propagate, not collapse to an empty list."""
+        client = MagicMock()
+        client.list_roots.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+            "ListRoots",
+        )
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_organizational_units()
+
+    def test_collect_accounts_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Organizations API error during list_accounts must
+        propagate, not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListAccounts",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_accounts()
+
+    def test_collect_policies_raises_on_generic_api_error_not_swallowed(self, monkeypatch):
+        """A real (non-PolicyTypeNotEnabledException) Organizations API
+        error during list_policies must propagate, not collapse to an
+        empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListPolicies",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_policies()
+
+    def test_collect_policies_skips_not_enabled_policy_type_gracefully(self, monkeypatch):
+        """PolicyTypeNotEnabledException for a single policy type is a
+        legitimate, expected condition and must not abort collection of the
+        remaining policy types."""
+        scp_policy = {"Id": "p-scp1", "Name": "scp-1"}
+
+        def paginate_policies(Filter=None, **kwargs):  # noqa: N803
+            if Filter == "TAG_POLICY":
+                raise botocore.exceptions.ClientError(
+                    {"Error": {"Code": "PolicyTypeNotEnabledException", "Message": "not enabled"}},
+                    "ListPolicies",
+                )
+            if Filter == "SERVICE_CONTROL_POLICY":
+                return [{"Policies": [scp_policy]}]
+            return [{"Policies": []}]
+
+        client = _fake_org_client()
+        # Override the default dispatcher's policies paginator with one that
+        # also raises for TAG_POLICY.
+        policies_paginator = MagicMock()
+        policies_paginator.paginate.side_effect = paginate_policies
+        original_get_paginator = client.get_paginator.side_effect
+
+        def get_paginator(op_name):
+            if op_name == "list_policies":
+                return policies_paginator
+            return original_get_paginator(op_name)
+
+        client.get_paginator.side_effect = get_paginator
+        monkeypatch.setattr(organizations_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        result = collect_policies()
+
+        ids = {row["Policy ID"] for row in result}
+        assert "p-scp1" in ids, "SCP collection should still succeed despite TAG_POLICY being disabled"
+
+    # -- (c) main(): failure surfaced, non-zero exit ---------------------------
+
+    def test_main_ou_collection_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An organizational-units API failure in main() must exit non-zero
+        and call utils.report_collection_failures -- never silently
+        collapse into an empty export."""
+        monkeypatch.setattr(organizations_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(organizations_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            organizations_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+        monkeypatch.setattr(
+            organizations_export.utils, "get_boto3_client", lambda service, *a, **kw: sts_client
+        )
+
+        monkeypatch.setattr(
+            organizations_export,
+            "get_organization_info",
+            lambda: {"Id": "o-abc123", "MasterAccountId": "123456789012"},
+        )
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListOrganizationalUnitsForParent",
+            )
+
+        monkeypatch.setattr(organizations_export, "collect_organizational_units", boom)
+        monkeypatch.setattr(organizations_export, "collect_accounts", lambda: [])
+        monkeypatch.setattr(organizations_export, "collect_policies", lambda: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(organizations_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            organizations_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "organizations"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "organizational_units"
+
+    # -- (d) Organizations not in use: graceful skip, no marker ---------------
+
+    def test_org_not_in_use_returns_gracefully_no_marker(self, monkeypatch):
+        """AWS Organizations not being in use (or this account not being
+        the management account) is a legitimate, expected state -- exit 0,
+        and utils.report_collection_failures is never called (no
+        *-FAILED-*.txt marker is written)."""
+        monkeypatch.setattr(organizations_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(organizations_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            organizations_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+        monkeypatch.setattr(
+            organizations_export.utils, "get_boto3_client", lambda service, *a, **kw: sts_client
+        )
+
+        monkeypatch.setattr(organizations_export, "get_organization_info", lambda: None)
+
+        report_called = []
+        monkeypatch.setattr(
+            organizations_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        result = organizations_export.main()
+
+        assert result is None
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_savings_plans_export.py
+++ b/tests/test_exporters/test_savings_plans_export.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Tests for savings_plans_export.py.
+
+Covers:
+- _build_savings_plan_row() per-item field extraction (KeyError guarding)
+- collect_savings_plans() per-item guarding and account-scope failure propagation
+- export_savings_plans_data()/main()'s failed-scope tracking, finalize, and
+  exit-code behavior
+
+Savings Plans is a global/account-scope service (not multi-region), so
+collect_savings_plans() is the account-scope PRIMARY collector -- mirrors the
+scripts/shield_export.py account-scope pattern (see scripts/lambda_export.py
+for the finalize shape). moto's Savings Plans support is limited (no
+describe_savings_plans state to seed and no configurable plan data), so these
+tests drive the module through monkeypatched boto3 clients / module
+functions rather than real moto-backed Savings Plans state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import savings_plans_export  # noqa: E402
+from savings_plans_export import collect_savings_plans  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(savings_plans_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_sp_client(plans=None):
+    """Build a MagicMock standing in for a boto3 savingsplans client."""
+    client = MagicMock()
+    client.describe_savings_plans.return_value = {"savingsPlans": plans or []}
+    return client
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Savings Plans: collect_savings_plans() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error into
+    an empty list, indistinguishable from an account with no savings plans
+    purchased. main() also used to have no way to signal that failure
+    downstream. These tests cover: (a) a malformed plan is skipped, not
+    fatal; (b) collect_savings_plans() raises rather than swallowing a real
+    API error; (c) that failure surfaces through main() as a non-zero exit
+    plus a utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    def test_malformed_plan_is_skipped_not_fatal(self, monkeypatch):
+        """One savings plan that fails to process must not discard the others."""
+        good = {
+            "savingsPlanId": "good-id",
+            "savingsPlanArn": "arn:aws:savingsplans::123456789012:savingsplan/good-id",
+            "savingsPlanType": "Compute",
+            "state": "active",
+            "commitment": "10.0",
+        }
+        bad = {
+            "savingsPlanId": "bad-id",
+            "savingsPlanArn": "arn:aws:savingsplans::123456789012:savingsplan/bad-id",
+            "savingsPlanType": "Compute",
+            "state": "active",
+            "commitment": "5.0",
+        }
+
+        client = _fake_sp_client(plans=[good, bad])
+        monkeypatch.setattr(savings_plans_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = savings_plans_export._build_savings_plan_row
+
+        def raise_for_bad(plan):
+            if plan.get("savingsPlanId") == "bad-id":
+                raise KeyError("SomeUnexpectedField")
+            return original(plan)
+
+        monkeypatch.setattr(savings_plans_export, "_build_savings_plan_row", raise_for_bad)
+
+        result = collect_savings_plans(["active"])
+
+        ids = {row["Savings Plan ID"] for row in result}
+        assert "good-id" in ids, "healthy savings plan was lost when a sibling failed"
+        assert "bad-id" not in ids, "malformed savings plan should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_savings_plans_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Savings Plans API error during collection must propagate,
+        not collapse to an empty list."""
+
+        client = MagicMock()
+        client.describe_savings_plans.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+            "DescribeSavingsPlans",
+        )
+        monkeypatch.setattr(savings_plans_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_savings_plans(["active"])
+
+    # -- (c) main(): failure surfaced, non-zero exit ------------------------
+
+    def test_main_savings_plans_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A savings plans API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+        monkeypatch.setattr(savings_plans_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(savings_plans_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            savings_plans_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        def boom(states):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "DescribeSavingsPlans",
+            )
+
+        monkeypatch.setattr(savings_plans_export, "collect_savings_plans", boom)
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(savings_plans_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            savings_plans_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "savings-plans"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "savings_plans"
+
+    def test_main_genuinely_empty_account_exits_cleanly_no_marker(self, monkeypatch):
+        """A genuinely empty account (no plans, no errors) must not write a
+        failure marker or exit non-zero."""
+        monkeypatch.setattr(savings_plans_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(savings_plans_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            savings_plans_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(savings_plans_export, "collect_savings_plans", lambda states: [])
+
+        report_called = []
+        monkeypatch.setattr(
+            savings_plans_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # main() completes without raising SystemExit(non-zero); it simply
+        # returns after logging the empty-account warning.
+        savings_plans_export.main()
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_sqs_sns_export.py
+++ b/tests/test_exporters/test_sqs_sns_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for sqs_sns_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import sqs_sns_export  # noqa: E402
+from sqs_sns_export import _scan_sqs_queues_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_queue(client, name):
+    """Create a standard SQS queue named ``name``."""
+    client.create_queue(QueueName=name)
+
+
+class TestScanSqsQueuesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_queues(self):
+        client = boto3.client("sqs", region_name=REGION)
+        _create_queue(client, "orders-queue")
+
+        rows = _scan_sqs_queues_region(REGION)
+
+        names = {row["Queue Name"] for row in rows}
+        assert "orders-queue" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("sqs", region_name=REGION)  # region exists, no queues
+
+        rows = _scan_sqs_queues_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One queue that fails to process must not discard the whole region."""
+        client = boto3.client("sqs", region_name=REGION)
+        _create_queue(client, "good-queue")
+        _create_queue(client, "bad-queue")
+
+        original = sqs_sns_export._build_queue_row
+
+        def raise_for_bad(queue_url, attributes, region):
+            if queue_url.endswith("bad-queue"):
+                raise KeyError("SomeUnexpectedField")
+            return original(queue_url, attributes, region)
+
+        monkeypatch.setattr(sqs_sns_export, "_build_queue_row", raise_for_bad)
+
+        rows = _scan_sqs_queues_region(REGION)
+
+        names = {row["Queue Name"] for row in rows}
+        assert "good-queue" in names, "healthy queue was lost when a sibling failed"
+        assert "bad-queue" not in names, "malformed queue should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListQueues",
+            )
+
+        monkeypatch.setattr(sqs_sns_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_sqs_queues_region(REGION)
+
+    @mock_aws
+    def test_collect_sqs_queues_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListQueues",
+            )
+
+        monkeypatch.setattr(sqs_sns_export, "_scan_sqs_queues_region", boom)
+
+        queues, failed_regions = sqs_sns_export.collect_sqs_queues([REGION])
+
+        assert queues == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_transfer_family_export.py
+++ b/tests/test_exporters/test_transfer_family_export.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Tests for transfer_family_export.py.
+
+Focus: the silent-collection-failure contract (Tier-2). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's Transfer Family support implements ``create_server`` /
+``describe_server`` but not ``list_servers`` (raises
+``NotImplementedError`` as of moto 5.1.21), so region scanning is
+exercised against a small fake Transfer client (monkeypatched in place of
+``utils.get_boto3_client``) rather than ``@mock_aws`` end-to-end.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import transfer_family_export  # noqa: E402
+from transfer_family_export import _build_server_row, _scan_transfer_servers_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in: ``paginate(**kwargs)`` returns an iterable of pages."""
+
+    def __init__(self, pages_fn):
+        self._pages_fn = pages_fn
+
+    def paginate(self, **kwargs):
+        return self._pages_fn(**kwargs)
+
+
+class _FakeTransferClient:
+    """
+    Fake Transfer Family client covering just the calls
+    ``_scan_transfer_servers_region`` makes: ``list_servers``,
+    ``describe_server``, and ``list_users``.
+    """
+
+    def __init__(self, server_ids, describe_overrides=None, users_by_server=None, list_servers_error=None):
+        self._server_ids = server_ids
+        self._describe_overrides = describe_overrides or {}
+        self._users_by_server = users_by_server or {}
+        self._list_servers_error = list_servers_error
+
+    def get_paginator(self, operation_name):
+        if operation_name == "list_servers":
+            def _pages(**kwargs):
+                if self._list_servers_error:
+                    raise self._list_servers_error
+                yield {"Servers": [{"ServerId": sid} for sid in self._server_ids]}
+
+            return _FakePaginator(_pages)
+
+        if operation_name == "list_users":
+            def _pages(**kwargs):
+                server_id = kwargs.get("ServerId")
+                usernames = self._users_by_server.get(server_id, [])
+                yield {"Users": [{"UserName": u} for u in usernames]}
+
+            return _FakePaginator(_pages)
+
+        raise NotImplementedError(f"get_paginator({operation_name!r}) not stubbed")
+
+    def describe_server(self, **kwargs):
+        server_id = kwargs["ServerId"]
+        override = self._describe_overrides.get(server_id)
+        if isinstance(override, Exception):
+            raise override
+        if override is not None:
+            return {"Server": override}
+        return {
+            "Server": {
+                "ServerId": server_id,
+                "Arn": f"arn:aws:transfer:{REGION}:123456789012:server/{server_id}",
+                "State": "ONLINE",
+                "Protocols": ["SFTP"],
+                "EndpointType": "PUBLIC",
+                "IdentityProviderType": "SERVICE_MANAGED",
+                "Domain": "S3",
+                "Tags": [{"Key": "Name", "Value": server_id}],
+            }
+        }
+
+
+def _install_fake_client(monkeypatch, client):
+    monkeypatch.setattr(
+        transfer_family_export.utils,
+        "get_boto3_client",
+        lambda service, region_name=None: client,
+    )
+
+
+class TestBuildServerRow:
+    """Pure row-building tests — no AWS calls."""
+
+    def test_builds_row_from_minimal_item(self):
+        item = {"ServerId": "s-123", "State": "ONLINE", "UserCount": 2}
+
+        row = _build_server_row(item, REGION)
+
+        assert row["Server ID"] == "s-123"
+        assert row["Region"] == REGION
+        assert row["State"] == "ONLINE"
+        assert row["User Count"] == 2
+
+    def test_missing_fields_default_gracefully(self):
+        """A divergent server variant missing optional fields must not raise."""
+        row = _build_server_row({"ServerId": "s-456"}, REGION)
+
+        assert row["Server ID"] == "s-456"
+        assert row["ARN"] == "N/A"
+        assert row["Tags"] == "None"
+
+    def test_malformed_tags_do_not_raise(self):
+        """Tags missing Key/Value must not raise a KeyError (the RDS pattern)."""
+        item = {"ServerId": "s-789", "Tags": [{"Key": "onlykey"}, {"Value": "onlyvalue"}]}
+
+        row = _build_server_row(item, REGION)
+
+        assert "onlykey=" in row["Tags"]
+        assert "=onlyvalue" in row["Tags"]
+
+
+class TestScanTransferServersRegion:
+    """Happy-path collection against the fake Transfer client."""
+
+    def test_collects_servers(self, monkeypatch):
+        client = _FakeTransferClient(server_ids=["s-1", "s-2"])
+        _install_fake_client(monkeypatch, client)
+
+        rows = _scan_transfer_servers_region(REGION)
+
+        server_ids = {row["Server ID"] for row in rows}
+        assert server_ids == {"s-1", "s-2"}
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _FakeTransferClient(server_ids=[])
+        _install_fake_client(monkeypatch, client)
+
+        rows = _scan_transfer_servers_region(REGION)
+
+        assert rows == []
+
+    def test_invalid_region_is_skipped(self):
+        rows = _scan_transfer_servers_region("not-a-region")
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed into an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One server whose describe_server fails must not discard the whole region."""
+        client = _FakeTransferClient(
+            server_ids=["good-server", "bad-server"],
+            describe_overrides={"bad-server": KeyError("SomeUnexpectedField")},
+        )
+        _install_fake_client(monkeypatch, client)
+
+        rows = _scan_transfer_servers_region(REGION)
+
+        server_ids = {row["Server ID"] for row in rows}
+        assert "good-server" in server_ids, "healthy server was lost when a sibling failed"
+        assert "bad-server" not in server_ids, "malformed server should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure (e.g. list_servers throttled) must
+        propagate so the caller can record a FAILED region, rather than
+        being swallowed into an empty list.
+        """
+        client = _FakeTransferClient(
+            server_ids=[],
+            list_servers_error=botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListServers",
+            ),
+        )
+        _install_fake_client(monkeypatch, client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_transfer_servers_region(REGION)
+
+    def test_collect_transfer_servers_all_regions_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker and
+        exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListServers",
+            )
+
+        monkeypatch.setattr(transfer_family_export, "_scan_transfer_servers_region", boom)
+
+        servers, failed_regions = transfer_family_export.collect_transfer_servers_all_regions([REGION])
+
+        assert servers == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -70,6 +70,9 @@ _EXCLUDED = {
     #   detective:ListGraphs                -> 404 "Not yet implemented"
     #   config:DescribeConformancePacks     -> NotImplementedError (one of its scopes)
     #   globalaccelerator:ListAccelerators  -> 404 "Not yet implemented"
+    #   codecommit:ListRepositories         -> NotImplementedError
+    #   savingsplans:DescribeSavingsPlans   -> 404 "Not yet implemented"
+    #   transfer:ListServers                -> NotImplementedError
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -77,6 +80,9 @@ _EXCLUDED = {
     "detective_export.py",
     "config_export.py",
     "globalaccelerator_export.py",
+    "codecommit_export.py",
+    "savings_plans_export.py",
+    "transfer_family_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **Final Tier-2 phase — Batch E: messaging, cost & governance (8 exporters)** — onto the shared plumbing from #234 (A=#237, B=#238, C=#239, D=#240). **This completes all 36 Tier-2 VULNERABLE exporters.**

## What
| Exporter | Type | Slug |
|---|---|---|
| eventbridge | multi-region | `eventbridge` |
| sqs_sns | multi-region (queues + topics) | `sqs-sns` |
| codecommit | multi-region | `codecommit` |
| codedeploy | multi-region | `codedeploy` |
| transfer_family | multi-region | `transfer-family` |
| budgets | account-scope | `budgets` |
| savings_plans | account-scope | `savings-plans` |
| organizations | account-scope (OUs + accounts + policies) | `organizations` |

Primary scope collectors RAISE on error → surfaced failures → per-item `_build_*_row` guard → partial export → `report_collection_failures` + `sys.exit(1)`. Account-scope services use the shield-style `failed_scopes` pattern. Hard subscripts guarded (`r['State']`, `q['Queue Type']`, `p['Hourly Commitment']`, `s['Server ID']`, org OU/account/policy fields). **organizations** keeps org-not-in-use → graceful exit 0 (no marker) and the `PolicyTypeNotEnabledException` skip. **sqs_sns** additionally fixes a latent `int(float-string)` crash on `CreatedTimestamp`. Enrichment sheets stay graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite (organizations +8 incl org-not-in-use→exit-0). moto covers eventbridge/sqs_sns/codedeploy/budgets happy paths; the rest use monkeypatch. **Batch-E suites: 47 passed. Full suite: 949 passed, 2 skipped. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusions
`codecommit`, `savings_plans`, `transfer_family` added to `_EXCLUDED` — moto has no backend for their primary APIs (`ListRepositories`/`ListServers` → NotImplementedError; `DescribeSavingsPlans` → 404). Dedicated regression suites cover them; eventbridge/sqs_sns/codedeploy/budgets/organizations pass smoke.

## Tier-2 complete
All 36 VULNERABLE exporters now surface collection failures (marker + non-zero exit) instead of silently losing data. Remaining: **Tier-3 (48 PARTIAL exporters)** — lower severity (a file still lands), tracked in #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)