### PR TITLE
Silent collection failure: Tier-3f (app-service exporters)

### DIFF
--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -45,99 +45,136 @@ except ImportError:
 args = utils.parse_script_args("Export AWS API Gateway REST and HTTP APIs to Excel")
 
 
+def _build_rest_api_row(item: dict, region: str) -> dict[str, Any]:
+    """
+    Build a single REST API export row from a get_rest_apis item.
+
+    Extracted so the per-item processing can be wrapped in try/except by the
+    caller: a malformed API entry is logged and skipped rather than
+    discarding the whole region's results.
+    """
+    api_id = item.get('id', 'N/A')
+    api_name = item.get('name', 'N/A')
+
+    print(f"  Processing REST API: {api_name}")
+
+    # API details
+    api_type = 'REST'
+    description = item.get('description', 'N/A')
+    created_date = item.get('createdDate', '')
+    if created_date:
+        created_date = created_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_date, datetime.datetime) else str(created_date)
+
+    # Endpoint configuration
+    endpoint_config = item.get('endpointConfiguration', {})
+    endpoint_types = endpoint_config.get('types', [])
+    endpoint_types_str = ', '.join(endpoint_types) if endpoint_types else 'EDGE'
+
+    # Policy
+    policy = item.get('policy', 'None')
+
+    # Version
+    version = item.get('version', 'N/A')
+
+    # Tags
+    tags = item.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
+
+    return {
+        'Region': region,
+        'API ID': api_id,
+        'API Name': api_name,
+        'API Type': api_type,
+        'Description': description,
+        'Endpoint Type': endpoint_types_str,
+        'Created Date': created_date if created_date else 'N/A',
+        'Version': version,
+        'Has Policy': 'Yes' if policy != 'None' else 'No',
+        'Tags': tags_str
+    }
+
+
 def scan_rest_apis_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan REST APIs in a single AWS region.
+
+    Not wrapped in a broad try/except: a region-level API/permission failure
+    here must propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no REST
+    APIs" (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed items are skipped (logged) rather than aborting the
+    whole region.
 
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of REST API dictionaries for this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records it
+            as a failed region and surfaces it; it is never masked as empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     region_apis = []
 
-    try:
-        apigw_client = utils.get_boto3_client('apigateway', region_name=region)
+    apigw_client = utils.get_boto3_client('apigateway', region_name=region)
 
-        paginator = apigw_client.get_paginator('get_rest_apis')
-        for page in paginator.paginate():
-            apis = page.get('items', [])
+    paginator = apigw_client.get_paginator('get_rest_apis')
+    for page in paginator.paginate():
+        apis = page.get('items', [])
 
-            for api in apis:
-                api_id = api.get('id', 'N/A')
-                api_name = api.get('name', 'N/A')
-
-                print(f"  Processing REST API: {api_name}")
-
-                # API details
-                api_type = 'REST'
-                description = api.get('description', 'N/A')
-                created_date = api.get('createdDate', '')
-                if created_date:
-                    created_date = created_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_date, datetime.datetime) else str(created_date)
-
-                # Endpoint configuration
-                endpoint_config = api.get('endpointConfiguration', {})
-                endpoint_types = endpoint_config.get('types', [])
-                endpoint_types_str = ', '.join(endpoint_types) if endpoint_types else 'EDGE'
-
-                # Policy
-                policy = api.get('policy', 'None')
-
-                # Version
-                version = api.get('version', 'N/A')
-
-                # Tags
-                tags = api.get('tags', {})
-                tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
-
-                region_apis.append({
-                    'Region': region,
-                    'API ID': api_id,
-                    'API Name': api_name,
-                    'API Type': api_type,
-                    'Description': description,
-                    'Endpoint Type': endpoint_types_str,
-                    'Created Date': created_date if created_date else 'N/A',
-                    'Version': version,
-                    'Has Policy': 'Yes' if policy != 'None' else 'No',
-                    'Tags': tags_str
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting REST APIs in region {region}", e)
+        for api in apis:
+            try:
+                region_apis.append(_build_rest_api_row(api, region))
+            except Exception as e:
+                # One malformed REST API is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed REST API in {region}: "
+                    f"{api.get('id', '<unknown>')}",
+                    e,
+                )
+                continue
 
     utils.log_info(f"Found {len(region_apis)} REST APIs in {region}")
     return region_apis
 
 
-@utils.aws_error_handler("Collecting REST APIs", default_return=[])
-def collect_rest_apis(regions: list[str]) -> list[dict[str, Any]]:
+def collect_rest_apis(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect REST API (v1) information from AWS regions.
+    Collect REST API (v1) information from AWS regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with REST API information
+        tuple: ``(apis, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING REST APIs (v1) ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=scan_rest_apis_in_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+
     # scan_regions_concurrent returns a list-of-lists (one list per region); flatten.
-    all_apis = [
-        api
-        for region_apis in utils.scan_regions_concurrent(
-            regions=regions,
-            scan_function=scan_rest_apis_in_region,
-        )
-        for api in region_apis
-    ]
+    all_apis = [api for region_apis in region_results for api in region_apis]
 
     utils.log_success(f"Total REST APIs collected: {len(all_apis)}")
-    return all_apis
+    return all_apis, failed_regions
 
 
 def scan_http_apis_in_region(region: str) -> list[dict[str, Any]]:
@@ -381,8 +418,9 @@ def export_api_gateway_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect REST APIs
-    rest_apis = collect_rest_apis(regions)
+    # STEP 1: Collect REST APIs (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    rest_apis, failed_regions = collect_rest_apis(regions)
     if rest_apis:
         data_frames['REST APIs'] = pd.DataFrame(rest_apis)
 
@@ -410,43 +448,58 @@ def export_api_gateway_data(account_id: str, account_name: str):
 
         data_frames['Summary'] = pd.DataFrame(summary_data)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded — a partial export is still produced when
+    # some regions failed (see the silent-collection-failure blast-radius
+    # audit). KEEP the existing always-written Summary/file logic: a Summary
+    # sheet lands whenever any of the three collections found data.
+    if data_frames:
+        # STEP 5: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 6: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'api-gateway',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("API Gateway data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No API Gateway data was collected. Nothing to export.")
         print("\nNo API Gateway resources found in the selected region(s).")
-        return
 
-    # STEP 5: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 6: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'api-gateway',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("API Gateway data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the REST APIs scope collection, make it loud: write
+    # a marker and exit non-zero, even if some data (from this scope or the
+    # HTTP APIs/stages enrichment) was exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'api-gateway', failed_regions)
+        print(
+            "\nERROR: API Gateway export completed with failures — data is incomplete. "
+            "See the *-api-gateway-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/apprunner_export.py
+++ b/scripts/apprunner_export.py
@@ -30,148 +30,190 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS App Runner services to Excel")
 
+def _build_service_row(service_summary: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single App Runner service.
+
+    Extracted so the per-service processing can be wrapped in try/except by
+    the caller: a malformed service entry is logged and skipped rather than
+    discarding the whole region's results.
+
+    Args:
+        service_summary: A single ServiceSummaryList entry from list_services.
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled service row.
+
+    Raises:
+        Exception: Any error building this row (caller logs and skips it).
+    """
+    service_arn = service_summary.get('ServiceArn', 'N/A')
+    service_name = service_summary.get('ServiceName', 'N/A')
+    service_id = service_summary.get('ServiceId', 'N/A')
+    service_url = service_summary.get('ServiceUrl', 'N/A')
+    status = service_summary.get('Status', 'N/A')
+
+    apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
+    service_response = apprunner_client.describe_service(ServiceArn=service_arn)
+    service = service_response.get('Service', {})
+
+    # Source configuration
+    source_config = service.get('SourceConfiguration', {})
+
+    # Image repository or code repository
+    image_repo = source_config.get('ImageRepository', {})
+    code_repo = source_config.get('CodeRepository', {})
+
+    if image_repo:
+        source_type = 'Container Image'
+        image_identifier = image_repo.get('ImageIdentifier', 'N/A')
+        image_repo_type = image_repo.get('ImageRepositoryType', 'N/A')
+        source_details = f"{image_repo_type}: {image_identifier}"
+    elif code_repo:
+        source_type = 'Source Code'
+        source_code_version = code_repo.get('SourceCodeVersion', {})
+        branch = source_code_version.get('Value', 'N/A')
+        source_details = f"Branch: {branch}"
+    else:
+        source_type = 'Unknown'
+        source_details = 'N/A'
+
+    # Auto deployment
+    auto_deploy_enabled = source_config.get('AutoDeploymentsEnabled', False)
+
+    # Instance configuration
+    instance_config = service.get('InstanceConfiguration', {})
+    cpu = instance_config.get('Cpu', 'N/A')
+    memory = instance_config.get('Memory', 'N/A')
+    instance_role_arn = instance_config.get('InstanceRoleArn', 'N/A')
+
+    # Extract role name
+    instance_role = 'N/A'
+    if instance_role_arn != 'N/A' and '/' in instance_role_arn:
+        instance_role = instance_role_arn.split('/')[-1]
+
+    # Health check configuration
+    health_check_config = service.get('HealthCheckConfiguration', {})
+    health_check_protocol = health_check_config.get('Protocol', 'N/A')
+    health_check_path = health_check_config.get('Path', 'N/A')
+    health_check_interval = health_check_config.get('Interval', 'N/A')
+    health_check_timeout = health_check_config.get('Timeout', 'N/A')
+
+    # Auto scaling configuration ARN
+    auto_scaling_config_name = service.get('AutoScalingConfigurationSummary', {}).get('AutoScalingConfigurationName', 'N/A')
+
+    # Network configuration
+    network_config = service.get('NetworkConfiguration', {})
+    egress_config = network_config.get('EgressConfiguration', {})
+    egress_type = egress_config.get('EgressType', 'DEFAULT')  # DEFAULT or VPC
+    vpc_connector_arn = egress_config.get('VpcConnectorArn', 'N/A') if egress_type == 'VPC' else 'N/A'
+
+    # Encryption configuration
+    encryption_config = service.get('EncryptionConfiguration', {})
+    kms_key = encryption_config.get('KmsKey', 'AWS Managed')
+
+    # Created and updated timestamps
+    created_at = service.get('CreatedAt')
+    created_at_str = created_at.strftime('%Y-%m-%d %H:%M:%S') if created_at else 'N/A'
+
+    updated_at = service.get('UpdatedAt')
+    updated_at_str = updated_at.strftime('%Y-%m-%d %H:%M:%S') if updated_at else 'N/A'
+
+    return {
+        'Region': region,
+        'Service Name': service_name,
+        'Service ID': service_id,
+        'Status': status,
+        'Service URL': service_url,
+        'Source Type': source_type,
+        'Source Details': source_details,
+        'Auto Deploy': 'Enabled' if auto_deploy_enabled else 'Disabled',
+        'CPU': cpu,
+        'Memory': memory,
+        'Instance Role': instance_role,
+        'Health Check Protocol': health_check_protocol,
+        'Health Check Path': health_check_path,
+        'Health Check Interval (s)': health_check_interval,
+        'Health Check Timeout (s)': health_check_timeout,
+        'Auto Scaling Config': auto_scaling_config_name,
+        'Egress Type': egress_type,
+        'VPC Connector': vpc_connector_arn if egress_type == 'VPC' else 'N/A',
+        'KMS Key': kms_key,
+        'Created': created_at_str,
+        'Updated': updated_at_str,
+        'Service ARN': service_arn,
+    }
+
+
 def _scan_apprunner_services_region(region: str) -> list[dict[str, Any]]:
-    """Scan App Runner services in a single region."""
+    """
+    Scan App Runner services in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    region-level errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no App Runner services" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed services are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_services = []
 
-    try:
-        apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
-        next_token = None
-        while True:
-            params = {}
-            params['MaxResults'] = 50
-            if next_token:
-                params['NextToken'] = next_token
-            page = apprunner_client.list_services(**params)
-            service_summaries = page.get('ServiceSummaryList', [])
+    apprunner_client = utils.get_boto3_client('apprunner', region_name=region)
+    next_token = None
+    while True:
+        params = {}
+        params['MaxResults'] = 50
+        if next_token:
+            params['NextToken'] = next_token
+        page = apprunner_client.list_services(**params)
+        service_summaries = page.get('ServiceSummaryList', [])
 
-            for service_summary in service_summaries:
-                service_arn = service_summary.get('ServiceArn', 'N/A')
-                service_name = service_summary.get('ServiceName', 'N/A')
-                service_id = service_summary.get('ServiceId', 'N/A')
-                service_url = service_summary.get('ServiceUrl', 'N/A')
-                status = service_summary.get('Status', 'N/A')
+        for service_summary in service_summaries:
+            service_name = service_summary.get('ServiceName', 'N/A')
+            try:
+                regional_services.append(_build_service_row(service_summary, region))
+            except Exception as e:
+                # One malformed service is skipped, not fatal to the region.
+                utils.log_warning(f"Could not get details for service {service_name}: {str(e)}")
+                continue
 
-                # Get detailed service information
-                try:
-                    service_response = apprunner_client.describe_service(ServiceArn=service_arn)
-                    service = service_response.get('Service', {})
-
-                    # Source configuration
-                    source_config = service.get('SourceConfiguration', {})
-
-                    # Image repository or code repository
-                    image_repo = source_config.get('ImageRepository', {})
-                    code_repo = source_config.get('CodeRepository', {})
-
-                    if image_repo:
-                        source_type = 'Container Image'
-                        image_identifier = image_repo.get('ImageIdentifier', 'N/A')
-                        image_repo_type = image_repo.get('ImageRepositoryType', 'N/A')
-                        source_details = f"{image_repo_type}: {image_identifier}"
-                    elif code_repo:
-                        source_type = 'Source Code'
-                        source_code_version = code_repo.get('SourceCodeVersion', {})
-                        branch = source_code_version.get('Value', 'N/A')
-                        source_details = f"Branch: {branch}"
-                    else:
-                        source_type = 'Unknown'
-                        source_details = 'N/A'
-
-                    # Auto deployment
-                    auto_deploy_enabled = source_config.get('AutoDeploymentsEnabled', False)
-
-                    # Instance configuration
-                    instance_config = service.get('InstanceConfiguration', {})
-                    cpu = instance_config.get('Cpu', 'N/A')
-                    memory = instance_config.get('Memory', 'N/A')
-                    instance_role_arn = instance_config.get('InstanceRoleArn', 'N/A')
-
-                    # Extract role name
-                    instance_role = 'N/A'
-                    if instance_role_arn != 'N/A' and '/' in instance_role_arn:
-                        instance_role = instance_role_arn.split('/')[-1]
-
-                    # Health check configuration
-                    health_check_config = service.get('HealthCheckConfiguration', {})
-                    health_check_protocol = health_check_config.get('Protocol', 'N/A')
-                    health_check_path = health_check_config.get('Path', 'N/A')
-                    health_check_interval = health_check_config.get('Interval', 'N/A')
-                    health_check_timeout = health_check_config.get('Timeout', 'N/A')
-
-                    # Auto scaling configuration ARN
-                    auto_scaling_config_name = service.get('AutoScalingConfigurationSummary', {}).get('AutoScalingConfigurationName', 'N/A')
-
-                    # Network configuration
-                    network_config = service.get('NetworkConfiguration', {})
-                    egress_config = network_config.get('EgressConfiguration', {})
-                    egress_type = egress_config.get('EgressType', 'DEFAULT')  # DEFAULT or VPC
-                    vpc_connector_arn = egress_config.get('VpcConnectorArn', 'N/A') if egress_type == 'VPC' else 'N/A'
-
-                    # Encryption configuration
-                    encryption_config = service.get('EncryptionConfiguration', {})
-                    kms_key = encryption_config.get('KmsKey', 'AWS Managed')
-
-                    # Created and updated timestamps
-                    created_at = service.get('CreatedAt')
-                    if created_at:
-                        created_at_str = created_at.strftime('%Y-%m-%d %H:%M:%S')
-                    else:
-                        created_at_str = 'N/A'
-
-                    updated_at = service.get('UpdatedAt')
-                    if updated_at:
-                        updated_at_str = updated_at.strftime('%Y-%m-%d %H:%M:%S')
-                    else:
-                        updated_at_str = 'N/A'
-
-                    regional_services.append({
-                        'Region': region,
-                        'Service Name': service_name,
-                        'Service ID': service_id,
-                        'Status': status,
-                        'Service URL': service_url,
-                        'Source Type': source_type,
-                        'Source Details': source_details,
-                        'Auto Deploy': 'Enabled' if auto_deploy_enabled else 'Disabled',
-                        'CPU': cpu,
-                        'Memory': memory,
-                        'Instance Role': instance_role,
-                        'Health Check Protocol': health_check_protocol,
-                        'Health Check Path': health_check_path,
-                        'Health Check Interval (s)': health_check_interval,
-                        'Health Check Timeout (s)': health_check_timeout,
-                        'Auto Scaling Config': auto_scaling_config_name,
-                        'Egress Type': egress_type,
-                        'VPC Connector': vpc_connector_arn if egress_type == 'VPC' else 'N/A',
-                        'KMS Key': kms_key,
-                        'Created': created_at_str,
-                        'Updated': updated_at_str,
-                        'Service ARN': service_arn,
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for service {service_name}: {str(e)}")
-                    continue
-
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-
-    except Exception as e:
-        utils.log_error(f"Error collecting App Runner services in {region}", e)
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
 
     return regional_services
 
 
-@utils.aws_error_handler("Collecting App Runner services", default_return=[])
-def collect_apprunner_services(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect App Runner service information from AWS regions."""
+def collect_apprunner_services(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect App Runner service information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(services, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING APP RUNNER SERVICES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_apprunner_services_region)
-    all_services = [svc for result in results for svc in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions,
+        _scan_apprunner_services_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_services = [svc for result in region_results for svc in result]
     utils.log_success(f"Total App Runner services collected: {len(all_services)}")
-    return all_services
+    return all_services, failed_regions
 
 
 def _scan_auto_scaling_configs_region(region: str) -> list[dict[str, Any]]:
@@ -474,7 +516,10 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect App Runner data and write the Excel export."""
     # Collect data
     print("\n=== Collecting App Runner Data ===")
-    services = collect_apprunner_services(regions)
+    # PRIMARY scope: region failures must propagate as failed_regions, never
+    # collapse into "empty". Auto-scaling configs / VPC connectors / custom
+    # domains below are enrichment and stay graceful.
+    services, failed_regions = collect_apprunner_services(regions)
     auto_scaling_configs = collect_auto_scaling_configs(regions)
     vpc_connectors = collect_vpc_connectors(regions)
     custom_domains = collect_custom_domains(regions, services)
@@ -516,6 +561,19 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the App Runner Services scope collection, make it
+    # loud: write a marker and exit non-zero, even though the forced Summary
+    # sheet means a workbook always lands. A complete-looking file hiding
+    # incomplete data is exactly the failure mode this guards against.
+    # Genuinely-empty accounts (no failed_regions) stay exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'apprunner', failed_regions)
+        print(
+            "\nERROR: App Runner export completed with failures — data is incomplete. "
+            "See the *-apprunner-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/appsync_export.py
+++ b/scripts/appsync_export.py
@@ -31,95 +31,136 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS AppSync GraphQL APIs to Excel")
 
+def _build_graphql_api_row(api: dict, region: str) -> dict[str, Any]:
+    """Build a single AppSync GraphQL API export row from a list_graphql_apis entry."""
+    api_id = api.get('apiId', 'N/A')
+    name = api.get('name', 'N/A')
+    authentication_type = api.get('authenticationType', 'N/A')
+
+    # Endpoint URLs
+    uris = api.get('uris', {})
+    graphql_url = uris.get('GRAPHQL', 'N/A') if uris else 'N/A'
+    realtime_url = uris.get('REALTIME', 'N/A') if uris else 'N/A'
+
+    # ARN
+    arn = api.get('arn', 'N/A')
+
+    # X-Ray tracing
+    xray_enabled = api.get('xrayEnabled', False)
+
+    # WAF Web ACL ARN
+    waf_web_acl_arn = api.get('wafWebAclArn', 'N/A')
+
+    # Additional authentication providers
+    additional_auth_providers = api.get('additionalAuthenticationProviders', [])
+    additional_auth_types = [provider.get('authenticationType', '')
+                            for provider in additional_auth_providers]
+    additional_auth_str = ', '.join(additional_auth_types) if additional_auth_types else 'None'
+
+    # Log config
+    log_config = api.get('logConfig', {})
+    field_log_level = log_config.get('fieldLogLevel', 'NONE') if log_config else 'NONE'
+    cloudwatch_logs_role_arn = log_config.get('cloudWatchLogsRoleArn', 'N/A') if log_config else 'N/A'
+
+    # Extract role name
+    log_role_name = 'N/A'
+    if cloudwatch_logs_role_arn != 'N/A' and '/' in cloudwatch_logs_role_arn:
+        log_role_name = cloudwatch_logs_role_arn.split('/')[-1]
+
+    # User pool config (for Cognito auth)
+    user_pool_config = api.get('userPoolConfig', {})
+    user_pool_id = user_pool_config.get('userPoolId', 'N/A') if user_pool_config else 'N/A'
+
+    # OpenID Connect config
+    openid_connect_config = api.get('openIDConnectConfig', {})
+    oidc_issuer = openid_connect_config.get('issuer', 'N/A') if openid_connect_config else 'N/A'
+
+    # Tags
+    tags = api.get('tags', {})
+    tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
+
+    return {
+        'Region': region,
+        'API Name': name,
+        'API ID': api_id,
+        'Authentication Type': authentication_type,
+        'Additional Auth': additional_auth_str,
+        'GraphQL Endpoint': graphql_url,
+        'Realtime Endpoint': realtime_url,
+        'X-Ray Tracing': 'Enabled' if xray_enabled else 'Disabled',
+        'Logging': field_log_level,
+        'Log Role': log_role_name,
+        'WAF Web ACL': 'Associated' if waf_web_acl_arn != 'N/A' else 'None',
+        'Cognito User Pool': user_pool_id,
+        'OIDC Issuer': oidc_issuer,
+        'Tags': tags_str,
+        'ARN': arn,
+    }
+
+
 def _scan_graphql_apis_region(region: str) -> list[dict[str, Any]]:
-    """Scan AppSync GraphQL APIs in a single region."""
+    """
+    Collect AppSync GraphQL APIs from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no GraphQL APIs" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed APIs are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_apis = []
 
-    try:
-        appsync_client = utils.get_boto3_client('appsync', region_name=region)
-        paginator = appsync_client.get_paginator('list_graphql_apis')
-        for page in paginator.paginate():
-            apis = page.get('graphqlApis', [])
+    appsync_client = utils.get_boto3_client('appsync', region_name=region)
+    paginator = appsync_client.get_paginator('list_graphql_apis')
 
-            for api in apis:
-                api_id = api.get('apiId', 'N/A')
-                name = api.get('name', 'N/A')
-                authentication_type = api.get('authenticationType', 'N/A')
+    for page in paginator.paginate():
+        apis = page.get('graphqlApis', [])
 
-                # Endpoint URLs
-                uris = api.get('uris', {})
-                graphql_url = uris.get('GRAPHQL', 'N/A') if uris else 'N/A'
-                realtime_url = uris.get('REALTIME', 'N/A') if uris else 'N/A'
-
-                # ARN
-                arn = api.get('arn', 'N/A')
-
-                # X-Ray tracing
-                xray_enabled = api.get('xrayEnabled', False)
-
-                # WAF Web ACL ARN
-                waf_web_acl_arn = api.get('wafWebAclArn', 'N/A')
-
-                # Additional authentication providers
-                additional_auth_providers = api.get('additionalAuthenticationProviders', [])
-                additional_auth_types = [provider.get('authenticationType', '')
-                                        for provider in additional_auth_providers]
-                additional_auth_str = ', '.join(additional_auth_types) if additional_auth_types else 'None'
-
-                # Log config
-                log_config = api.get('logConfig', {})
-                field_log_level = log_config.get('fieldLogLevel', 'NONE') if log_config else 'NONE'
-                cloudwatch_logs_role_arn = log_config.get('cloudWatchLogsRoleArn', 'N/A') if log_config else 'N/A'
-
-                # Extract role name
-                log_role_name = 'N/A'
-                if cloudwatch_logs_role_arn != 'N/A' and '/' in cloudwatch_logs_role_arn:
-                    log_role_name = cloudwatch_logs_role_arn.split('/')[-1]
-
-                # User pool config (for Cognito auth)
-                user_pool_config = api.get('userPoolConfig', {})
-                user_pool_id = user_pool_config.get('userPoolId', 'N/A') if user_pool_config else 'N/A'
-
-                # OpenID Connect config
-                openid_connect_config = api.get('openIDConnectConfig', {})
-                oidc_issuer = openid_connect_config.get('issuer', 'N/A') if openid_connect_config else 'N/A'
-
-                # Tags
-                tags = api.get('tags', {})
-                tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()]) if tags else 'None'
-
-                regional_apis.append({
-                    'Region': region,
-                    'API Name': name,
-                    'API ID': api_id,
-                    'Authentication Type': authentication_type,
-                    'Additional Auth': additional_auth_str,
-                    'GraphQL Endpoint': graphql_url,
-                    'Realtime Endpoint': realtime_url,
-                    'X-Ray Tracing': 'Enabled' if xray_enabled else 'Disabled',
-                    'Logging': field_log_level,
-                    'Log Role': log_role_name,
-                    'WAF Web ACL': 'Associated' if waf_web_acl_arn != 'N/A' else 'None',
-                    'Cognito User Pool': user_pool_id,
-                    'OIDC Issuer': oidc_issuer,
-                    'Tags': tags_str,
-                    'ARN': arn,
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting AppSync GraphQL APIs in {region}", e)
+        for api in apis:
+            try:
+                regional_apis.append(_build_graphql_api_row(api, region))
+            except Exception as e:
+                # One malformed API is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed AppSync GraphQL API in {region}: "
+                    f"{api.get('apiId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return regional_apis
 
 
-@utils.aws_error_handler("Collecting AppSync GraphQL APIs", default_return=[])
-def collect_graphql_apis(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect AppSync GraphQL API information from AWS regions."""
+def collect_graphql_apis(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AppSync GraphQL API information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(apis, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING APPSYNC GRAPHQL APIS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_graphql_apis_region)
-    all_apis = [api for result in results for api in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_graphql_apis_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_apis = [api for result in region_results for api in result]
     utils.log_success(f"Total AppSync GraphQL APIs collected: {len(all_apis)}")
-    return all_apis
+    return all_apis, failed_regions
 
 
 @utils.aws_error_handler("Collecting AppSync data sources", default_return=[])
@@ -456,9 +497,10 @@ def generate_summary(apis: list[dict[str, Any]],
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect AppSync data and write the Excel export."""
-    # Collect data
+    # Collect data. GraphQL APIs is the primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty".
     print("\n=== Collecting AppSync Data ===")
-    apis = collect_graphql_apis(regions)
+    apis, failed_regions = collect_graphql_apis(regions)
     data_sources = collect_data_sources(regions, apis)
     resolvers = collect_resolvers(regions, apis)
     api_keys = collect_api_keys(regions, apis)
@@ -500,6 +542,18 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary GraphQL APIs scope collection, make it
+    # loud: write a marker and exit non-zero, even though a workbook (with its
+    # forced Summary sheet) was always written. A workbook that looks complete
+    # is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'appsync', failed_regions)
+        print(
+            "\nERROR: AppSync export completed with failures — data is incomplete. "
+            "See the *-appsync-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/cloudmap_export.py
+++ b/scripts/cloudmap_export.py
@@ -27,74 +27,111 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Cloud Map namespaces and services to Excel")
 
+def _build_namespace_row(namespace_summary: dict, region: str) -> dict[str, Any]:
+    """Build a single Cloud Map namespace export row from a list_namespaces summary."""
+    namespace_id = namespace_summary.get('Id', 'N/A')
+    namespace_name = namespace_summary.get('Name', 'N/A')
+    namespace_type = namespace_summary.get('Type', 'N/A')
+
+    sd_client = utils.get_boto3_client('servicediscovery', region_name=region)
+
+    # Get detailed namespace information
+    namespace_response = sd_client.get_namespace(
+        Id=namespace_id
+    )
+    namespace_details = namespace_response.get('Namespace', {})
+
+    description = namespace_details.get('Description', 'N/A')
+    service_count = namespace_details.get('ServiceCount', 0)
+    arn = namespace_details.get('Arn', 'N/A')
+    create_date = namespace_details.get('CreateDate', 'N/A')
+    if create_date != 'N/A':
+        create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Properties specific to namespace type
+    properties = namespace_details.get('Properties', {})
+    dns_properties = properties.get('DnsProperties', {})
+    http_properties = properties.get('HttpProperties', {})
+
+    hosted_zone_id = dns_properties.get('HostedZoneId', 'N/A')
+    http_name = http_properties.get('HttpName', 'N/A')
+
+    return {
+        'Region': region,
+        'Namespace ID': namespace_id,
+        'Namespace Name': namespace_name,
+        'Type': namespace_type,
+        'Description': description,
+        'Service Count': service_count,
+        'Hosted Zone ID': hosted_zone_id,
+        'HTTP Name': http_name,
+        'Created': create_date,
+        'ARN': arn
+    }
+
+
 def _scan_namespaces_region(region: str) -> list[dict[str, Any]]:
-    """Scan Cloud Map namespaces in a single region."""
+    """
+    Collect Cloud Map namespaces from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no namespaces" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed namespaces are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_namespaces = []
     sd_client = utils.get_boto3_client('servicediscovery', region_name=region)
 
-    try:
-        paginator = sd_client.get_paginator('list_namespaces')
-        for page in paginator.paginate():
-            namespaces = page.get('Namespaces', [])
+    paginator = sd_client.get_paginator('list_namespaces')
+    for page in paginator.paginate():
+        namespaces = page.get('Namespaces', [])
 
-            for namespace_summary in namespaces:
-                namespace_id = namespace_summary.get('Id', 'N/A')
-                namespace_name = namespace_summary.get('Name', 'N/A')
-                namespace_type = namespace_summary.get('Type', 'N/A')
-
-                try:
-                    # Get detailed namespace information
-                    namespace_response = sd_client.get_namespace(
-                        Id=namespace_id
-                    )
-                    namespace_details = namespace_response.get('Namespace', {})
-
-                    description = namespace_details.get('Description', 'N/A')
-                    service_count = namespace_details.get('ServiceCount', 0)
-                    arn = namespace_details.get('Arn', 'N/A')
-                    create_date = namespace_details.get('CreateDate', 'N/A')
-                    if create_date != 'N/A':
-                        create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Properties specific to namespace type
-                    properties = namespace_details.get('Properties', {})
-                    dns_properties = properties.get('DnsProperties', {})
-                    http_properties = properties.get('HttpProperties', {})
-
-                    hosted_zone_id = dns_properties.get('HostedZoneId', 'N/A')
-                    http_name = http_properties.get('HttpName', 'N/A')
-
-                    regional_namespaces.append({
-                        'Region': region,
-                        'Namespace ID': namespace_id,
-                        'Namespace Name': namespace_name,
-                        'Type': namespace_type,
-                        'Description': description,
-                        'Service Count': service_count,
-                        'Hosted Zone ID': hosted_zone_id,
-                        'HTTP Name': http_name,
-                        'Created': create_date,
-                        'ARN': arn
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for namespace {namespace_id} in {region}: {str(e)}")
-                    continue
-
-    except Exception as e:
-        utils.log_warning(f"Error listing namespaces in {region}: {str(e)}")
+        for namespace_summary in namespaces:
+            try:
+                regional_namespaces.append(_build_namespace_row(namespace_summary, region))
+            except Exception as e:
+                # One malformed namespace is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Cloud Map namespace in {region}: "
+                    f"{namespace_summary.get('Id', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return regional_namespaces
 
 
-@utils.aws_error_handler("Collecting Cloud Map namespaces", default_return=[])
-def collect_namespaces(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Cloud Map namespace information from AWS regions."""
+def collect_namespaces(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Cloud Map namespace information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(namespaces, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING CLOUD MAP NAMESPACES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_namespaces_region)
-    all_namespaces = [namespace for result in results for namespace in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_namespaces_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_namespaces = [namespace for result in region_results for namespace in result]
     utils.log_success(f"Total namespaces collected: {len(all_namespaces)}")
-    return all_namespaces
+    return all_namespaces, failed_regions
 
 
 def _scan_services_region(region: str) -> list[dict[str, Any]]:
@@ -317,7 +354,9 @@ def main():
     # Collect data
     print("\nCollecting Cloud Map data...")
 
-    namespaces = collect_namespaces(regions)
+    # Namespaces are the primary scope — region failures must propagate as
+    # failed_regions, never collapse into "empty".
+    namespaces, failed_regions = collect_namespaces(regions)
     services = collect_services(regions)
     instances = collect_service_instances(regions)
     summary = generate_summary(namespaces, services, instances)
@@ -347,7 +386,8 @@ def main():
         df_instances = utils.prepare_dataframe_for_export(df_instances)
         dataframes['Service Instances'] = df_instances
 
-    # Export to Excel
+    # Export to Excel — a forced Summary sheet means a workbook always lands,
+    # even when the underlying data is empty or a region failed.
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'cloudmap', region_suffix)
@@ -360,6 +400,18 @@ def main():
         utils.log_warning("No Cloud Map data found to export")
 
     utils.log_success("Cloud Map export completed successfully")
+
+    # If ANY region failed the namespace scope collection, make it loud: write
+    # a marker and exit non-zero, even though a workbook was still written
+    # (the forced Summary sheet). A complete-looking file that hides a failed
+    # scope is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'cloudmap', failed_regions)
+        print(
+            "\nERROR: Cloud Map export completed with failures — data is incomplete. "
+            "See the *-cloudmap-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/cognito_export.py
+++ b/scripts/cognito_export.py
@@ -27,9 +27,126 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Amazon Cognito user pools and identity pools to Excel")
 
+def _build_user_pool_row(pool: dict, region: str) -> dict[str, Any]:
+    """Build a single Cognito user pool export row from a describe_user_pool response."""
+    # Basic information
+    pool_name = pool.get('Name', 'N/A')
+    pool_id = pool.get('Id', 'N/A')
+    pool_arn = pool.get('Arn', 'N/A')
+    status = pool.get('Status', 'N/A')
+
+    # Creation and modification dates
+    creation_date = pool.get('CreationDate', 'N/A')
+    if creation_date != 'N/A':
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_modified = pool.get('LastModifiedDate', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    # MFA Configuration
+    mfa_config = pool.get('MfaConfiguration', 'OFF')
+
+    # Password policy
+    policies = pool.get('Policies', {})
+    password_policy = policies.get('PasswordPolicy', {})
+    min_length = password_policy.get('MinimumLength', 'N/A')
+    require_uppercase = password_policy.get('RequireUppercase', False)
+    require_lowercase = password_policy.get('RequireLowercase', False)
+    require_numbers = password_policy.get('RequireNumbers', False)
+    require_symbols = password_policy.get('RequireSymbols', False)
+    temp_password_validity = password_policy.get('TemporaryPasswordValidityDays', 'N/A')
+
+    # Auto-verified attributes
+    auto_verified = pool.get('AutoVerifiedAttributes', [])
+    auto_verified_str = ', '.join(auto_verified) if auto_verified else 'None'
+
+    # Username attributes
+    username_attrs = pool.get('UsernameAttributes', [])
+    username_attrs_str = ', '.join(username_attrs) if username_attrs else 'username'
+
+    # Email configuration
+    email_config = pool.get('EmailConfiguration', {})
+    email_source = email_config.get('SourceArn', 'Default')
+    email_sending = email_config.get('EmailSendingAccount', 'COGNITO_DEFAULT')
+
+    # SMS configuration
+    sms_config = pool.get('SmsConfiguration', {})
+    sms_role = sms_config.get('SnsCallerArn', 'N/A')
+
+    # Advanced security
+    user_pool_add_ons = pool.get('UserPoolAddOns', {})
+    advanced_security = user_pool_add_ons.get('AdvancedSecurityMode', 'OFF')
+
+    # Account recovery
+    account_recovery = pool.get('AccountRecoverySetting', {})
+    recovery_mechanisms = account_recovery.get('RecoveryMechanisms', [])
+    recovery_str = ', '.join([m.get('Name', 'N/A') for m in recovery_mechanisms])
+
+    # Device tracking
+    device_config = pool.get('DeviceConfiguration', {})
+    challenge_required = device_config.get('ChallengeRequiredOnNewDevice', False)
+    device_only_remembered = device_config.get('DeviceOnlyRememberedOnUserPrompt', False)
+
+    # User attribute update settings
+    user_attr_update = pool.get('UserAttributeUpdateSettings', {})
+    attrs_require_verification = user_attr_update.get('AttributesRequireVerificationBeforeUpdate', [])
+    attrs_verify_str = ', '.join(attrs_require_verification) if attrs_require_verification else 'None'
+
+    # Lambda triggers
+    lambda_config = pool.get('LambdaConfig', {})
+    triggers = []
+    for trigger_name, trigger_arn in lambda_config.items():
+        if trigger_arn:
+            triggers.append(trigger_name)
+    triggers_str = ', '.join(triggers) if triggers else 'None'
+
+    # Estimated number of users
+    estimated_users = pool.get('EstimatedNumberOfUsers', 0)
+
+    return {
+        'Region': region,
+        'Pool Name': pool_name,
+        'Pool ID': pool_id,
+        'ARN': pool_arn,
+        'Status': status,
+        'Created': creation_date,
+        'Last Modified': last_modified,
+        'Estimated Users': estimated_users,
+        'MFA': mfa_config,
+        'Advanced Security': advanced_security,
+        'Min Password Length': min_length,
+        'Require Uppercase': require_uppercase,
+        'Require Lowercase': require_lowercase,
+        'Require Numbers': require_numbers,
+        'Require Symbols': require_symbols,
+        'Temp Password Validity (Days)': temp_password_validity,
+        'Auto Verified Attributes': auto_verified_str,
+        'Username Attributes': username_attrs_str,
+        'Email Sending Account': email_sending,
+        'Email Source ARN': email_source,
+        'SMS Role ARN': sms_role,
+        'Account Recovery': recovery_str,
+        'Device Challenge Required': challenge_required,
+        'Device Only Remembered on Prompt': device_only_remembered,
+        'Attributes Require Verification': attrs_verify_str,
+        'Lambda Triggers': triggers_str
+    }
+
+
 def scan_user_pools_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan Cognito user pools in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors from ``list_user_pools``: an API/permission failure here must
+    propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no user
+    pools" (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    A single pool that fails to describe/build is skipped (logged) rather
+    than aborting the whole region.
 
     Args:
         region: AWS region to scan
@@ -37,160 +154,63 @@ def scan_user_pools_in_region(region: str) -> list[dict[str, Any]]:
     Returns:
         list: List of dictionaries with user pool information from this region
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_pools = []
     cognito_client = utils.get_boto3_client('cognito-idp', region_name=region)
 
-    try:
-        paginator = cognito_client.get_paginator('list_user_pools')
-        for page in paginator.paginate(MaxResults=60):
-            pools = page.get('UserPools', [])
+    paginator = cognito_client.get_paginator('list_user_pools')
+    for page in paginator.paginate(MaxResults=60):
+        pools = page.get('UserPools', [])
 
-            for pool_summary in pools:
-                pool_id = pool_summary.get('Id', 'N/A')
+        for pool_summary in pools:
+            pool_id = pool_summary.get('Id', 'N/A')
 
-                # Get detailed pool information
-                try:
-                    pool_response = cognito_client.describe_user_pool(UserPoolId=pool_id)
-                    pool = pool_response.get('UserPool', {})
-
-                    # Basic information
-                    pool_name = pool.get('Name', 'N/A')
-                    pool_id = pool.get('Id', 'N/A')
-                    pool_arn = pool.get('Arn', 'N/A')
-                    status = pool.get('Status', 'N/A')
-
-                    # Creation and modification dates
-                    creation_date = pool.get('CreationDate', 'N/A')
-                    if creation_date != 'N/A':
-                        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S')
-
-                    last_modified = pool.get('LastModifiedDate', 'N/A')
-                    if last_modified != 'N/A':
-                        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # MFA Configuration
-                    mfa_config = pool.get('MfaConfiguration', 'OFF')
-
-                    # Password policy
-                    policies = pool.get('Policies', {})
-                    password_policy = policies.get('PasswordPolicy', {})
-                    min_length = password_policy.get('MinimumLength', 'N/A')
-                    require_uppercase = password_policy.get('RequireUppercase', False)
-                    require_lowercase = password_policy.get('RequireLowercase', False)
-                    require_numbers = password_policy.get('RequireNumbers', False)
-                    require_symbols = password_policy.get('RequireSymbols', False)
-                    temp_password_validity = password_policy.get('TemporaryPasswordValidityDays', 'N/A')
-
-                    # Auto-verified attributes
-                    auto_verified = pool.get('AutoVerifiedAttributes', [])
-                    auto_verified_str = ', '.join(auto_verified) if auto_verified else 'None'
-
-                    # Username attributes
-                    username_attrs = pool.get('UsernameAttributes', [])
-                    username_attrs_str = ', '.join(username_attrs) if username_attrs else 'username'
-
-                    # Email configuration
-                    email_config = pool.get('EmailConfiguration', {})
-                    email_source = email_config.get('SourceArn', 'Default')
-                    email_sending = email_config.get('EmailSendingAccount', 'COGNITO_DEFAULT')
-
-                    # SMS configuration
-                    sms_config = pool.get('SmsConfiguration', {})
-                    sms_role = sms_config.get('SnsCallerArn', 'N/A')
-
-                    # Advanced security
-                    user_pool_add_ons = pool.get('UserPoolAddOns', {})
-                    advanced_security = user_pool_add_ons.get('AdvancedSecurityMode', 'OFF')
-
-                    # Account recovery
-                    account_recovery = pool.get('AccountRecoverySetting', {})
-                    recovery_mechanisms = account_recovery.get('RecoveryMechanisms', [])
-                    recovery_str = ', '.join([m.get('Name', 'N/A') for m in recovery_mechanisms])
-
-                    # Device tracking
-                    device_config = pool.get('DeviceConfiguration', {})
-                    challenge_required = device_config.get('ChallengeRequiredOnNewDevice', False)
-                    device_only_remembered = device_config.get('DeviceOnlyRememberedOnUserPrompt', False)
-
-                    # User attribute update settings
-                    user_attr_update = pool.get('UserAttributeUpdateSettings', {})
-                    attrs_require_verification = user_attr_update.get('AttributesRequireVerificationBeforeUpdate', [])
-                    attrs_verify_str = ', '.join(attrs_require_verification) if attrs_require_verification else 'None'
-
-                    # Lambda triggers
-                    lambda_config = pool.get('LambdaConfig', {})
-                    triggers = []
-                    for trigger_name, trigger_arn in lambda_config.items():
-                        if trigger_arn:
-                            triggers.append(trigger_name)
-                    triggers_str = ', '.join(triggers) if triggers else 'None'
-
-                    # Estimated number of users
-                    estimated_users = pool.get('EstimatedNumberOfUsers', 0)
-
-                    regional_pools.append({
-                        'Region': region,
-                        'Pool Name': pool_name,
-                        'Pool ID': pool_id,
-                        'ARN': pool_arn,
-                        'Status': status,
-                        'Created': creation_date,
-                        'Last Modified': last_modified,
-                        'Estimated Users': estimated_users,
-                        'MFA': mfa_config,
-                        'Advanced Security': advanced_security,
-                        'Min Password Length': min_length,
-                        'Require Uppercase': require_uppercase,
-                        'Require Lowercase': require_lowercase,
-                        'Require Numbers': require_numbers,
-                        'Require Symbols': require_symbols,
-                        'Temp Password Validity (Days)': temp_password_validity,
-                        'Auto Verified Attributes': auto_verified_str,
-                        'Username Attributes': username_attrs_str,
-                        'Email Sending Account': email_sending,
-                        'Email Source ARN': email_source,
-                        'SMS Role ARN': sms_role,
-                        'Account Recovery': recovery_str,
-                        'Device Challenge Required': challenge_required,
-                        'Device Only Remembered on Prompt': device_only_remembered,
-                        'Attributes Require Verification': attrs_verify_str,
-                        'Lambda Triggers': triggers_str
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for pool {pool_id} in {region}: {str(e)}")
-                    continue
-
-    except Exception as e:
-        utils.log_warning(f"Error listing user pools in {region}: {str(e)}")
+            # Get detailed pool information; one malformed/undescribable pool
+            # is skipped, not fatal to the region.
+            try:
+                pool_response = cognito_client.describe_user_pool(UserPoolId=pool_id)
+                pool = pool_response.get('UserPool', {})
+                regional_pools.append(_build_user_pool_row(pool, region))
+            except Exception as e:
+                utils.log_warning(f"Could not get details for pool {pool_id} in {region}: {str(e)}")
+                continue
 
     utils.log_info(f"Found {len(regional_pools)} user pools in {region}")
     return regional_pools
 
 
-@utils.aws_error_handler("Collecting Cognito user pools", default_return=[])
-def collect_user_pools(regions: list[str]) -> list[dict[str, Any]]:
+def collect_user_pools(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Cognito user pool information from AWS regions using concurrent scanning.
+    Collect Cognito user pool information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with user pool information
+        tuple: ``(pools, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_user_pools_in_region,
+        show_progress=True,
+        collect_failures=True,
     )
     all_pools = []
     for pools in region_results:
         all_pools.extend(pools)
 
     utils.log_info(f"Collected {len(all_pools)} user pools")
-    return all_pools
+    return all_pools, failed_regions
 
 
 def scan_identity_pools_in_region(region: str) -> list[dict[str, Any]]:
@@ -776,7 +796,10 @@ def main():
     # Collect data
     print("\nCollecting Cognito data...")
 
-    user_pools = collect_user_pools(regions)
+    # Primary scope — region failures must propagate as failed_regions,
+    # never collapse into "empty". Clients/providers/groups below are
+    # enrichment and stay graceful (aws_error_handler default_return=[]).
+    user_pools, failed_regions = collect_user_pools(regions)
     identity_pools = collect_identity_pools(regions)
     clients = collect_user_pool_clients(regions)
     providers = collect_identity_providers(regions)
@@ -829,6 +852,18 @@ def main():
         # Log summary
     else:
         utils.log_warning("No Cognito data found to export")
+
+    # If ANY region failed the user pools scope collection, make it loud:
+    # write a marker and exit non-zero, even though the forced Summary sheet
+    # means a workbook was still written. A complete-looking file that hides
+    # a silent collection failure is exactly the bug this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'cognito', failed_regions)
+        print(
+            "\nERROR: Cognito export completed with failures — data is incomplete. "
+            "See the *-cognito-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Cognito export completed successfully")
 

--- a/scripts/ecs_export.py
+++ b/scripts/ecs_export.py
@@ -143,275 +143,332 @@ def get_load_balancer_name(elbv2_client, load_balancer_arn):
         return response['LoadBalancers'][0].get('LoadBalancerName', 'Unknown')
     return 'Unknown'
 
-@utils.aws_error_handler("Collecting ECS resources from region", default_return=[])
-def get_ecs_resources_from_region(region: str) -> list[dict[str, Any]]:
+def _build_service_context(ecs_client, elbv2_client, service: dict) -> dict[str, Any]:
     """
-    Collect ECS resource information for a specific region.
+    Derive the shared per-service fields used by both row builders below.
 
-    Args:
-        region: AWS region name
-
-    Returns:
-        list: List of dictionaries with ECS resource information
+    Every field is read with ``.get()`` and a safe default so a service
+    entry missing an expected key cannot raise a ``KeyError`` here.
     """
-    print(f"\nCollecting ECS information in region: {region}")
-    ecs_resources = []
+    service_name = service.get('serviceName', 'Unknown')
+    task_definition_arn = service.get('taskDefinition', 'N/A')
+    task_def = get_task_definition_details(ecs_client, task_definition_arn)
 
-    try:
-        # Create ECS, ELBv2, and EC2 clients for this region
-        ecs_client = utils.get_boto3_client('ecs', region_name=region)
-        elbv2_client = utils.get_boto3_client('elbv2', region_name=region)
+    task_family = task_def.get('family', 'Unknown')
+    task_revision = task_def.get('revision', 'Unknown')
+    cpu_allocation = task_def.get('cpu', 'Unknown')
+    memory_allocation = task_def.get('memory', 'Unknown')
+    network_mode = task_def.get('networkMode', 'Unknown')
 
-        # Get all ECS clusters
-        cluster_arns = []
-        paginator = ecs_client.get_paginator('list_clusters')
-        for page in paginator.paginate():
-            cluster_arns.extend(page['clusterArns'])
+    # Get the IAM role
+    execution_role_arn = task_def.get('executionRoleArn', 'None')
+    task_role_arn = task_def.get('taskRoleArn', 'None')
 
-        if not cluster_arns:
-            print(f"  No ECS clusters found in {region}")
-            return []
+    # Extract role name from ARN
+    execution_role_name = execution_role_arn.split('/')[-1] if execution_role_arn != 'None' else 'None'
+    task_role_name = task_role_arn.split('/')[-1] if task_role_arn != 'None' else 'None'
 
-        print(f"  Found {len(cluster_arns)} ECS clusters")
+    # Format roles
+    iam_roles = []
+    if execution_role_name != 'None':
+        iam_roles.append(f"Execution: {execution_role_name}")
+    if task_role_name != 'None':
+        iam_roles.append(f"Task: {task_role_name}")
 
-        # Get details for each cluster
-        for i, cluster_arn in enumerate(cluster_arns, 1):
-            print(f"  Processing cluster {i}/{len(cluster_arns)}: {cluster_arn.split('/')[-1]}")
+    iam_role = ", ".join(iam_roles) if iam_roles else "None"
 
-            try:
-                # Get cluster details
-                cluster_response = ecs_client.describe_clusters(
-                    clusters=[cluster_arn],
-                    include=['SETTINGS', 'CONFIGURATIONS', 'TAGS']
-                )
+    # Get launch type
+    if 'launchType' in service:
+        launch_type = service.get('launchType', 'Unknown')
+    elif service.get('capacityProviderStrategy'):
+        provider = service['capacityProviderStrategy'][0].get('capacityProvider', 'Unknown')
+        launch_type = 'FARGATE' if 'FARGATE' in provider else f"CapacityProvider: {provider}"
+    else:
+        launch_type = 'Unknown'
 
-                if not cluster_response['clusters']:
-                    continue
+    # Get desired and running count
+    desired_count = service.get('desiredCount', 0)
+    running_count = service.get('runningCount', 0)
 
-                cluster = cluster_response['clusters'][0]
-                cluster_name = cluster['clusterName']
+    # Get creation time
+    created_at = service.get('createdAt', datetime.datetime.now())
+    if isinstance(created_at, datetime.datetime):
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                # Get all services in this cluster
-                service_arns = []
-                services_paginator = ecs_client.get_paginator('list_services')
-                for page in services_paginator.paginate(cluster=cluster_arn):
-                    service_arns.extend(page['serviceArns'])
+    # Get load balancer info if available
+    elb_target_groups = []
+    for lb in service.get('loadBalancers', []) or []:
+        target_group_arn = lb.get('targetGroupArn')
+        if not target_group_arn:
+            continue
+        target_group = get_target_group_info(elbv2_client, target_group_arn)
+        lb_arns = target_group.get('LoadBalancerArns') if target_group else None
 
-                if not service_arns:
-                    print(f"    No services found in cluster {cluster_name}")
-                    continue
+        if target_group and target_group.get('TargetGroupName') and lb_arns:
+            lb_name = get_load_balancer_name(elbv2_client, lb_arns[0])
+            elb_target_groups.append(f"{lb_name}:{target_group.get('TargetGroupName')}")
+        else:
+            elb_target_groups.append(target_group_arn.split('/')[-1] if target_group_arn else 'Unknown')
 
-                print(f"    Found {len(service_arns)} services in cluster {cluster_name}")
+    elb_target_group = ', '.join(elb_target_groups) if elb_target_groups else 'None'
 
-                # Process services in batches (describe_services has a limit of 10 services per call)
-                for j in range(0, len(service_arns), 10):
-                    service_batch = service_arns[j:j+10]
+    # Get network configuration if available
+    subnet_ids = []
+    security_groups = []
+    network_configuration = service.get('networkConfiguration', {}) or {}
+    vpc_config = network_configuration.get('awsvpcConfiguration')
+    if vpc_config:
+        subnet_ids = vpc_config.get('subnets', [])
+        security_groups = vpc_config.get('securityGroups', [])
 
-                    # Get service details
-                    service_response = ecs_client.describe_services(
-                        cluster=cluster_arn,
-                        services=service_batch,
-                        include=['TAGS']
-                    )
+    return {
+        'service_name': service_name,
+        'task_definition_arn': task_definition_arn,
+        'task_def': task_def,
+        'task_family': task_family,
+        'task_revision': task_revision,
+        'cpu_allocation': cpu_allocation,
+        'memory_allocation': memory_allocation,
+        'network_mode': network_mode,
+        'iam_role': iam_role,
+        'launch_type': launch_type,
+        'desired_count': desired_count,
+        'running_count': running_count,
+        'created_at': created_at,
+        'elb_target_group': elb_target_group,
+        'subnet_ids': subnet_ids,
+        'security_groups': security_groups,
+    }
 
-                    for service in service_response['services']:
-                        service_name = service['serviceName']
-                        print(f"      Processing service: {service_name}")
 
-                        # Get task definition details
-                        task_definition_arn = service['taskDefinition']
-                        task_def = get_task_definition_details(ecs_client, task_definition_arn)
+def _build_service_no_tasks_row(cluster_name: str, context: dict) -> dict[str, Any]:
+    """Build the export row for a service that currently has no running tasks."""
+    subnet_ids = context['subnet_ids']
+    security_groups = context['security_groups']
 
-                        task_family = task_def.get('family', 'Unknown')
-                        task_revision = task_def.get('revision', 'Unknown')
-                        cpu_allocation = task_def.get('cpu', 'Unknown')
-                        memory_allocation = task_def.get('memory', 'Unknown')
-                        network_mode = task_def.get('networkMode', 'Unknown')
+    return {
+        'Cluster Name': cluster_name,
+        'Service Name': context['service_name'],
+        'Task Definition': context['task_definition_arn'].split('/')[-1],
+        'Task Family': context['task_family'],
+        'Task Revision': context['task_revision'],
+        'Task Status': 'No Running Tasks',
+        'Launch Type': context['launch_type'],
+        'Desired Task Count': context['desired_count'],
+        'Running Task Count': context['running_count'],
+        'CPU Allocation': context['cpu_allocation'],
+        'Memory Allocation': context['memory_allocation'],
+        'Container Name': 'N/A',
+        'Image Used': 'N/A',
+        'Port Mappings': 'N/A',
+        'ELB Target Group': context['elb_target_group'],
+        'Network Mode': context['network_mode'],
+        'Subnet IDs': ', '.join(subnet_ids) if subnet_ids else 'None',
+        'Security Groups': ', '.join(security_groups) if security_groups else 'None',
+        'IAM Role': context['iam_role'],
+        'Created At': context['created_at']
+    }
 
-                        # Get the IAM role
-                        execution_role_arn = task_def.get('executionRoleArn', 'None')
-                        task_role_arn = task_def.get('taskRoleArn', 'None')
 
-                        # Extract role name from ARN
-                        execution_role_name = execution_role_arn.split('/')[-1] if execution_role_arn != 'None' else 'None'
-                        task_role_name = task_role_arn.split('/')[-1] if task_role_arn != 'None' else 'None'
+def _build_container_row(cluster_name: str, context: dict, task: dict, container: dict) -> dict[str, Any]:
+    """Build the export row for a single container within a running task."""
+    task_def = context['task_def']
+    container_name = container.get('name', 'Unknown')
+    container_image = container.get('image', 'Unknown')
 
-                        # Format roles
-                        iam_roles = []
-                        if execution_role_name != 'None':
-                            iam_roles.append(f"Execution: {execution_role_name}")
-                        if task_role_name != 'None':
-                            iam_roles.append(f"Task: {task_role_name}")
+    # Get container definition for port mappings
+    container_def = None
+    for c in task_def.get('containerDefinitions', []):
+        if c.get('name') == container_name:
+            container_def = c
+            break
 
-                        iam_role = ", ".join(iam_roles) if iam_roles else "None"
+    # Extract port mappings
+    port_mappings = []
+    if container_def and container_def.get('portMappings'):
+        for pm in container_def['portMappings']:
+            host_port = pm.get('hostPort', 'Auto')
+            container_port = pm.get('containerPort', 'Unknown')
+            protocol = pm.get('protocol', 'tcp')
+            port_mappings.append(f"{container_port}:{host_port}/{protocol}")
 
-                        # Get launch type
-                        launch_type = ''
-                        if 'launchType' in service:
-                            launch_type = service['launchType']
-                        elif 'capacityProviderStrategy' in service and service['capacityProviderStrategy']:
-                            provider = service['capacityProviderStrategy'][0]['capacityProvider']
-                            if 'FARGATE' in provider:
-                                launch_type = 'FARGATE'
-                            else:
-                                launch_type = f"CapacityProvider: {provider}"
-                        else:
-                            launch_type = 'Unknown'
+    subnet_ids = context['subnet_ids']
+    security_groups = context['security_groups']
 
-                        # Get desired and running count
-                        desired_count = service.get('desiredCount', 0)
-                        running_count = service.get('runningCount', 0)
+    return {
+        'Cluster Name': cluster_name,
+        'Service Name': context['service_name'],
+        'Task Definition': context['task_definition_arn'].split('/')[-1],
+        'Task Family': context['task_family'],
+        'Task Revision': context['task_revision'],
+        'Task Status': task.get('lastStatus', 'Unknown'),
+        'Launch Type': task.get('launchType', context['launch_type']),
+        'Desired Task Count': context['desired_count'],
+        'Running Task Count': context['running_count'],
+        'CPU Allocation': context['cpu_allocation'],
+        'Memory Allocation': context['memory_allocation'],
+        'Container Name': container_name,
+        'Image Used': container_image,
+        'Port Mappings': ', '.join(port_mappings) if port_mappings else 'None',
+        'ELB Target Group': context['elb_target_group'],
+        'Network Mode': context['network_mode'],
+        'Subnet IDs': ', '.join(subnet_ids) if subnet_ids else 'None',
+        'Security Groups': ', '.join(security_groups) if security_groups else 'None',
+        'IAM Role': context['iam_role'],
+        'Created At': context['created_at']
+    }
 
-                        # Get creation time
-                        created_at = service.get('createdAt', datetime.datetime.now())
-                        if isinstance(created_at, datetime.datetime):
-                            created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
 
-                        # Get load balancer info if available
-                        elb_target_groups = []
-                        if 'loadBalancers' in service and service['loadBalancers']:
-                            for lb in service['loadBalancers']:
-                                if 'targetGroupArn' in lb:
-                                    target_group_arn = lb['targetGroupArn']
-                                    target_group = get_target_group_info(elbv2_client, target_group_arn)
+def _build_cluster_rows(ecs_client, elbv2_client, cluster_arn: str, region: str) -> list[dict[str, Any]]:
+    """
+    Build all export rows (service/task/container entries) for a single cluster.
 
-                                    if target_group and 'TargetGroupName' in target_group and 'LoadBalancerArns' in target_group and target_group['LoadBalancerArns']:
-                                        lb_name = get_load_balancer_name(elbv2_client, target_group['LoadBalancerArns'][0])
-                                        elb_target_groups.append(f"{lb_name}:{target_group['TargetGroupName']}")
-                                    else:
-                                        elb_target_groups.append(target_group_arn.split('/')[-1] if target_group_arn else 'Unknown')
+    Left to raise on error — the caller (``_scan_ecs_region``) wraps each
+    cluster in try/except so one malformed cluster is skipped without losing
+    the rest of the region's clusters.
+    """
+    rows: list[dict[str, Any]] = []
 
-                        elb_target_group = ', '.join(elb_target_groups) if elb_target_groups else 'None'
+    # Get cluster details
+    cluster_response = ecs_client.describe_clusters(
+        clusters=[cluster_arn],
+        include=['SETTINGS', 'CONFIGURATIONS', 'TAGS']
+    )
 
-                        # Get network configuration if available
-                        subnet_ids = []
-                        security_groups = []
+    if not cluster_response['clusters']:
+        return rows
 
-                        if 'networkConfiguration' in service and 'awsvpcConfiguration' in service['networkConfiguration']:
-                            vpc_config = service['networkConfiguration']['awsvpcConfiguration']
-                            subnet_ids = vpc_config.get('subnets', [])
-                            security_groups = vpc_config.get('securityGroups', [])
+    cluster = cluster_response['clusters'][0]
+    cluster_name = cluster.get('clusterName', 'Unknown')
 
-                        # Get tasks for this service to get task status
-                        task_arns = []
-                        tasks_paginator = ecs_client.get_paginator('list_tasks')
-                        for page in tasks_paginator.paginate(cluster=cluster_arn, serviceName=service_name):
-                            task_arns.extend(page['taskArns'])
+    # Get all services in this cluster
+    service_arns = []
+    services_paginator = ecs_client.get_paginator('list_services')
+    for page in services_paginator.paginate(cluster=cluster_arn):
+        service_arns.extend(page['serviceArns'])
 
-                        # If there are no tasks, we still want to show the service
-                        if not task_arns:
-                            # Create a base entry for the service with no running tasks
-                            base_entry = {
-                                'Cluster Name': cluster_name,
-                                'Service Name': service_name,
-                                'Task Definition': task_definition_arn.split('/')[-1],
-                                'Task Family': task_family,
-                                'Task Revision': task_revision,
-                                'Task Status': 'No Running Tasks',
-                                'Launch Type': launch_type,
-                                'Desired Task Count': desired_count,
-                                'Running Task Count': running_count,
-                                'CPU Allocation': cpu_allocation,
-                                'Memory Allocation': memory_allocation,
-                                'Container Name': 'N/A',
-                                'Image Used': 'N/A',
-                                'Port Mappings': 'N/A',
-                                'ELB Target Group': elb_target_group,
-                                'Network Mode': network_mode,
-                                'Subnet IDs': ', '.join(subnet_ids) if subnet_ids else 'None',
-                                'Security Groups': ', '.join(security_groups) if security_groups else 'None',
-                                'IAM Role': iam_role,
-                                'Created At': created_at
-                            }
-                            ecs_resources.append(base_entry)
-                            continue
+    if not service_arns:
+        print(f"    No services found in cluster {cluster_name}")
+        return rows
 
-                        # Get details for each task
-                        for k in range(0, len(task_arns), 100):  # describe_tasks has a limit of 100 tasks per call
-                            task_batch = task_arns[k:k+100]
+    print(f"    Found {len(service_arns)} services in cluster {cluster_name}")
 
-                            task_response = ecs_client.describe_tasks(
-                                cluster=cluster_arn,
-                                tasks=task_batch
-                            )
+    # Process services in batches (describe_services has a limit of 10 services per call)
+    for j in range(0, len(service_arns), 10):
+        service_batch = service_arns[j:j + 10]
 
-                            for task in task_response['tasks']:
-                                task_status = task.get('lastStatus', 'Unknown')
+        service_response = ecs_client.describe_services(
+            cluster=cluster_arn,
+            services=service_batch,
+            include=['TAGS']
+        )
 
-                                # Process each container in the task
-                                for container in task.get('containers', []):
-                                    container_name = container.get('name', 'Unknown')
-                                    container_image = container.get('image', 'Unknown')
+        for service in service_response['services']:
+            service_name = service.get('serviceName', 'Unknown')
+            print(f"      Processing service: {service_name}")
 
-                                    # Get container definition for port mappings
-                                    container_def = None
-                                    for c in task_def.get('containerDefinitions', []):
-                                        if c.get('name') == container_name:
-                                            container_def = c
-                                            break
+            context = _build_service_context(ecs_client, elbv2_client, service)
 
-                                    # Extract port mappings
-                                    port_mappings = []
-                                    if container_def and 'portMappings' in container_def and container_def['portMappings']:
-                                        for pm in container_def['portMappings']:
-                                            host_port = pm.get('hostPort', 'Auto')
-                                            container_port = pm.get('containerPort', 'Unknown')
-                                            protocol = pm.get('protocol', 'tcp')
+            # Get tasks for this service to get task status
+            task_arns = []
+            tasks_paginator = ecs_client.get_paginator('list_tasks')
+            for page in tasks_paginator.paginate(cluster=cluster_arn, serviceName=service_name):
+                task_arns.extend(page['taskArns'])
 
-                                            port_mappings.append(f"{container_port}:{host_port}/{protocol}")
-
-                                    # Create entry for this container
-                                    ecs_resources.append({
-                                        'Cluster Name': cluster_name,
-                                        'Service Name': service_name,
-                                        'Task Definition': task_definition_arn.split('/')[-1],
-                                        'Task Family': task_family,
-                                        'Task Revision': task_revision,
-                                        'Task Status': task_status,
-                                        'Launch Type': task.get('launchType', launch_type),
-                                        'Desired Task Count': desired_count,
-                                        'Running Task Count': running_count,
-                                        'CPU Allocation': cpu_allocation,
-                                        'Memory Allocation': memory_allocation,
-                                        'Container Name': container_name,
-                                        'Image Used': container_image,
-                                        'Port Mappings': ', '.join(port_mappings) if port_mappings else 'None',
-                                        'ELB Target Group': elb_target_group,
-                                        'Network Mode': network_mode,
-                                        'Subnet IDs': ', '.join(subnet_ids) if subnet_ids else 'None',
-                                        'Security Groups': ', '.join(security_groups) if security_groups else 'None',
-                                        'IAM Role': iam_role,
-                                        'Created At': created_at
-                                    })
-
-            except Exception as e:
-                print(f"    Error processing cluster {cluster_arn}: {e}")
+            # If there are no tasks, we still want to show the service
+            if not task_arns:
+                rows.append(_build_service_no_tasks_row(cluster_name, context))
                 continue
 
-    except EndpointConnectionError:
-        print(f"  ECS service is not available in region {region}")
-    except Exception as e:
-        print(f"  Error collecting ECS data in region {region}: {e}")
+            # Get details for each task
+            for k in range(0, len(task_arns), 100):  # describe_tasks has a limit of 100 tasks per call
+                task_batch = task_arns[k:k + 100]
+
+                task_response = ecs_client.describe_tasks(
+                    cluster=cluster_arn,
+                    tasks=task_batch
+                )
+
+                for task in task_response['tasks']:
+                    for container in task.get('containers', []):
+                        rows.append(_build_container_row(cluster_name, context, task, container))
+
+    return rows
+
+
+def _scan_ecs_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect ECS resources (clusters/services/tasks/containers) from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no ECS resources" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    A single malformed cluster is skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nCollecting ECS information in region: {region}")
+    ecs_resources: list[dict[str, Any]] = []
+
+    ecs_client = utils.get_boto3_client('ecs', region_name=region)
+    elbv2_client = utils.get_boto3_client('elbv2', region_name=region)
+
+    # Get all ECS clusters
+    cluster_arns = []
+    paginator = ecs_client.get_paginator('list_clusters')
+    for page in paginator.paginate():
+        cluster_arns.extend(page['clusterArns'])
+
+    if not cluster_arns:
+        print(f"  No ECS clusters found in {region}")
+        return []
+
+    print(f"  Found {len(cluster_arns)} ECS clusters")
+
+    # Get details for each cluster
+    for i, cluster_arn in enumerate(cluster_arns, 1):
+        print(f"  Processing cluster {i}/{len(cluster_arns)}: {cluster_arn.split('/')[-1]}")
+
+        try:
+            ecs_resources.extend(_build_cluster_rows(ecs_client, elbv2_client, cluster_arn, region))
+        except Exception as e:
+            # One malformed cluster is skipped, not fatal to the region.
+            utils.log_error(f"Skipping malformed ECS cluster in {region}: {cluster_arn}", e)
+            continue
 
     return ecs_resources
 
-def get_ecs_resources(regions: list[str]) -> list[dict[str, Any]]:
+
+def get_ecs_resources(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect ECS resources from multiple regions concurrently.
+    Collect ECS resource information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS region names to scan
 
     Returns:
-        list: Combined list of ECS resources from all regions
+        tuple: ``(all_resources, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING ECS RESOURCES ===")
     utils.log_info(f"Scanning {len(regions)} regions...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
-        scan_function=get_ecs_resources_from_region,
-        show_progress=True
+        scan_function=_scan_ecs_region,
+        show_progress=True,
+        collect_failures=True,
     )
 
     all_resources = []
@@ -419,7 +476,7 @@ def get_ecs_resources(regions: list[str]) -> list[dict[str, Any]]:
         all_resources.extend(resources_in_region)
 
     utils.log_success(f"Total ECS resources collected: {len(all_resources)}")
-    return all_resources
+    return all_resources, failed_regions
 
 def get_standalone_tasks_from_region(region: str) -> list[dict[str, Any]]:
     """
@@ -541,7 +598,9 @@ def main():
 
         regions = utils.prompt_region_selection()
 
-        all_ecs_resources = get_ecs_resources(regions)
+        # Primary scope: region failures must propagate as failed_regions,
+        # never collapse into "empty" (see silent-collection-failure audit).
+        all_ecs_resources, failed_regions = get_ecs_resources(regions)
         standalone_tasks = get_standalone_tasks(regions)
 
         # Build multi-sheet export
@@ -554,6 +613,8 @@ def main():
         # Create export filename using utils
         filename = utils.create_export_filename(account_name, "ecs-resources", "all")
 
+        # A workbook always lands, even when nothing was collected — PRESERVED
+        # from the pre-fix behavior (Tier-3 PARTIAL class).
         if data_frames:
             output_path = utils.save_multiple_dataframes_to_excel(data_frames, filename)
         else:
@@ -566,6 +627,18 @@ def main():
             print(f"Total standalone ECS tasks: {len(standalone_tasks)}")
         else:
             print("\nError exporting data to Excel.")
+
+        # If ANY region failed the primary ECS resource scope collection,
+        # make it loud: write a marker and exit non-zero, even though a
+        # workbook was still written above. A partial export that looks
+        # complete is exactly the failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'ecs-resources', failed_regions)
+            print(
+                "\nERROR: ECS export completed with failures — data is incomplete. "
+                "See the *-ecs-resources-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\nOperation cancelled by user.")

--- a/scripts/eks_export.py
+++ b/scripts/eks_export.py
@@ -104,9 +104,18 @@ def get_available_regions():
     return available_regions if available_regions else aws_regions  # Fallback to all partition regions
 
 @utils.aws_error_handler("Collecting cluster details", default_return=None)
-def collect_cluster_details(client, cluster_name, region):
+def _build_cluster_row(client, cluster_name, region):
     """
-    Collect detailed information about an EKS cluster.
+    Build a single EKS cluster export row via ``describe_cluster``.
+
+    This is per-item enrichment on top of the primary ``list_clusters`` scan:
+    a single cluster's describe call failing (throttling, a cluster deleted
+    mid-scan, etc.) is caught by ``@utils.aws_error_handler`` and returns
+    ``None`` rather than aborting the whole region — the caller skips a
+    ``None`` result and continues with the remaining clusters. This is
+    intentionally graceful (unlike the region-level ``list_clusters`` call in
+    ``_scan_eks_clusters_region``, which must raise — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
     Args:
         client: boto3 EKS client
@@ -114,7 +123,8 @@ def collect_cluster_details(client, cluster_name, region):
         region: AWS region
 
     Returns:
-        dict: Dictionary containing cluster details
+        dict: Dictionary containing cluster details, or None if the describe
+            call failed.
     """
     # Get cluster details
     response = client.describe_cluster(name=cluster_name)
@@ -404,44 +414,126 @@ def collect_cluster_addons(client, cluster_name, region):
 
     return addons_data
 
-def collect_eks_clusters(region):
+def _scan_eks_clusters_region(region):
     """
-    Collect EKS cluster information from a specific region.
+    Collect EKS cluster information from a single region.
+
+    This is the primary-scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure from ``list_clusters`` must propagate
+    so ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no EKS clusters" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Per-cluster ``describe_cluster`` failures are handled gracefully by
+    ``_build_cluster_row`` (decorated with ``default_return=None``) — one
+    malformed/inaccessible cluster does not sink the whole region.
 
     Args:
         region: AWS region to collect clusters from
 
     Returns:
-        tuple: (clusters_data, node_groups_data, addons_data)
+        list: List of cluster info dictionaries for this region.
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    print(f"\nProcessing region: {region}")
+
+    client = utils.get_boto3_client('eks', region_name=region)
+
+    # List all EKS clusters in the region
+    paginator = client.get_paginator('list_clusters')
+    cluster_names = []
+    for page in paginator.paginate():
+        cluster_names.extend(page.get('clusters', []))
+
+    if not cluster_names:
+        utils.log_info(f"No EKS clusters found in {region}")
+        return []
+
+    utils.log_info(f"Found {len(cluster_names)} EKS clusters in {region} to process")
+
     clusters_data = []
+    for i, cluster_name in enumerate(cluster_names, 1):
+        progress = (i / len(cluster_names)) * 100
+        utils.log_info(f"[{progress:.1f}%] Processing cluster {i}/{len(cluster_names)}: {cluster_name}")
+
+        # Collect cluster details. One malformed/inaccessible cluster is
+        # skipped, not fatal to the region (_build_cluster_row already
+        # returns None gracefully via its own decorator, but the explicit
+        # try/except here also protects against unexpected raises).
+        try:
+            cluster_info = _build_cluster_row(client, cluster_name, region)
+        except Exception as e:
+            utils.log_error(
+                f"Skipping EKS cluster '{cluster_name}' in {region} due to a processing error", e
+            )
+            continue
+
+        if cluster_info:
+            clusters_data.append(cluster_info)
+
+    print(f"  Found {len(clusters_data)} EKS clusters")
+    return clusters_data
+
+
+def collect_eks_clusters(regions):
+    """
+    Collect EKS cluster information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: ``(clusters_data, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_eks_clusters_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_clusters = [cluster for result in region_results for cluster in result]
+    return all_clusters, failed_regions
+
+
+def _scan_node_groups_and_addons_region(region):
+    """
+    Collect EKS node groups and add-ons for a single region (enrichment).
+
+    Kept graceful — unlike ``_scan_eks_clusters_region`` — since node groups
+    and add-ons are secondary detail relative to the primary cluster
+    inventory; a region-level failure here degrades to an empty result
+    instead of failing the whole export.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        tuple: (node_groups_data, addons_data) for this region.
+    """
     node_groups_data = []
     addons_data = []
+
+    if not utils.is_aws_region(region):
+        return node_groups_data, addons_data
 
     try:
         client = utils.get_boto3_client('eks', region_name=region)
 
-        # List all EKS clusters in the region
         paginator = client.get_paginator('list_clusters')
         cluster_names = []
         for page in paginator.paginate():
             cluster_names.extend(page.get('clusters', []))
 
-        if not cluster_names:
-            utils.log_info(f"No EKS clusters found in {region}")
-            return clusters_data, node_groups_data, addons_data
-
-        utils.log_info(f"Found {len(cluster_names)} EKS clusters in {region} to process")
-
-        for i, cluster_name in enumerate(cluster_names, 1):
-            progress = (i / len(cluster_names)) * 100
-            utils.log_info(f"[{progress:.1f}%] Processing cluster {i}/{len(cluster_names)}: {cluster_name}")
-
-            # Collect cluster details
-            cluster_info = collect_cluster_details(client, cluster_name, region)
-            if cluster_info:
-                clusters_data.append(cluster_info)
-
+        for cluster_name in cluster_names:
             # Collect node groups for this cluster
             cluster_node_groups = collect_node_groups(client, cluster_name, region)
             node_groups_data.extend(cluster_node_groups)
@@ -457,9 +549,32 @@ def collect_eks_clusters(region):
         else:
             utils.log_error(f"Error accessing EKS in {region}: {e}")
     except Exception as e:
-        utils.log_error(f"Error collecting EKS clusters from {region}", e)
+        utils.log_error(f"Error collecting EKS node groups/add-ons from {region}", e)
 
-    return clusters_data, node_groups_data, addons_data
+    return node_groups_data, addons_data
+
+
+def collect_node_groups_and_addons(regions):
+    """
+    Collect EKS node group and add-on information across regions (enrichment).
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        tuple: (node_groups_data, addons_data)
+    """
+    results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_node_groups_and_addons_region,
+        show_progress=True,
+    )
+    node_groups_data = []
+    addons_data = []
+    for region_node_groups, region_addons in results:
+        node_groups_data.extend(region_node_groups)
+        addons_data.extend(region_addons)
+    return node_groups_data, addons_data
 
 def format_timestamp(timestamp):
     """
@@ -669,26 +784,17 @@ def main():
 
         utils.log_info(f"Will scan EKS clusters in regions: {', '.join(available_regions)}")
 
-        # Collect EKS data from all available regions
-        all_clusters_data = []
-        all_node_groups_data = []
-        all_addons_data = []
+        # STEP 1: Collect EKS clusters (primary scope — region failures must
+        # propagate as failed_regions, never collapse into "empty").
+        all_clusters_data, failed_regions = collect_eks_clusters(available_regions)
+        utils.log_success(f"Total EKS clusters collected: {len(all_clusters_data)}")
 
-        for region in available_regions:
-            utils.log_info(f"Collecting EKS information from {region}...")
+        # STEP 2: Collect node groups and add-ons (enrichment — degrades
+        # gracefully; a region-level failure here does not fail the whole export).
+        all_node_groups_data, all_addons_data = collect_node_groups_and_addons(available_regions)
 
-            clusters_data, node_groups_data, addons_data = collect_eks_clusters(region)
-
-            all_clusters_data.extend(clusters_data)
-            all_node_groups_data.extend(node_groups_data)
-            all_addons_data.extend(addons_data)
-
-            if clusters_data:
-                utils.log_success(f"Collected {len(clusters_data)} clusters from {region}")
-            else:
-                utils.log_info(f"No EKS clusters found in {region}")
-
-        if not all_clusters_data and not all_node_groups_data and not all_addons_data:
+        if not all_clusters_data and not all_node_groups_data and not all_addons_data and not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
             utils.log_warning("No EKS data collected from any region. Exiting.")
             return
 
@@ -696,7 +802,8 @@ def main():
         print("COLLECTION COMPLETE")
         print("====================================================================")
 
-        # Export to Excel
+        # Export whatever succeeded — a partial export is required even when
+        # some regions failed (see the silent-collection-failure blast-radius audit).
         filename = export_to_excel(all_clusters_data, all_node_groups_data, all_addons_data, account_id, account_name)
 
         if filename:
@@ -714,8 +821,20 @@ def main():
                 utils.log_info(f"Clusters with encryption: {encrypted_clusters}")
 
             print("\nScript execution completed.")
-        else:
+        elif not failed_regions:
             utils.log_error("Export failed. Please check the logs.")
+
+        # If ANY region failed the primary EKS clusters scope collection,
+        # make it loud: write a marker and exit non-zero, even if some data
+        # was exported. A partial export that looks complete is exactly the
+        # failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'eks', failed_regions)
+            print(
+                "\nERROR: EKS export completed with failures — data is incomplete. "
+                "See the *-eks-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/elasticbeanstalk_export.py
+++ b/scripts/elasticbeanstalk_export.py
@@ -32,9 +32,71 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Elastic Beanstalk applications and environments to Excel")
 
-@utils.aws_error_handler("Collecting Elastic Beanstalk applications from region", default_return=[])
+def _build_application_row(app: dict, region: str) -> dict[str, Any]:
+    """Build a single Elastic Beanstalk application export row from a describe response."""
+    app_name = app.get('ApplicationName', 'N/A')
+    description = app.get('Description', 'N/A')
+
+    # Resource lifecycle config
+    resource_lifecycle_config = app.get('ResourceLifecycleConfig', {})
+    service_role = resource_lifecycle_config.get('ServiceRole', 'N/A')
+    version_lifecycle_config = resource_lifecycle_config.get('VersionLifecycleConfig', {})
+    max_count = version_lifecycle_config.get('MaxCountRule', {}).get('MaxCount', 'N/A')
+    max_age_days = version_lifecycle_config.get('MaxAgeRule', {}).get('MaxAgeInDays', 'N/A')
+
+    # Extract role name
+    role_name = 'N/A'
+    if service_role != 'N/A' and '/' in service_role:
+        role_name = service_role.split('/')[-1]
+
+    # Date created
+    date_created = app.get('DateCreated')
+    date_created_str = date_created.strftime('%Y-%m-%d %H:%M:%S') if date_created else 'N/A'
+
+    # Date updated
+    date_updated = app.get('DateUpdated')
+    date_updated_str = date_updated.strftime('%Y-%m-%d %H:%M:%S') if date_updated else 'N/A'
+
+    # Versions count
+    versions = app.get('Versions', [])
+    version_count = len(versions)
+
+    # Configuration templates
+    config_templates = app.get('ConfigurationTemplates', [])
+    config_template_count = len(config_templates)
+
+    return {
+        'Region': region,
+        'Application Name': app_name,
+        'Description': description,
+        'Version Count': version_count,
+        'Config Template Count': config_template_count,
+        'Service Role': role_name,
+        'Max Versions': max_count,
+        'Max Age (Days)': max_age_days,
+        'Created': date_created_str,
+        'Updated': date_updated_str,
+    }
+
+
 def collect_applications_from_region(region: str) -> list[dict[str, Any]]:
-    """Collect Elastic Beanstalk application information from a single AWS region."""
+    """
+    Collect Elastic Beanstalk applications from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no applications" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed applications are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     applications = []
     eb_client = utils.get_boto3_client('elasticbeanstalk', region_name=region)
 
@@ -42,62 +104,40 @@ def collect_applications_from_region(region: str) -> list[dict[str, Any]]:
     apps = response.get('Applications', [])
 
     for app in apps:
-        app_name = app.get('ApplicationName', 'N/A')
-        description = app.get('Description', 'N/A')
-
-        # Resource lifecycle config
-        resource_lifecycle_config = app.get('ResourceLifecycleConfig', {})
-        service_role = resource_lifecycle_config.get('ServiceRole', 'N/A')
-        version_lifecycle_config = resource_lifecycle_config.get('VersionLifecycleConfig', {})
-        max_count = version_lifecycle_config.get('MaxCountRule', {}).get('MaxCount', 'N/A')
-        max_age_days = version_lifecycle_config.get('MaxAgeRule', {}).get('MaxAgeInDays', 'N/A')
-
-        # Extract role name
-        role_name = 'N/A'
-        if service_role != 'N/A' and '/' in service_role:
-            role_name = service_role.split('/')[-1]
-
-        # Date created
-        date_created = app.get('DateCreated')
-        date_created_str = date_created.strftime('%Y-%m-%d %H:%M:%S') if date_created else 'N/A'
-
-        # Date updated
-        date_updated = app.get('DateUpdated')
-        date_updated_str = date_updated.strftime('%Y-%m-%d %H:%M:%S') if date_updated else 'N/A'
-
-        # Versions count
-        versions = app.get('Versions', [])
-        version_count = len(versions)
-
-        # Configuration templates
-        config_templates = app.get('ConfigurationTemplates', [])
-        config_template_count = len(config_templates)
-
-        applications.append({
-            'Region': region,
-            'Application Name': app_name,
-            'Description': description,
-            'Version Count': version_count,
-            'Config Template Count': config_template_count,
-            'Service Role': role_name,
-            'Max Versions': max_count,
-            'Max Age (Days)': max_age_days,
-            'Created': date_created_str,
-            'Updated': date_updated_str,
-        })
+        try:
+            applications.append(_build_application_row(app, region))
+        except Exception as e:
+            # One malformed application is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed Elastic Beanstalk application in {region}: "
+                f"{app.get('ApplicationName', '<unknown>')}",
+                e,
+            )
+            continue
 
     return applications
 
 
-def collect_applications(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Elastic Beanstalk application information using concurrent scanning."""
+def collect_applications(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Elastic Beanstalk application information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(applications, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING ELASTIC BEANSTALK APPLICATIONS ===")
     utils.log_info(f"Scanning {len(regions)} regions...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_applications_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     all_applications = []
@@ -105,7 +145,7 @@ def collect_applications(regions: list[str]) -> list[dict[str, Any]]:
         all_applications.extend(apps_in_region)
 
     utils.log_success(f"Total applications collected: {len(all_applications)}")
-    return all_applications
+    return all_applications, failed_regions
 
 
 @utils.aws_error_handler("Collecting Elastic Beanstalk environments from region", default_return=[])
@@ -488,11 +528,21 @@ def generate_summary(applications: list[dict[str, Any]],
     return summary
 
 
-def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
-    """Collect Elastic Beanstalk data and write the Excel export."""
+def _run_export(account_id: str, account_name: str, regions: list[str]) -> list:
+    """
+    Collect Elastic Beanstalk data and write the Excel export.
+
+    Returns:
+        list: ``failed_regions`` — ``(region, error_message)`` tuples for
+        regions whose Applications scope collection failed. The Summary
+        sheet (and workbook) is always written regardless; the caller
+        decides whether to also report a FAILED marker and exit non-zero.
+    """
     # Collect data
     print("\n=== Collecting Elastic Beanstalk Data ===")
-    applications = collect_applications(regions)
+    # Applications are the primary scope — region failures must propagate as
+    # failed_regions, never collapse into "empty".
+    applications, failed_regions = collect_applications(regions)
     environments = collect_environments(regions)
     versions = collect_application_versions(regions)
     templates = collect_configuration_templates(regions)
@@ -535,6 +585,9 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
+    return failed_regions
+
+
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""
     if not utils.ensure_dependencies('pandas', 'openpyxl'):
@@ -571,7 +624,19 @@ def main():
                 step = 3
 
             elif step == 3:
-                _run_export(account_id, account_name, regions)
+                failed_regions = _run_export(account_id, account_name, regions)
+                # If ANY region failed the Applications scope collection,
+                # make it loud: write a marker and exit non-zero, even
+                # though a workbook was still written (the forced Summary
+                # sheet). A complete-looking file that hides a failed scope
+                # is exactly the failure mode this guards against.
+                if failed_regions:
+                    utils.report_collection_failures(account_name, 'elasticbeanstalk', failed_regions)
+                    print(
+                        "\nERROR: Elastic Beanstalk export completed with failures — data is incomplete. "
+                        "See the *-elasticbeanstalk-FAILED-*.txt marker in the output directory."
+                    )
+                    sys.exit(1)
                 break
 
     except KeyboardInterrupt:

--- a/tests/test_exporters/test_api_gateway_export.py
+++ b/tests/test_exporters/test_api_gateway_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for api_gateway_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import api_gateway_export  # noqa: E402
+from api_gateway_export import scan_rest_apis_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_rest_api(client, name):
+    """Create a REST API named ``name``."""
+    return client.create_rest_api(name=name, description=f"{name} desc")
+
+
+class TestScanRestApisInRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_rest_apis(self):
+        client = boto3.client("apigateway", region_name=REGION)
+        _create_rest_api(client, "web-api")
+
+        rows = scan_rest_apis_in_region(REGION)
+
+        names = {row["API Name"] for row in rows}
+        assert "web-api" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("apigateway", region_name=REGION)  # region exists, no APIs
+
+        rows = scan_rest_apis_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One REST API that fails to process must not discard the whole region."""
+        client = boto3.client("apigateway", region_name=REGION)
+        _create_rest_api(client, "good-api")
+        _create_rest_api(client, "bad-api")
+
+        original = api_gateway_export._build_rest_api_row
+
+        def raise_for_bad(item, region):
+            if item.get("name") == "bad-api":
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(api_gateway_export, "_build_rest_api_row", raise_for_bad)
+
+        rows = scan_rest_apis_in_region(REGION)
+
+        names = {row["API Name"] for row in rows}
+        assert "good-api" in names, "healthy REST API was lost when a sibling failed"
+        assert "bad-api" not in names, "malformed REST API should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "GetRestApis",
+            )
+
+        monkeypatch.setattr(api_gateway_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_rest_apis_in_region(REGION)
+
+    @mock_aws
+    def test_collect_rest_apis_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "GetRestApis",
+            )
+
+        monkeypatch.setattr(api_gateway_export, "scan_rest_apis_in_region", boom)
+
+        apis, failed_regions = api_gateway_export.collect_rest_apis([REGION])
+
+        assert apis == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_apprunner_export.py
+++ b/tests/test_exporters/test_apprunner_export.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Tests for apprunner_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+NOTE: moto has no AWS App Runner support at all (not even ``list_services``
+returns "Not yet implemented" as of moto 5.1.21). Every test here therefore
+monkeypatches ``utils.get_boto3_client`` to return a fake App Runner client
+instead of using ``@mock_aws`` — there is no moto backend to mock against.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import apprunner_export  # noqa: E402
+from apprunner_export import _scan_apprunner_services_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakeApprunnerClient:
+    """
+    Minimal stand-in for a boto3 App Runner client.
+
+    ``list_services`` returns the fixed ``summaries`` in a single page.
+    ``describe_service`` raises for any service name in ``fail_names``
+    (simulating a per-item describe failure) and otherwise returns an empty
+    (but valid) ``Service`` body.
+    """
+
+    def __init__(self, summaries: list[dict[str, Any]], fail_names: set = frozenset()):
+        self.summaries = summaries
+        self.fail_names = fail_names
+
+    def list_services(self, **kwargs):
+        return {"ServiceSummaryList": self.summaries, "NextToken": None}
+
+    def describe_service(self, **kwargs):
+        service_arn = kwargs["ServiceArn"]
+        name = service_arn.split("/")[-1] if "/" in service_arn else service_arn
+        if name in self.fail_names:
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalFailure", "Message": "boom"}},
+                "DescribeService",
+            )
+        return {"Service": {}}
+
+
+def _summary(name: str) -> dict[str, Any]:
+    return {
+        "ServiceArn": f"arn:aws:apprunner:{REGION}:123456789012:service/{name}",
+        "ServiceName": name,
+        "ServiceId": name,
+        "ServiceUrl": f"{name}.example.com",
+        "Status": "RUNNING",
+    }
+
+
+class TestScanApprunnerServicesRegion:
+    """Happy-path collection."""
+
+    def test_collects_services(self, monkeypatch):
+        client = _FakeApprunnerClient([_summary("web-service")])
+        monkeypatch.setattr(apprunner_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = _scan_apprunner_services_region(REGION)
+
+        names = {row["Service Name"] for row in rows}
+        assert "web-service" in names
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _FakeApprunnerClient([])
+        monkeypatch.setattr(apprunner_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = _scan_apprunner_services_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region. apprunner_export.py is a
+    Tier-3 PARTIAL case: it already writes a forced Summary sheet, so a
+    workbook always lands — the fix adds failed-scope tracking so a scope
+    failure ALSO writes a ``*-apprunner-FAILED-*.txt`` marker and exits
+    non-zero, instead of silently reporting a zero-row Services sheet as if
+    the account genuinely had none.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One service whose describe_service fails must not discard the whole region."""
+        client = _FakeApprunnerClient(
+            [_summary("good-service"), _summary("bad-service")],
+            fail_names={"bad-service"},
+        )
+        monkeypatch.setattr(apprunner_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = _scan_apprunner_services_region(REGION)
+
+        names = {row["Service Name"] for row in rows}
+        assert "good-service" in names, "healthy service was lost when a sibling failed"
+        assert "bad-service" not in names, "malformed service should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure (e.g. list_services itself failing) must
+        propagate (so the caller can record a FAILED region) rather than
+        being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListServices",
+            )
+
+        monkeypatch.setattr(apprunner_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_apprunner_services_region(REGION)
+
+    def test_collect_apprunner_services_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker +
+        exit 1 (while the forced Summary sheet still lands).
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListServices",
+            )
+
+        monkeypatch.setattr(apprunner_export, "_scan_apprunner_services_region", boom)
+
+        services, failed_regions = apprunner_export.collect_apprunner_services([REGION])
+
+        assert services == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_appsync_export.py
+++ b/tests/test_exporters/test_appsync_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Tests for appsync_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's AppSync support does not implement failure injection (its
+list_graphql_apis always succeeds against an empty/mocked account), so the
+region-failure cases here monkeypatch the boto3 client / scan function
+directly instead of relying on moto to raise.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import appsync_export  # noqa: E402
+from appsync_export import _scan_graphql_apis_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal stand-in for a boto3 paginator over a fixed set of pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeAppSyncClient:
+    """Minimal stand-in for the AppSync boto3 client's list_graphql_apis paginator."""
+
+    def __init__(self, apis):
+        self._apis = apis
+
+    def get_paginator(self, name):
+        assert name == "list_graphql_apis"
+        return _FakePaginator([{"graphqlApis": self._apis}])
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One GraphQL API that fails to process must not discard the whole region."""
+        fake_apis = [
+            {"apiId": "good-id", "name": "good-api", "authenticationType": "API_KEY"},
+            {"apiId": "bad-id", "name": "bad-api", "authenticationType": "API_KEY"},
+        ]
+        monkeypatch.setattr(
+            appsync_export.utils,
+            "get_boto3_client",
+            lambda *args, **kwargs: _FakeAppSyncClient(fake_apis),
+        )
+
+        original = appsync_export._build_graphql_api_row
+
+        def raise_for_bad(api, region):
+            if api.get("apiId") == "bad-id":
+                raise KeyError("SomeUnexpectedField")
+            return original(api, region)
+
+        monkeypatch.setattr(appsync_export, "_build_graphql_api_row", raise_for_bad)
+
+        rows = _scan_graphql_apis_region(REGION)
+
+        names = {row["API Name"] for row in rows}
+        assert "good-api" in names, "healthy API was lost when a sibling failed"
+        assert "bad-api" not in names, "malformed API should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListGraphqlApis",
+            )
+
+        monkeypatch.setattr(appsync_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_graphql_apis_region(REGION)
+
+    def test_collect_graphql_apis_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListGraphqlApis",
+            )
+
+        monkeypatch.setattr(appsync_export, "_scan_graphql_apis_region", boom)
+
+        apis, failed_regions = appsync_export.collect_graphql_apis([REGION])
+
+        assert apis == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_cloudmap_export.py
+++ b/tests/test_exporters/test_cloudmap_export.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for cloudmap_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's servicediscovery support does not model API-level failures
+(e.g. a namespace whose ``get_namespace`` call raises, or a region-level
+paginator failure), so the regression cases below use monkeypatched fake
+clients/functions instead of real moto failures. The happy-path class uses
+real moto since ``create_http_namespace`` / ``list_namespaces`` /
+``get_namespace`` are supported there.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cloudmap_export  # noqa: E402
+from cloudmap_export import _scan_namespaces_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in returning pre-built pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeServiceDiscoveryClient:
+    """
+    Fake ``servicediscovery`` client used where moto cannot simulate the
+    failure being tested (a namespace whose detail lookup raises).
+    """
+
+    def __init__(self, namespace_summaries, raise_for_ids=None):
+        self._namespace_summaries = namespace_summaries
+        self._raise_for_ids = raise_for_ids or set()
+
+    def get_paginator(self, operation_name):
+        if operation_name == "list_namespaces":
+            return _FakePaginator([{"Namespaces": self._namespace_summaries}])
+        raise NotImplementedError(operation_name)
+
+    def get_namespace(self, Id):  # noqa: N803 - mirrors the boto3 servicediscovery API
+        if Id in self._raise_for_ids:
+            raise KeyError("SomeUnexpectedField")
+        return {
+            "Namespace": {
+                "Id": Id,
+                "Name": f"name-{Id}",
+                "Type": "HTTP",
+                "Arn": f"arn:aws:servicediscovery:{REGION}:123456789012:namespace/{Id}",
+                "CreateDate": "N/A",
+                "Properties": {},
+            }
+        }
+
+
+class TestScanNamespacesRegion:
+    """Happy-path collection (real moto)."""
+
+    @mock_aws
+    def test_collects_namespaces(self):
+        client = boto3.client("servicediscovery", region_name=REGION)
+        client.create_http_namespace(Name="web-namespace")
+
+        rows = _scan_namespaces_region(REGION)
+
+        names = {row["Namespace Name"] for row in rows}
+        assert "web-namespace" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("servicediscovery", region_name=REGION)  # region exists, no namespaces
+
+        rows = _scan_namespaces_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One namespace that fails to process must not discard the whole region."""
+        fake_client = _FakeServiceDiscoveryClient(
+            namespace_summaries=[
+                {"Id": "good-ns", "Name": "good", "Type": "HTTP"},
+                {"Id": "bad-ns", "Name": "bad", "Type": "HTTP"},
+            ],
+            raise_for_ids={"bad-ns"},
+        )
+        monkeypatch.setattr(
+            cloudmap_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_namespaces_region(REGION)
+
+        ids = {row["Namespace ID"] for row in rows}
+        assert "good-ns" in ids, "healthy namespace was lost when a sibling failed"
+        assert "bad-ns" not in ids, "malformed namespace should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListNamespaces",
+            )
+
+        monkeypatch.setattr(cloudmap_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_namespaces_region(REGION)
+
+    def test_collect_namespaces_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListNamespaces",
+            )
+
+        monkeypatch.setattr(cloudmap_export, "_scan_namespaces_region", boom)
+
+        namespaces, failed_regions = cloudmap_export.collect_namespaces([REGION])
+
+        assert namespaces == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_cognito_export.py
+++ b/tests/test_exporters/test_cognito_export.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Tests for cognito_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's cognito-idp backend depends on ``joserfc``, which is not
+installed in this environment (``ModuleNotFoundError: No module named
+'joserfc'`` when moto's cognitoidp models module is imported). Tests that
+need actual user pool data therefore monkeypatch a fake cognito-idp client
+(paginator + describe_user_pool) instead of using ``@mock_aws`` for those
+calls. Tests that only need a region-level API failure to propagate use
+``@mock_aws`` + monkeypatched ``utils.get_boto3_client`` as before, since
+those never touch the cognitoidp backend.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cognito_export  # noqa: E402
+from cognito_export import scan_user_pools_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class _FakePaginator:
+    """Minimal stand-in for a boto3 paginator over a single page."""
+
+    def __init__(self, page):
+        self._page = page
+
+    def paginate(self, **kwargs):
+        return iter([self._page])
+
+
+class _FakeCognitoClient:
+    """Minimal stand-in for a cognito-idp client, keyed by pool ID."""
+
+    def __init__(self, pools_by_id):
+        self._pools_by_id = pools_by_id
+
+    def get_paginator(self, operation_name):
+        assert operation_name == "list_user_pools"
+        summaries = [{"Id": pid, "Name": p["Name"]} for pid, p in self._pools_by_id.items()]
+        return _FakePaginator({"UserPools": summaries})
+
+    def describe_user_pool(self, UserPoolId):  # noqa: N803 - mirrors the boto3 cognito-idp API
+        if UserPoolId not in self._pools_by_id:
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "not found"}},
+                "DescribeUserPool",
+            )
+        return {"UserPool": self._pools_by_id[UserPoolId]}
+
+
+def _install_fake_client(monkeypatch, pools_by_id):
+    """Patch utils.get_boto3_client so cognito_export gets the fake client."""
+    fake_client = _FakeCognitoClient(pools_by_id)
+
+    def fake_get_boto3_client(service, region_name=None, **kwargs):
+        assert service == "cognito-idp"
+        return fake_client
+
+    monkeypatch.setattr(cognito_export.utils, "get_boto3_client", fake_get_boto3_client)
+    return fake_client
+
+
+class TestScanUserPoolsInRegion:
+    """Happy-path collection."""
+
+    def test_collects_user_pools(self, monkeypatch):
+        _install_fake_client(monkeypatch, {"pool-1": {"Id": "pool-1", "Name": "web-pool"}})
+
+        rows = scan_user_pools_in_region(REGION)
+
+        names = {row["Pool Name"] for row in rows}
+        assert "web-pool" in names
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        _install_fake_client(monkeypatch, {})  # region exists, no pools
+
+        rows = scan_user_pools_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One user pool that fails to describe/build must not discard the whole region."""
+        _install_fake_client(
+            monkeypatch,
+            {
+                "pool-good": {"Id": "pool-good", "Name": "good-pool"},
+                "pool-bad": {"Id": "pool-bad", "Name": "bad-pool"},
+            },
+        )
+
+        original = cognito_export._build_user_pool_row
+
+        def raise_for_bad(pool, region):
+            if pool.get("Name") == "bad-pool":
+                raise KeyError("SomeUnexpectedField")
+            return original(pool, region)
+
+        monkeypatch.setattr(cognito_export, "_build_user_pool_row", raise_for_bad)
+
+        rows = scan_user_pools_in_region(REGION)
+
+        names = {row["Pool Name"] for row in rows}
+        assert "good-pool" in names, "healthy user pool was lost when a sibling failed"
+        assert "bad-pool" not in names, "malformed user pool should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListUserPools",
+            )
+
+        monkeypatch.setattr(cognito_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_user_pools_in_region(REGION)
+
+    @mock_aws
+    def test_collect_user_pools_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListUserPools",
+            )
+
+        monkeypatch.setattr(cognito_export, "scan_user_pools_in_region", boom)
+
+        pools, failed_regions = cognito_export.collect_user_pools([REGION])
+
+        assert pools == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_ecs_export.py
+++ b/tests/test_exporters/test_ecs_export.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ecs_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ecs_export  # noqa: E402
+from ecs_export import _scan_ecs_region  # noqa: E402
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_cluster_with_service(client, cluster_name, service_name):
+    """Create an ECS cluster + task definition + service named as given."""
+    client.create_cluster(clusterName=cluster_name)
+    client.register_task_definition(
+        family=f"{service_name}-family",
+        containerDefinitions=[{"name": "web", "image": "nginx", "memory": 128}],
+    )
+    client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=f"{service_name}-family",
+        desiredCount=1,
+    )
+
+
+class TestScanEcsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_ecs_services(self):
+        client = boto3.client("ecs", region_name=REGION)
+        _create_cluster_with_service(client, "web-cluster", "web-service")
+
+        rows = _scan_ecs_region(REGION)
+
+        names = {row["Service Name"] for row in rows}
+        assert "web-service" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ecs", region_name=REGION)  # region exists, no clusters
+
+        rows = _scan_ecs_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One cluster that fails to process must not discard the whole region."""
+        client = boto3.client("ecs", region_name=REGION)
+        _create_cluster_with_service(client, "good-cluster", "good-service")
+        _create_cluster_with_service(client, "bad-cluster", "bad-service")
+
+        original = ecs_export._build_cluster_rows
+
+        def raise_for_bad(ecs_client, elbv2_client, cluster_arn, region):
+            if "bad-cluster" in cluster_arn:
+                raise KeyError("SomeUnexpectedField")
+            return original(ecs_client, elbv2_client, cluster_arn, region)
+
+        monkeypatch.setattr(ecs_export, "_build_cluster_rows", raise_for_bad)
+
+        rows = _scan_ecs_region(REGION)
+
+        names = {row["Service Name"] for row in rows}
+        assert "good-service" in names, "healthy cluster was lost when a sibling failed"
+        assert "bad-service" not in names, "malformed cluster should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListClusters",
+            )
+
+        monkeypatch.setattr(ecs_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_ecs_region(REGION)
+
+    @mock_aws
+    def test_get_ecs_resources_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListClusters",
+            )
+
+        monkeypatch.setattr(ecs_export, "_scan_ecs_region", boom)
+
+        resources, failed_regions = ecs_export.get_ecs_resources([REGION])
+
+        assert resources == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_eks_export.py
+++ b/tests/test_exporters/test_eks_export.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for eks_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import eks_export  # noqa: E402
+from eks_export import _scan_eks_clusters_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_cluster(client, name):
+    """Create an EKS cluster named ``name``."""
+    client.create_cluster(
+        name=name,
+        roleArn="arn:aws:iam::123456789012:role/eks-role",
+        resourcesVpcConfig={"subnetIds": ["subnet-12345678"]},
+    )
+
+
+class TestScanEksClustersRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_clusters(self):
+        client = boto3.client("eks", region_name=REGION)
+        _create_cluster(client, "web-cluster")
+
+        rows = _scan_eks_clusters_region(REGION)
+
+        names = {row["Cluster Name"] for row in rows}
+        assert "web-cluster" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("eks", region_name=REGION)  # region exists, no clusters
+
+        rows = _scan_eks_clusters_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One cluster that fails to process must not discard the whole region."""
+        client = boto3.client("eks", region_name=REGION)
+        _create_cluster(client, "good-cluster")
+        _create_cluster(client, "bad-cluster")
+
+        original = eks_export._build_cluster_row
+
+        def raise_for_bad(client, cluster_name, region):
+            if cluster_name == "bad-cluster":
+                raise KeyError("SomeUnexpectedField")
+            return original(client, cluster_name, region)
+
+        monkeypatch.setattr(eks_export, "_build_cluster_row", raise_for_bad)
+
+        rows = _scan_eks_clusters_region(REGION)
+
+        names = {row["Cluster Name"] for row in rows}
+        assert "good-cluster" in names, "healthy cluster was lost when a sibling failed"
+        assert "bad-cluster" not in names, "malformed cluster should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListClusters",
+            )
+
+        monkeypatch.setattr(eks_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_eks_clusters_region(REGION)
+
+    @mock_aws
+    def test_collect_eks_clusters_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListClusters",
+            )
+
+        monkeypatch.setattr(eks_export, "_scan_eks_clusters_region", boom)
+
+        clusters, failed_regions = eks_export.collect_eks_clusters([REGION])
+
+        assert clusters == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_elasticbeanstalk_export.py
+++ b/tests/test_exporters/test_elasticbeanstalk_export.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for elasticbeanstalk_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import elasticbeanstalk_export  # noqa: E402
+from elasticbeanstalk_export import collect_applications_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_application(client, name):
+    """Create an Elastic Beanstalk application named ``name``."""
+    client.create_application(ApplicationName=name, Description=f"{name} description")
+
+
+class TestCollectApplicationsFromRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_applications(self):
+        client = boto3.client("elasticbeanstalk", region_name=REGION)
+        _create_application(client, "web-app")
+
+        rows = collect_applications_from_region(REGION)
+
+        names = {row["Application Name"] for row in rows}
+        assert "web-app" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("elasticbeanstalk", region_name=REGION)  # region exists, no apps
+
+        rows = collect_applications_from_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One application that fails to process must not discard the whole region."""
+        client = boto3.client("elasticbeanstalk", region_name=REGION)
+        _create_application(client, "good-app")
+        _create_application(client, "bad-app")
+
+        original = elasticbeanstalk_export._build_application_row
+
+        def raise_for_bad(app, region):
+            if app.get("ApplicationName") == "bad-app":
+                raise KeyError("SomeUnexpectedField")
+            return original(app, region)
+
+        monkeypatch.setattr(elasticbeanstalk_export, "_build_application_row", raise_for_bad)
+
+        rows = collect_applications_from_region(REGION)
+
+        names = {row["Application Name"] for row in rows}
+        assert "good-app" in names, "healthy application was lost when a sibling failed"
+        assert "bad-app" not in names, "malformed application should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeApplications",
+            )
+
+        monkeypatch.setattr(elasticbeanstalk_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_applications_from_region(REGION)
+
+    @mock_aws
+    def test_collect_applications_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        while still writing the always-on Summary sheet workbook.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeApplications",
+            )
+
+        monkeypatch.setattr(elasticbeanstalk_export, "collect_applications_from_region", boom)
+
+        applications, failed_regions = elasticbeanstalk_export.collect_applications([REGION])
+
+        assert applications == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -73,6 +73,7 @@ _EXCLUDED = {
     #   codecommit:ListRepositories         -> NotImplementedError
     #   savingsplans:DescribeSavingsPlans   -> 404 "Not yet implemented"
     #   transfer:ListServers                -> NotImplementedError
+    #   apprunner:ListServices              -> 404 "Not yet implemented"
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -83,6 +84,7 @@ _EXCLUDED = {
     "codecommit_export.py",
     "savings_plans_export.py",
     "transfer_family_export.py",
+    "apprunner_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **First Tier-3 (PARTIAL) phase — Batch F: app services (8 exporters).** Builds on the completed Tier-1+Tier-2 (#234, #237–#241).

## Tier-3 nuance
PARTIAL exporters already write a forced Summary sheet, so a workbook always lands (unlike Tier-2's no-file case). This fix **preserves** that always-written-summary behavior and **layers** failed-scope tracking + `*-FAILED-*.txt` marker + non-zero exit on top. Genuine-empty stays exit 0; any real scope failure now writes the marker and exits 1.

## What
| Exporter | Slug |
|---|---|
| api_gateway | `api-gateway` |
| appsync | `appsync` |
| cloudmap | `cloudmap` |
| cognito | `cognito` |
| ecs | `ecs-resources` |
| eks | `eks` |
| elasticbeanstalk | `elasticbeanstalk` |
| apprunner | `apprunner` |

Primary scope collector RAISES on error → `scan_regions_concurrent(collect_failures=True)` → per-item `_build_*_row` guard → preserved Summary → `report_collection_failures` + `sys.exit(1)`. `ecs` guards `cluster['clusterName']` + service subscripts. Enrichment sheets (stages, data sources, node groups, environments, etc.) stay graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite. **Batch-F suites: 38 passed. Full suite: 986 passed, 2 skipped. `ruff check .` clean (py39 floor).**

## test_smoke.py exclusion
Only `apprunner_export` added to `_EXCLUDED` — moto has no App Runner backend (`ListServices` → 404). **cognito and api_gateway are deliberately NOT excluded**: their moto backends need optional deps (`joserfc`, `openapi_spec_validator`) that CI installs via `moto[all]`, so they pass in CI (verified locally by installing a crypto-compatible `joserfc` → cognito 6/6 green). Excluding them would have masked real coverage.

## Remaining
Tier-3 batches **G** data/analytics, **H** security/identity, **I** devops/governance, **J** cost/compute, **K** networking/misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)