### PR TITLE
Silent collection failure: Tier-3g (data & analytics exporters)

### DIFF
--- a/scripts/documentdb_export.py
+++ b/scripts/documentdb_export.py
@@ -58,123 +58,163 @@ def calculate_documentdb_instance_monthly_cost(instance_class: str, pricing_data
     return round(float(monthly), 2)
 
 
+def _build_cluster_row(cluster: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single DocumentDB cluster export row from a describe response."""
+    cluster_id = cluster.get('DBClusterIdentifier', 'N/A')
+
+    # Basic cluster information
+    engine = cluster.get('Engine', 'N/A')
+    engine_version = cluster.get('EngineVersion', 'N/A')
+    status = cluster.get('Status', 'unknown')
+
+    # Endpoint information
+    endpoint = cluster.get('Endpoint', 'N/A')
+    reader_endpoint = cluster.get('ReaderEndpoint', 'N/A')
+    port = cluster.get('Port', 0)
+
+    # Member instances
+    cluster_members = cluster.get('DBClusterMembers', [])
+    member_count = len(cluster_members)
+
+    # Primary instance identifier
+    primary_instance = 'N/A'
+    for member in cluster_members:
+        if member.get('IsClusterWriter', False):
+            primary_instance = member.get('DBInstanceIdentifier', 'N/A')
+            break
+
+    # Multi-AZ and availability zones
+    multi_az = cluster.get('MultiAZ', False)
+    availability_zones = cluster.get('AvailabilityZones', [])
+    az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
+
+    # Backup configuration
+    backup_retention_period = cluster.get('BackupRetentionPeriod', 0)
+    preferred_backup_window = cluster.get('PreferredBackupWindow', 'N/A')
+    preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
+
+    # Encryption
+    storage_encrypted = cluster.get('StorageEncrypted', False)
+    kms_key_id = cluster.get('KmsKeyId', 'N/A')
+    if kms_key_id != 'N/A' and '/' in kms_key_id:
+        kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
+
+    # Deletion protection
+    deletion_protection = cluster.get('DeletionProtection', False)
+
+    # Cluster creation time
+    cluster_create_time = cluster.get('ClusterCreateTime')
+    if cluster_create_time:
+        cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
+    else:
+        cluster_create_time_str = 'N/A'
+
+    # VPC security groups
+    vpc_security_groups = cluster.get('VpcSecurityGroups', [])
+    security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
+    security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
+
+    # DB subnet group
+    db_subnet_group = cluster.get('DBSubnetGroup', 'N/A')
+    if isinstance(db_subnet_group, dict):
+        db_subnet_group = db_subnet_group.get('DBSubnetGroupName', 'N/A')
+
+    # Cluster parameter group
+    db_cluster_parameter_group = cluster.get('DBClusterParameterGroup', 'N/A')
+
+    # Enabled CloudWatch logs exports
+    enabled_cloudwatch_logs_exports = cluster.get('EnabledCloudwatchLogsExports', [])
+    logs_exports_str = ', '.join(enabled_cloudwatch_logs_exports) if enabled_cloudwatch_logs_exports else 'None'
+
+    return {
+        'Region': region,
+        'Cluster ID': cluster_id,
+        'Engine': engine,
+        'Engine Version': engine_version,
+        'Status': status,
+        'Endpoint': endpoint,
+        'Reader Endpoint': reader_endpoint,
+        'Port': port,
+        'Member Instances': member_count,
+        'Primary Instance': primary_instance,
+        'Multi-AZ': 'Yes' if multi_az else 'No',
+        'Availability Zones': az_list,
+        'Backup Retention (Days)': backup_retention_period,
+        'Backup Window': preferred_backup_window,
+        'Maintenance Window': preferred_maintenance_window,
+        'Storage Encrypted': 'Yes' if storage_encrypted else 'No',
+        'KMS Key ID': kms_key_id if storage_encrypted else 'N/A',
+        'Deletion Protection': 'Yes' if deletion_protection else 'No',
+        'Created': cluster_create_time_str,
+        'Security Groups': security_groups_str,
+        'Subnet Group': db_subnet_group,
+        'Parameter Group': db_cluster_parameter_group,
+        'CloudWatch Logs': logs_exports_str,
+    }
+
+
 def _scan_documentdb_clusters_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for DocumentDB clusters."""
+    """
+    Collect DocumentDB clusters from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no DocumentDB clusters" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed clusters are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     clusters_data = []
 
-    try:
-        docdb_client = utils.get_boto3_client('docdb', region_name=region)
+    docdb_client = utils.get_boto3_client('docdb', region_name=region)
 
-        paginator = docdb_client.get_paginator('describe_db_clusters')
-        for page in paginator.paginate():
-            db_clusters = page.get('DBClusters', [])
+    paginator = docdb_client.get_paginator('describe_db_clusters')
+    for page in paginator.paginate():
+        db_clusters = page.get('DBClusters', [])
 
-            for cluster in db_clusters:
-                cluster_id = cluster.get('DBClusterIdentifier', 'N/A')
-
-                # Basic cluster information
-                engine = cluster.get('Engine', 'N/A')
-                engine_version = cluster.get('EngineVersion', 'N/A')
-                status = cluster.get('Status', 'unknown')
-
-                # Endpoint information
-                endpoint = cluster.get('Endpoint', 'N/A')
-                reader_endpoint = cluster.get('ReaderEndpoint', 'N/A')
-                port = cluster.get('Port', 0)
-
-                # Member instances
-                cluster_members = cluster.get('DBClusterMembers', [])
-                member_count = len(cluster_members)
-
-                # Primary instance identifier
-                primary_instance = 'N/A'
-                for member in cluster_members:
-                    if member.get('IsClusterWriter', False):
-                        primary_instance = member.get('DBInstanceIdentifier', 'N/A')
-                        break
-
-                # Multi-AZ and availability zones
-                multi_az = cluster.get('MultiAZ', False)
-                availability_zones = cluster.get('AvailabilityZones', [])
-                az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
-
-                # Backup configuration
-                backup_retention_period = cluster.get('BackupRetentionPeriod', 0)
-                preferred_backup_window = cluster.get('PreferredBackupWindow', 'N/A')
-                preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
-
-                # Encryption
-                storage_encrypted = cluster.get('StorageEncrypted', False)
-                kms_key_id = cluster.get('KmsKeyId', 'N/A')
-                if kms_key_id != 'N/A' and '/' in kms_key_id:
-                    kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
-
-                # Deletion protection
-                deletion_protection = cluster.get('DeletionProtection', False)
-
-                # Cluster creation time
-                cluster_create_time = cluster.get('ClusterCreateTime')
-                if cluster_create_time:
-                    cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
-                else:
-                    cluster_create_time_str = 'N/A'
-
-                # VPC security groups
-                vpc_security_groups = cluster.get('VpcSecurityGroups', [])
-                security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
-                security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
-
-                # DB subnet group
-                db_subnet_group = cluster.get('DBSubnetGroup', 'N/A')
-                if isinstance(db_subnet_group, dict):
-                    db_subnet_group = db_subnet_group.get('DBSubnetGroupName', 'N/A')
-
-                # Cluster parameter group
-                db_cluster_parameter_group = cluster.get('DBClusterParameterGroup', 'N/A')
-
-                # Enabled CloudWatch logs exports
-                enabled_cloudwatch_logs_exports = cluster.get('EnabledCloudwatchLogsExports', [])
-                logs_exports_str = ', '.join(enabled_cloudwatch_logs_exports) if enabled_cloudwatch_logs_exports else 'None'
-
-                clusters_data.append({
-                    'Region': region,
-                    'Cluster ID': cluster_id,
-                    'Engine': engine,
-                    'Engine Version': engine_version,
-                    'Status': status,
-                    'Endpoint': endpoint,
-                    'Reader Endpoint': reader_endpoint,
-                    'Port': port,
-                    'Member Instances': member_count,
-                    'Primary Instance': primary_instance,
-                    'Multi-AZ': 'Yes' if multi_az else 'No',
-                    'Availability Zones': az_list,
-                    'Backup Retention (Days)': backup_retention_period,
-                    'Backup Window': preferred_backup_window,
-                    'Maintenance Window': preferred_maintenance_window,
-                    'Storage Encrypted': 'Yes' if storage_encrypted else 'No',
-                    'KMS Key ID': kms_key_id if storage_encrypted else 'N/A',
-                    'Deletion Protection': 'Yes' if deletion_protection else 'No',
-                    'Created': cluster_create_time_str,
-                    'Security Groups': security_groups_str,
-                    'Subnet Group': db_subnet_group,
-                    'Parameter Group': db_cluster_parameter_group,
-                    'CloudWatch Logs': logs_exports_str,
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting DocumentDB clusters in {region}", e)
+        for cluster in db_clusters:
+            try:
+                clusters_data.append(_build_cluster_row(cluster, region))
+            except Exception as e:
+                # One malformed cluster is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed DocumentDB cluster in {region}: "
+                    f"{cluster.get('DBClusterIdentifier', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return clusters_data
 
 
-@utils.aws_error_handler("Collecting DocumentDB clusters", default_return=[])
-def collect_documentdb_clusters(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect DocumentDB cluster information from AWS regions."""
-    results = utils.scan_regions_concurrent(regions, _scan_documentdb_clusters_region)
-    all_clusters = [cluster for result in results for cluster in result]
+def collect_documentdb_clusters(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect DocumentDB cluster information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(clusters, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_documentdb_clusters_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_clusters = [cluster for result in region_results for cluster in result]
     utils.log_success(f"Collected {len(all_clusters)} DocumentDB clusters")
-    return all_clusters
+    return all_clusters, failed_regions
 
 
 def _scan_documentdb_instances_region(region: str) -> list[dict[str, Any]]:
@@ -519,7 +559,11 @@ def generate_summary(clusters: list[dict[str, Any]],
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect DocumentDB data and write the Excel export."""
     print("\n=== Collecting DocumentDB Data ===")
-    clusters = collect_documentdb_clusters(regions)
+    # Primary scope (clusters): region failures must propagate as
+    # failed_regions, never collapse into "empty".
+    clusters, failed_regions = collect_documentdb_clusters(regions)
+    # Enrichment scopes: degrade gracefully; a region-level failure here does
+    # not fail the whole export.
     instances = collect_documentdb_instances(regions)
     snapshots = collect_documentdb_snapshots(regions)
     subnet_groups = collect_documentdb_subnet_groups(regions)
@@ -561,6 +605,20 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary DocumentDB clusters scope collection,
+    # make it loud: write a marker and exit non-zero, even though the
+    # always-written Summary sheet means a workbook still landed. A
+    # complete-looking file that silently hides a zero-row scope is exactly
+    # the failure mode this guards against. A genuinely empty account (every
+    # region succeeded, none had clusters) stays a plain export, exit 0.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'documentdb', failed_regions)
+        print(
+            "\nERROR: DocumentDB export completed with failures — data is incomplete. "
+            "See the *-documentdb-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/glacier_export.py
+++ b/scripts/glacier_export.py
@@ -29,103 +29,149 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export S3 Glacier vaults to Excel")
 
+def _build_vault_row(vault: dict[str, Any], region: str, glacier_client) -> dict[str, Any]:
+    """
+    Build a single Glacier vault export row.
+
+    Per-vault enrichment calls (access policy, lock policy, notifications,
+    tags) remain best-effort: each is wrapped in its own try/except so a
+    missing/denied enrichment call degrades gracefully instead of losing the
+    whole vault.
+    """
+    vault_name = vault.get('VaultName', 'N/A')
+    vault_arn = vault.get('VaultARN', 'N/A')
+
+    # Get vault access policy
+    vault_policy = 'N/A'
+    try:
+        policy_response = glacier_client.get_vault_access_policy(vaultName=vault_name)
+        vault_policy = policy_response.get('policy', {}).get('Policy', 'N/A')
+    except Exception:
+        pass
+
+    # Get vault lock policy
+    lock_policy = 'N/A'
+    lock_state = 'N/A'
+    try:
+        lock_response = glacier_client.get_vault_lock(vaultName=vault_name)
+        lock_policy = lock_response.get('Policy', 'N/A')
+        lock_state = lock_response.get('State', 'N/A')
+    except Exception:
+        pass
+
+    # Get vault notifications
+    sns_topic = 'N/A'
+    events_str = 'N/A'
+    try:
+        notif_response = glacier_client.get_vault_notifications(vaultName=vault_name)
+        notification_cfg = notif_response.get('vaultNotificationConfig', {})
+        sns_topic = notification_cfg.get('SNSTopic', 'N/A')
+        events = notification_cfg.get('Events', [])
+        events_str = ', '.join(events) if events else 'N/A'
+    except Exception:
+        pass
+
+    # Get vault tags
+    tags_str = 'None'
+    try:
+        tags_response = glacier_client.list_tags_for_vault(vaultName=vault_name)
+        tags = tags_response.get('Tags', {})
+        if tags:
+            tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()])
+    except Exception:
+        pass
+
+    creation_date = vault.get('CreationDate', 'N/A')
+    if creation_date != 'N/A' and isinstance(creation_date, datetime):
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_inventory = vault.get('LastInventoryDate', 'N/A')
+    if last_inventory != 'N/A' and isinstance(last_inventory, datetime):
+        last_inventory = last_inventory.strftime('%Y-%m-%d %H:%M:%S')
+
+    size_bytes = vault.get('SizeInBytes', 0)
+    size_gb = round(size_bytes / (1024**3), 2) if size_bytes else 0
+
+    return {
+        'Region': region,
+        'Vault Name': vault_name,
+        'Number of Archives': vault.get('NumberOfArchives', 0),
+        'Size (GB)': size_gb,
+        'Size (Bytes)': size_bytes,
+        'Created': creation_date,
+        'Last Inventory': last_inventory,
+        'Has Access Policy': 'Yes' if vault_policy != 'N/A' else 'No',
+        'Has Lock Policy': 'Yes' if lock_policy != 'N/A' else 'No',
+        'Lock State': lock_state,
+        'Has Notifications': 'Yes' if sns_topic != 'N/A' else 'No',
+        'SNS Topic': sns_topic,
+        'Notification Events': events_str,
+        'Tags': tags_str,
+        'ARN': vault_arn
+    }
+
+
 def _scan_vaults_region(region: str) -> list[dict[str, Any]]:
-    """Scan Glacier vaults in a single region."""
+    """
+    Collect Glacier vaults from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no vaults" (the silent-
+    collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed vaults are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_vaults = []
     glacier_client = utils.get_boto3_client('glacier', region_name=region)
 
-    try:
-        paginator = glacier_client.get_paginator('list_vaults')
-        for page in paginator.paginate():
-            vaults = page.get('VaultList', [])
+    paginator = glacier_client.get_paginator('list_vaults')
+    for page in paginator.paginate():
+        vaults = page.get('VaultList', [])
 
-            for vault in vaults:
-                vault_name = vault.get('VaultName', 'N/A')
-                vault_arn = vault.get('VaultARN', 'N/A')
-
-                # Get vault access policy
-                vault_policy = 'N/A'
-                try:
-                    policy_response = glacier_client.get_vault_access_policy(vaultName=vault_name)
-                    vault_policy = policy_response.get('policy', {}).get('Policy', 'N/A')
-                except Exception:
-                    pass
-
-                # Get vault lock policy
-                lock_policy = 'N/A'
-                lock_state = 'N/A'
-                try:
-                    lock_response = glacier_client.get_vault_lock(vaultName=vault_name)
-                    lock_policy = lock_response.get('Policy', 'N/A')
-                    lock_state = lock_response.get('State', 'N/A')
-                except Exception:
-                    pass
-
-                # Get vault notifications
-                sns_topic = 'N/A'
-                events_str = 'N/A'
-                try:
-                    notif_response = glacier_client.get_vault_notifications(vaultName=vault_name)
-                    notification_cfg = notif_response.get('vaultNotificationConfig', {})
-                    sns_topic = notification_cfg.get('SNSTopic', 'N/A')
-                    events = notification_cfg.get('Events', [])
-                    events_str = ', '.join(events) if events else 'N/A'
-                except Exception:
-                    pass
-
-                # Get vault tags
-                tags_str = 'None'
-                try:
-                    tags_response = glacier_client.list_tags_for_vault(vaultName=vault_name)
-                    tags = tags_response.get('Tags', {})
-                    if tags:
-                        tags_str = ', '.join([f"{k}={v}" for k, v in tags.items()])
-                except Exception:
-                    pass
-
-                creation_date = vault.get('CreationDate', 'N/A')
-                if creation_date != 'N/A' and isinstance(creation_date, datetime):
-                    creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S')
-
-                last_inventory = vault.get('LastInventoryDate', 'N/A')
-                if last_inventory != 'N/A' and isinstance(last_inventory, datetime):
-                    last_inventory = last_inventory.strftime('%Y-%m-%d %H:%M:%S')
-
-                size_bytes = vault.get('SizeInBytes', 0)
-                size_gb = round(size_bytes / (1024**3), 2) if size_bytes else 0
-
-                regional_vaults.append({
-                    'Region': region,
-                    'Vault Name': vault_name,
-                    'Number of Archives': vault.get('NumberOfArchives', 0),
-                    'Size (GB)': size_gb,
-                    'Size (Bytes)': size_bytes,
-                    'Created': creation_date,
-                    'Last Inventory': last_inventory,
-                    'Has Access Policy': 'Yes' if vault_policy != 'N/A' else 'No',
-                    'Has Lock Policy': 'Yes' if lock_policy != 'N/A' else 'No',
-                    'Lock State': lock_state,
-                    'Has Notifications': 'Yes' if sns_topic != 'N/A' else 'No',
-                    'SNS Topic': sns_topic,
-                    'Notification Events': events_str,
-                    'Tags': tags_str,
-                    'ARN': vault_arn
-                })
-
-    except Exception as e:
-        utils.log_warning(f"Error listing vaults in {region}: {str(e)}")
+        for vault in vaults:
+            try:
+                regional_vaults.append(_build_vault_row(vault, region, glacier_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Glacier vault in {region}: "
+                    f"{vault.get('VaultName', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return regional_vaults
 
 
-@utils.aws_error_handler("Collecting Glacier vaults", default_return=[])
-def collect_vaults(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Glacier vault information from AWS regions."""
+def collect_vaults(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Glacier vault information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(vaults, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING GLACIER VAULTS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_vaults_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_vaults_region,
+        show_progress=True,
+        collect_failures=True,
+    )
     all_vaults = [vault for result in results for vault in result]
     utils.log_success(f"Total vaults collected: {len(all_vaults)}")
-    return all_vaults
+    return all_vaults, failed_regions
 
 
 def generate_summary(vaults: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -219,7 +265,7 @@ def main():
     # Collect data
     print("\nCollecting Glacier vault data...")
 
-    vaults = collect_vaults(regions)
+    vaults, failed_regions = collect_vaults(regions)
     summary = generate_summary(vaults)
 
     # Create DataFrames
@@ -264,6 +310,19 @@ def main():
         utils.log_warning("No Glacier vaults found to export")
 
     utils.log_success("Glacier export completed successfully")
+
+    # If ANY region failed the primary vault scope collection, make it loud:
+    # write a marker and exit non-zero, even though the Summary sheet (and
+    # any collected data) was still exported above. A complete-looking
+    # workbook with silently zero/partial rows is exactly the failure mode
+    # this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'glacier', failed_regions)
+        print(
+            "\nERROR: Glacier export completed with failures — data is incomplete. "
+            "See the *-glacier-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/glue_athena_export.py
+++ b/scripts/glue_athena_export.py
@@ -32,256 +32,476 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Glue and Athena resources to Excel")
 
+
 def _scan_glue_databases_region(region: str) -> list[dict[str, Any]]:
-    """Scan Glue databases in a single region."""
+    """
+    Scan Glue databases in a single region.
+
+    This is one of six primary scope collectors (databases, tables, crawlers,
+    jobs, Athena workgroups, Athena data catalogs). It deliberately does NOT
+    swallow region-level errors: an API/permission failure here must
+    propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no Glue
+    databases" (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed databases are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_databases = []
+    glue_client = utils.get_boto3_client('glue', region_name=region)
+    paginator = glue_client.get_paginator('get_databases')
 
-    try:
-        glue_client = utils.get_boto3_client('glue', region_name=region)
-        paginator = glue_client.get_paginator('get_databases')
-        for page in paginator.paginate():
-            databases = page.get('DatabaseList', [])
+    for page in paginator.paginate():
+        databases = page.get('DatabaseList', [])
 
-            for db in databases:
-                db_name = db.get('Name', 'N/A')
-                description = db.get('Description', 'N/A')
-                location_uri = db.get('LocationUri', 'N/A')
-
-                # Creation time
-                create_time = db.get('CreateTime')
-                if create_time:
-                    create_time_str = create_time.strftime('%Y-%m-%d %H:%M:%S')
-                else:
-                    create_time_str = 'N/A'
-
-                # Catalog ID
-                catalog_id = db.get('CatalogId', 'N/A')
-
-                regional_databases.append({
-                    'Region': region,
-                    'Database Name': db_name,
-                    'Description': description,
-                    'Location URI': location_uri,
-                    'Catalog ID': catalog_id,
-                    'Created': create_time_str,
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting Glue databases in {region}", e)
+        for db in databases:
+            try:
+                regional_databases.append(_build_database_row(db, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Glue database in {region}: "
+                    f"{db.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return regional_databases
 
 
-@utils.aws_error_handler("Collecting Glue databases", default_return=[])
-def collect_glue_databases(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect AWS Glue database information from AWS regions."""
+def _build_database_row(db: dict, region: str) -> dict[str, Any]:
+    """Build a single Glue database export row."""
+    db_name = db.get('Name', 'N/A')
+    description = db.get('Description', 'N/A')
+    location_uri = db.get('LocationUri', 'N/A')
+
+    create_time = db.get('CreateTime')
+    create_time_str = create_time.strftime('%Y-%m-%d %H:%M:%S') if create_time else 'N/A'
+
+    catalog_id = db.get('CatalogId', 'N/A')
+
+    return {
+        'Region': region,
+        'Database Name': db_name,
+        'Description': description,
+        'Location URI': location_uri,
+        'Catalog ID': catalog_id,
+        'Created': create_time_str,
+    }
+
+
+def collect_glue_databases(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AWS Glue database information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(databases, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING GLUE DATABASES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_glue_databases_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_glue_databases_region, show_progress=True, collect_failures=True
+    )
     all_databases = [db for result in results for db in result]
     utils.log_success(f"Total Glue databases collected: {len(all_databases)}")
-    return all_databases
-
+    return all_databases, failed_regions
 
 
 def _scan_glue_tables_region(region: str) -> list[dict[str, Any]]:
-    """Scan Glue tables in a single region."""
+    """
+    Scan Glue tables in a single region.
+
+    Fetching the region's database list is the scope's top-level call and is
+    NOT swallowed — its failure must propagate so the region is recorded as
+    failed. Fetching tables for one specific database, and building one
+    table's row, are per-item operations: they are logged and skipped so a
+    single bad database/table does not discard the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_tables = []
-    try:
-        glue_client = utils.get_boto3_client('glue', region_name=region)
+    glue_client = utils.get_boto3_client('glue', region_name=region)
+
+    databases = []
+    db_paginator = glue_client.get_paginator('get_databases')
+    for page in db_paginator.paginate():
+        databases.extend(page.get('DatabaseList', []))
+
+    for db in databases:
+        db_name = db.get('Name', '')
         try:
-            databases = []
-            db_paginator = glue_client.get_paginator('get_databases')
-            for page in db_paginator.paginate():
-                databases.extend(page.get('DatabaseList', []))
+            paginator = glue_client.get_paginator('get_tables')
+            for page in paginator.paginate(DatabaseName=db_name):
+                tables = page.get('TableList', [])
+                for table in tables:
+                    try:
+                        regional_tables.append(_build_table_row(table, region, db_name))
+                    except Exception as e:
+                        utils.log_error(
+                            f"Skipping malformed Glue table in {region}/{db_name}: "
+                            f"{table.get('Name', '<unknown>')}",
+                            e,
+                        )
+                        continue
         except Exception as e:
-            utils.log_warning(f"Could not list databases in {region}: {str(e)}")
-            return regional_tables
-        for db in databases:
-            db_name = db.get('Name', '')
-            try:
-                paginator = glue_client.get_paginator('get_tables')
-                for page in paginator.paginate(DatabaseName=db_name):
-                    tables = page.get('TableList', [])
-                    for table in tables:
-                        table_name = table.get('Name', 'N/A')
-                        description = table.get('Description', 'N/A')
-                        storage_descriptor = table.get('StorageDescriptor', {})
-                        location = storage_descriptor.get('Location', 'N/A')
-                        input_format = storage_descriptor.get('InputFormat', 'N/A')
-                        output_format = storage_descriptor.get('OutputFormat', 'N/A')
-                        serde_info = storage_descriptor.get('SerdeInfo', {})
-                        serialization_library = serde_info.get('SerializationLibrary', 'N/A')
-                        columns = storage_descriptor.get('Columns', [])
-                        column_count = len(columns)
-                        partition_keys = table.get('PartitionKeys', [])
-                        partition_count = len(partition_keys)
-                        partition_names = [pk.get('Name', '') for pk in partition_keys]
-                        partition_names_str = ', '.join(partition_names) if partition_names else 'None'
-                        table_type = table.get('TableType', 'N/A')
-                        create_time = table.get('CreateTime')
-                        create_time_str = create_time.strftime('%Y-%m-%d %H:%M:%S') if create_time else 'N/A'
-                        update_time = table.get('UpdateTime')
-                        update_time_str = update_time.strftime('%Y-%m-%d %H:%M:%S') if update_time else 'N/A'
-                        regional_tables.append({'Region': region, 'Database': db_name, 'Table Name': table_name, 'Description': description, 'Table Type': table_type, 'Location': location, 'Column Count': column_count, 'Partition Keys': partition_names_str, 'Partition Count': partition_count, 'Input Format': input_format, 'Output Format': output_format, 'Serialization Library': serialization_library, 'Created': create_time_str, 'Updated': update_time_str})
-            except Exception as e:
-                utils.log_warning(f"Could not get tables for database {db_name}: {str(e)}")
-    except Exception as e:
-        utils.log_error(f"Error collecting Glue tables in {region}", e)
+            utils.log_warning(f"Could not get tables for database {db_name}: {str(e)}")
+
     return regional_tables
 
 
+def _build_table_row(table: dict, region: str, db_name: str) -> dict[str, Any]:
+    """Build a single Glue table export row."""
+    table_name = table.get('Name', 'N/A')
+    description = table.get('Description', 'N/A')
+    storage_descriptor = table.get('StorageDescriptor', {})
+    location = storage_descriptor.get('Location', 'N/A')
+    input_format = storage_descriptor.get('InputFormat', 'N/A')
+    output_format = storage_descriptor.get('OutputFormat', 'N/A')
+    serde_info = storage_descriptor.get('SerdeInfo', {})
+    serialization_library = serde_info.get('SerializationLibrary', 'N/A')
+    columns = storage_descriptor.get('Columns', [])
+    column_count = len(columns)
+    partition_keys = table.get('PartitionKeys', [])
+    partition_count = len(partition_keys)
+    partition_names = [pk.get('Name', '') for pk in partition_keys]
+    partition_names_str = ', '.join(partition_names) if partition_names else 'None'
+    table_type = table.get('TableType', 'N/A')
+    create_time = table.get('CreateTime')
+    create_time_str = create_time.strftime('%Y-%m-%d %H:%M:%S') if create_time else 'N/A'
+    update_time = table.get('UpdateTime')
+    update_time_str = update_time.strftime('%Y-%m-%d %H:%M:%S') if update_time else 'N/A'
+
+    return {
+        'Region': region,
+        'Database': db_name,
+        'Table Name': table_name,
+        'Description': description,
+        'Table Type': table_type,
+        'Location': location,
+        'Column Count': column_count,
+        'Partition Keys': partition_names_str,
+        'Partition Count': partition_count,
+        'Input Format': input_format,
+        'Output Format': output_format,
+        'Serialization Library': serialization_library,
+        'Created': create_time_str,
+        'Updated': update_time_str,
+    }
+
+
+def collect_glue_tables(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AWS Glue table information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(tables, failed_regions)``.
+    """
+    print("\n=== COLLECTING GLUE TABLES ===")
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_glue_tables_region, show_progress=True, collect_failures=True
+    )
+    all_tables = [table for result in results for table in result]
+    utils.log_success(f"Total Glue tables collected: {len(all_tables)}")
+    return all_tables, failed_regions
+
+
 def _scan_glue_crawlers_region(region: str) -> list[dict[str, Any]]:
-    """Scan Glue crawlers in a single region."""
+    """Scan Glue crawlers in a single region. Region-level failures propagate."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_crawlers = []
-    try:
-        glue_client = utils.get_boto3_client('glue', region_name=region)
-        paginator = glue_client.get_paginator('get_crawlers')
-        for page in paginator.paginate():
-            for crawler in page.get('Crawlers', []):
-                role = crawler.get('Role', 'N/A')
-                if role != 'N/A' and '/' in role:
-                    role = role.split('/')[-1]
-                targets = crawler.get('Targets', {})
-                s3_targets = targets.get('S3Targets', [])
-                s3_paths = [t.get('Path', '') for t in s3_targets]
-                s3_paths_str = ', '.join(s3_paths[:3]) if s3_paths else 'None'
-                if len(s3_paths) > 3:
-                    s3_paths_str += f' (+{len(s3_paths) - 3} more)'
-                schedule = crawler.get('Schedule', {})
-                classifiers = crawler.get('Classifiers', [])
-                schema_change_policy = crawler.get('SchemaChangePolicy', {})
-                recrawl_policy = crawler.get('RecrawlPolicy', {})
-                last_crawl = crawler.get('LastCrawl', {})
-                creation_time = crawler.get('CreationTime')
-                regional_crawlers.append({'Region': region, 'Crawler Name': crawler.get('Name', 'N/A'), 'State': crawler.get('State', 'N/A'), 'Database': crawler.get('DatabaseName', 'N/A'), 'Role': role, 'S3 Targets': len(s3_targets), 'S3 Paths': s3_paths_str, 'JDBC Targets': len(targets.get('JdbcTargets', [])), 'DynamoDB Targets': len(targets.get('DynamoDBTargets', [])), 'Schedule': schedule.get('ScheduleExpression', 'N/A') if schedule else 'N/A', 'Classifiers': ', '.join(classifiers) if classifiers else 'Default', 'Update Behavior': schema_change_policy.get('UpdateBehavior', 'N/A'), 'Delete Behavior': schema_change_policy.get('DeleteBehavior', 'N/A'), 'Recrawl Behavior': recrawl_policy.get('RecrawlBehavior', 'N/A'), 'Last Crawl Status': last_crawl.get('Status', 'Never run') if last_crawl else 'Never run', 'Created': creation_time.strftime('%Y-%m-%d %H:%M:%S') if creation_time else 'N/A'})
-    except Exception as e:
-        utils.log_error(f"Error collecting Glue crawlers in {region}", e)
+    glue_client = utils.get_boto3_client('glue', region_name=region)
+    paginator = glue_client.get_paginator('get_crawlers')
+
+    for page in paginator.paginate():
+        for crawler in page.get('Crawlers', []):
+            try:
+                regional_crawlers.append(_build_crawler_row(crawler, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Glue crawler in {region}: "
+                    f"{crawler.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
+
     return regional_crawlers
 
 
+def _build_crawler_row(crawler: dict, region: str) -> dict[str, Any]:
+    """Build a single Glue crawler export row."""
+    role = crawler.get('Role', 'N/A')
+    if role != 'N/A' and '/' in role:
+        role = role.split('/')[-1]
+    targets = crawler.get('Targets', {})
+    s3_targets = targets.get('S3Targets', [])
+    s3_paths = [t.get('Path', '') for t in s3_targets]
+    s3_paths_str = ', '.join(s3_paths[:3]) if s3_paths else 'None'
+    if len(s3_paths) > 3:
+        s3_paths_str += f' (+{len(s3_paths) - 3} more)'
+    schedule = crawler.get('Schedule', {})
+    classifiers = crawler.get('Classifiers', [])
+    schema_change_policy = crawler.get('SchemaChangePolicy', {})
+    recrawl_policy = crawler.get('RecrawlPolicy', {})
+    last_crawl = crawler.get('LastCrawl', {})
+    creation_time = crawler.get('CreationTime')
+
+    return {
+        'Region': region,
+        'Crawler Name': crawler.get('Name', 'N/A'),
+        'State': crawler.get('State', 'N/A'),
+        'Database': crawler.get('DatabaseName', 'N/A'),
+        'Role': role,
+        'S3 Targets': len(s3_targets),
+        'S3 Paths': s3_paths_str,
+        'JDBC Targets': len(targets.get('JdbcTargets', [])),
+        'DynamoDB Targets': len(targets.get('DynamoDBTargets', [])),
+        'Schedule': schedule.get('ScheduleExpression', 'N/A') if schedule else 'N/A',
+        'Classifiers': ', '.join(classifiers) if classifiers else 'Default',
+        'Update Behavior': schema_change_policy.get('UpdateBehavior', 'N/A'),
+        'Delete Behavior': schema_change_policy.get('DeleteBehavior', 'N/A'),
+        'Recrawl Behavior': recrawl_policy.get('RecrawlBehavior', 'N/A'),
+        'Last Crawl Status': last_crawl.get('Status', 'Never run') if last_crawl else 'Never run',
+        'Created': creation_time.strftime('%Y-%m-%d %H:%M:%S') if creation_time else 'N/A',
+    }
+
+
+def collect_glue_crawlers(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AWS Glue crawler information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(crawlers, failed_regions)``.
+    """
+    print("\n=== COLLECTING GLUE CRAWLERS ===")
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_glue_crawlers_region, show_progress=True, collect_failures=True
+    )
+    all_crawlers = [crawler for result in results for crawler in result]
+    utils.log_success(f"Total Glue crawlers collected: {len(all_crawlers)}")
+    return all_crawlers, failed_regions
+
+
 def _scan_glue_jobs_region(region: str) -> list[dict[str, Any]]:
-    """Scan Glue jobs in a single region."""
+    """Scan Glue jobs in a single region. Region-level failures propagate."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_jobs = []
-    try:
-        glue_client = utils.get_boto3_client('glue', region_name=region)
-        paginator = glue_client.get_paginator('get_jobs')
-        for page in paginator.paginate():
-            for job in page.get('Jobs', []):
-                role = job.get('Role', 'N/A')
-                if role != 'N/A' and '/' in role:
-                    role = role.split('/')[-1]
-                command = job.get('Command', {})
-                connections = job.get('Connections', {})
-                connection_list = connections.get('Connections', [])
-                created_on = job.get('CreatedOn')
-                last_modified_on = job.get('LastModifiedOn')
-                regional_jobs.append({'Region': region, 'Job Name': job.get('Name', 'N/A'), 'Description': job.get('Description', 'N/A'), 'Command': command.get('Name', 'N/A'), 'Role': role, 'Glue Version': job.get('GlueVersion', 'N/A'), 'Worker Type': job.get('WorkerType', 'N/A'), 'Number of Workers': job.get('NumberOfWorkers', 'N/A'), 'Max Capacity': job.get('MaxCapacity', 'N/A'), 'Python Version': command.get('PythonVersion', 'N/A'), 'Script Location': command.get('ScriptLocation', 'N/A'), 'Max Retries': job.get('MaxRetries', 0), 'Timeout (min)': job.get('Timeout', 0), 'Connections': ', '.join(connection_list) if connection_list else 'None', 'Created': created_on.strftime('%Y-%m-%d %H:%M:%S') if created_on else 'N/A', 'Last Modified': last_modified_on.strftime('%Y-%m-%d %H:%M:%S') if last_modified_on else 'N/A'})
-    except Exception as e:
-        utils.log_error(f"Error collecting Glue jobs in {region}", e)
+    glue_client = utils.get_boto3_client('glue', region_name=region)
+    paginator = glue_client.get_paginator('get_jobs')
+
+    for page in paginator.paginate():
+        for job in page.get('Jobs', []):
+            try:
+                regional_jobs.append(_build_job_row(job, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Glue job in {region}: "
+                    f"{job.get('Name', '<unknown>')}",
+                    e,
+                )
+                continue
+
     return regional_jobs
 
 
+def _build_job_row(job: dict, region: str) -> dict[str, Any]:
+    """Build a single Glue job export row."""
+    role = job.get('Role', 'N/A')
+    if role != 'N/A' and '/' in role:
+        role = role.split('/')[-1]
+    command = job.get('Command', {})
+    connections = job.get('Connections', {})
+    connection_list = connections.get('Connections', [])
+    created_on = job.get('CreatedOn')
+    last_modified_on = job.get('LastModifiedOn')
+
+    return {
+        'Region': region,
+        'Job Name': job.get('Name', 'N/A'),
+        'Description': job.get('Description', 'N/A'),
+        'Command': command.get('Name', 'N/A'),
+        'Role': role,
+        'Glue Version': job.get('GlueVersion', 'N/A'),
+        'Worker Type': job.get('WorkerType', 'N/A'),
+        'Number of Workers': job.get('NumberOfWorkers', 'N/A'),
+        'Max Capacity': job.get('MaxCapacity', 'N/A'),
+        'Python Version': command.get('PythonVersion', 'N/A'),
+        'Script Location': command.get('ScriptLocation', 'N/A'),
+        'Max Retries': job.get('MaxRetries', 0),
+        'Timeout (min)': job.get('Timeout', 0),
+        'Connections': ', '.join(connection_list) if connection_list else 'None',
+        'Created': created_on.strftime('%Y-%m-%d %H:%M:%S') if created_on else 'N/A',
+        'Last Modified': last_modified_on.strftime('%Y-%m-%d %H:%M:%S') if last_modified_on else 'N/A',
+    }
+
+
+def collect_glue_jobs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect AWS Glue job information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(jobs, failed_regions)``.
+    """
+    print("\n=== COLLECTING GLUE JOBS ===")
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_glue_jobs_region, show_progress=True, collect_failures=True
+    )
+    all_jobs = [job for result in results for job in result]
+    utils.log_success(f"Total Glue jobs collected: {len(all_jobs)}")
+    return all_jobs, failed_regions
+
+
 def _scan_athena_workgroups_region(region: str) -> list[dict[str, Any]]:
-    """Scan Athena workgroups in a single region."""
+    """
+    Scan Athena workgroups in a single region.
+
+    Listing workgroups is the scope's top-level call and is NOT swallowed —
+    its failure must propagate so the region is recorded as failed. Fetching
+    the full details for one specific workgroup is a per-item operation: it
+    is logged and skipped so a single inaccessible workgroup does not
+    discard the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_workgroups = []
-    try:
-        athena_client = utils.get_boto3_client('athena', region_name=region)
-        next_token = None
-        while True:
-            params = {}
-            params['MaxResults'] = 50
-            if next_token:
-                params['NextToken'] = next_token
-            page = athena_client.list_work_groups(**params)
-            for wg_summary in page.get('WorkGroups', []):
-                workgroup_name = wg_summary.get('Name', 'N/A')
-                try:
-                    wg_response = athena_client.get_work_group(WorkGroup=workgroup_name)
-                    wg = wg_response.get('WorkGroup', {})
-                    configuration = wg.get('Configuration', {})
-                    result_config = configuration.get('ResultConfiguration', {})
-                    encryption_config = result_config.get('EncryptionConfiguration', {})
-                    encryption_option = encryption_config.get('EncryptionOption', 'None')
-                    engine_version = configuration.get('EngineVersion', {})
-                    creation_time = wg.get('CreationTime')
-                    regional_workgroups.append({'Region': region, 'Workgroup Name': workgroup_name, 'State': wg.get('State', 'N/A'), 'Description': wg.get('Description', 'N/A'), 'Output Location': result_config.get('OutputLocation', 'N/A'), 'Encryption': encryption_option, 'KMS Key': encryption_config.get('KmsKey', 'N/A') if encryption_option != 'None' else 'N/A', 'Bytes Scanned Cutoff': configuration.get('BytesScannedCutoffPerQuery', 'N/A'), 'Enforce Config': 'Yes' if configuration.get('EnforceWorkGroupConfiguration', False) else 'No', 'CloudWatch Metrics': 'Yes' if configuration.get('PublishCloudWatchMetricsEnabled', False) else 'No', 'Requester Pays': 'Yes' if configuration.get('RequesterPaysEnabled', False) else 'No', 'Engine Version': engine_version.get('SelectedEngineVersion', 'N/A') if engine_version else 'N/A', 'Created': creation_time.strftime('%Y-%m-%d %H:%M:%S') if creation_time else 'N/A'})
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for workgroup {workgroup_name}: {str(e)}")
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-    except Exception as e:
-        utils.log_error(f"Error collecting Athena workgroups in {region}", e)
+    athena_client = utils.get_boto3_client('athena', region_name=region)
+    next_token = None
+
+    while True:
+        params = {'MaxResults': 50}
+        if next_token:
+            params['NextToken'] = next_token
+        page = athena_client.list_work_groups(**params)
+
+        for wg_summary in page.get('WorkGroups', []):
+            workgroup_name = wg_summary.get('Name', 'N/A')
+            try:
+                wg_response = athena_client.get_work_group(WorkGroup=workgroup_name)
+                wg = wg_response.get('WorkGroup', {})
+                regional_workgroups.append(_build_workgroup_row(wg, region, workgroup_name))
+            except Exception as e:
+                utils.log_warning(f"Could not get details for workgroup {workgroup_name}: {str(e)}")
+
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
+
     return regional_workgroups
 
 
-def _scan_athena_data_catalogs_region(region: str) -> list[dict[str, Any]]:
-    """Scan Athena data catalogs in a single region."""
-    regional_catalogs = []
-    try:
-        athena_client = utils.get_boto3_client('athena', region_name=region)
-        paginator = athena_client.get_paginator('list_data_catalogs')
-        for page in paginator.paginate():
-            for catalog_summary in page.get('DataCatalogsSummary', []):
-                catalog_name = catalog_summary.get('CatalogName', 'N/A')
-                try:
-                    catalog_response = athena_client.get_data_catalog(Name=catalog_name)
-                    catalog = catalog_response.get('DataCatalog', {})
-                    parameters = catalog.get('Parameters', {})
-                    regional_catalogs.append({'Region': region, 'Catalog Name': catalog_name, 'Type': catalog.get('Type', 'N/A'), 'Description': catalog.get('Description', 'N/A'), 'Parameters': ', '.join([f"{k}={v}" for k, v in parameters.items()]) if parameters else 'None'})
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for catalog {catalog_name}: {str(e)}")
-    except Exception as e:
-        utils.log_error(f"Error collecting Athena data catalogs in {region}", e)
-    return regional_catalogs
+def _build_workgroup_row(wg: dict, region: str, workgroup_name: str) -> dict[str, Any]:
+    """Build a single Athena workgroup export row."""
+    configuration = wg.get('Configuration', {})
+    result_config = configuration.get('ResultConfiguration', {})
+    encryption_config = result_config.get('EncryptionConfiguration', {})
+    encryption_option = encryption_config.get('EncryptionOption', 'None')
+    engine_version = configuration.get('EngineVersion', {})
+    creation_time = wg.get('CreationTime')
 
-@utils.aws_error_handler("Collecting Glue tables", default_return=[])
-def collect_glue_tables(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect AWS Glue table information from AWS regions."""
-    print("\n=== COLLECTING GLUE TABLES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_glue_tables_region)
-    all_tables = [table for result in results for table in result]
-    utils.log_success(f"Total Glue tables collected: {len(all_tables)}")
-    return all_tables
-@utils.aws_error_handler("Collecting Glue crawlers", default_return=[])
-def collect_glue_crawlers(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect AWS Glue crawler information from AWS regions."""
-    print("\n=== COLLECTING GLUE CRAWLERS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_glue_crawlers_region)
-    all_crawlers = [crawler for result in results for crawler in result]
-    utils.log_success(f"Total Glue crawlers collected: {len(all_crawlers)}")
-    return all_crawlers
+    return {
+        'Region': region,
+        'Workgroup Name': workgroup_name,
+        'State': wg.get('State', 'N/A'),
+        'Description': wg.get('Description', 'N/A'),
+        'Output Location': result_config.get('OutputLocation', 'N/A'),
+        'Encryption': encryption_option,
+        'KMS Key': encryption_config.get('KmsKey', 'N/A') if encryption_option != 'None' else 'N/A',
+        'Bytes Scanned Cutoff': configuration.get('BytesScannedCutoffPerQuery', 'N/A'),
+        'Enforce Config': 'Yes' if configuration.get('EnforceWorkGroupConfiguration', False) else 'No',
+        'CloudWatch Metrics': 'Yes' if configuration.get('PublishCloudWatchMetricsEnabled', False) else 'No',
+        'Requester Pays': 'Yes' if configuration.get('RequesterPaysEnabled', False) else 'No',
+        'Engine Version': engine_version.get('SelectedEngineVersion', 'N/A') if engine_version else 'N/A',
+        'Created': creation_time.strftime('%Y-%m-%d %H:%M:%S') if creation_time else 'N/A',
+    }
 
 
-@utils.aws_error_handler("Collecting Glue jobs", default_return=[])
-def collect_glue_jobs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect AWS Glue job information from AWS regions."""
-    print("\n=== COLLECTING GLUE JOBS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_glue_jobs_region)
-    all_jobs = [job for result in results for job in result]
-    utils.log_success(f"Total Glue jobs collected: {len(all_jobs)}")
-    return all_jobs
+def collect_athena_workgroups(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Athena workgroup information across regions, surfacing failures.
 
-
-@utils.aws_error_handler("Collecting Athena workgroups", default_return=[])
-def collect_athena_workgroups(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Athena workgroup information from AWS regions."""
+    Returns:
+        tuple: ``(workgroups, failed_regions)``.
+    """
     print("\n=== COLLECTING ATHENA WORKGROUPS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_athena_workgroups_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_athena_workgroups_region, show_progress=True, collect_failures=True
+    )
     all_workgroups = [wg for result in results for wg in result]
     utils.log_success(f"Total Athena workgroups collected: {len(all_workgroups)}")
-    return all_workgroups
+    return all_workgroups, failed_regions
 
 
-@utils.aws_error_handler("Collecting Athena data catalogs", default_return=[])
-def collect_athena_data_catalogs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Athena data catalog information from AWS regions."""
+def _scan_athena_data_catalogs_region(region: str) -> list[dict[str, Any]]:
+    """
+    Scan Athena data catalogs in a single region.
+
+    Listing data catalogs is the scope's top-level call and is NOT swallowed
+    — its failure must propagate so the region is recorded as failed.
+    Fetching the full details for one specific catalog is a per-item
+    operation: it is logged and skipped so a single inaccessible catalog
+    does not discard the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    regional_catalogs = []
+    athena_client = utils.get_boto3_client('athena', region_name=region)
+    paginator = athena_client.get_paginator('list_data_catalogs')
+
+    for page in paginator.paginate():
+        for catalog_summary in page.get('DataCatalogsSummary', []):
+            catalog_name = catalog_summary.get('CatalogName', 'N/A')
+            try:
+                catalog_response = athena_client.get_data_catalog(Name=catalog_name)
+                catalog = catalog_response.get('DataCatalog', {})
+                regional_catalogs.append(_build_catalog_row(catalog, region, catalog_name))
+            except Exception as e:
+                utils.log_warning(f"Could not get details for catalog {catalog_name}: {str(e)}")
+
+    return regional_catalogs
+
+
+def _build_catalog_row(catalog: dict, region: str, catalog_name: str) -> dict[str, Any]:
+    """Build a single Athena data catalog export row."""
+    parameters = catalog.get('Parameters', {})
+
+    return {
+        'Region': region,
+        'Catalog Name': catalog_name,
+        'Type': catalog.get('Type', 'N/A'),
+        'Description': catalog.get('Description', 'N/A'),
+        'Parameters': ', '.join([f"{k}={v}" for k, v in parameters.items()]) if parameters else 'None',
+    }
+
+
+def collect_athena_data_catalogs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Athena data catalog information across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(catalogs, failed_regions)``.
+    """
     print("\n=== COLLECTING ATHENA DATA CATALOGS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_athena_data_catalogs_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_athena_data_catalogs_region, show_progress=True, collect_failures=True
+    )
     all_catalogs = [catalog for result in results for catalog in result]
     utils.log_success(f"Total Athena data catalogs collected: {len(all_catalogs)}")
-    return all_catalogs
-
+    return all_catalogs, failed_regions
 
 
 def generate_summary(databases: list[dict[str, Any]],
@@ -372,14 +592,29 @@ def generate_summary(databases: list[dict[str, Any]],
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Glue and Athena data and write the Excel export."""
-    # Collect data
+    # Collect data. Each collector below is an independent region-scanned
+    # scope (databases, tables, crawlers, jobs, Athena workgroups, Athena
+    # data catalogs); a region-level failure in any of them propagates via
+    # scan_regions_concurrent(..., collect_failures=True) instead of being
+    # silently collapsed into "empty". All six failed_regions lists are
+    # merged into one combined list below (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
     print("\n=== Collecting Glue & Athena Data ===")
-    databases = collect_glue_databases(regions)
-    tables = collect_glue_tables(regions)
-    crawlers = collect_glue_crawlers(regions)
-    jobs = collect_glue_jobs(regions)
-    workgroups = collect_athena_workgroups(regions)
-    catalogs = collect_athena_data_catalogs(regions)
+    databases, failed_databases = collect_glue_databases(regions)
+    tables, failed_tables = collect_glue_tables(regions)
+    crawlers, failed_crawlers = collect_glue_crawlers(regions)
+    jobs, failed_jobs = collect_glue_jobs(regions)
+    workgroups, failed_workgroups = collect_athena_workgroups(regions)
+    catalogs, failed_catalogs = collect_athena_data_catalogs(regions)
+
+    failed_regions = (
+        failed_databases
+        + failed_tables
+        + failed_crawlers
+        + failed_jobs
+        + failed_workgroups
+        + failed_catalogs
+    )
 
     # Generate summary
     summary = generate_summary(databases, tables, crawlers, jobs, workgroups, catalogs)
@@ -413,7 +648,9 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     region_suffix = regions[0] if len(regions) == 1 else 'all-regions'
     filename = utils.create_export_filename(account_name, 'glue-athena', region_suffix)
 
-    # Save to Excel with multiple sheets
+    # Save to Excel with multiple sheets. The Summary sheet is ALWAYS
+    # written (forced), so a workbook lands even when every scope failed —
+    # that must not mask a real failure; see the failed_regions check below.
     print("\n=== Exporting to Excel ===")
     dataframes = {
         'Glue Databases': databases_df,
@@ -426,6 +663,20 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY scope failed in ANY region, make it loud: write a marker and
+    # exit non-zero, even though the always-written Summary sheet means a
+    # workbook still landed. A complete-looking workbook with silently
+    # zero-row data sheets is exactly the failure mode this guards against.
+    # A genuinely empty account (every scope succeeded, nothing found) has
+    # an empty failed_regions list and stays exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'glue-athena', failed_regions)
+        print(
+            "\nERROR: Glue/Athena export completed with failures — data is incomplete. "
+            "See the *-glue-athena-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/lakeformation_export.py
+++ b/scripts/lakeformation_export.py
@@ -13,6 +13,18 @@ Features:
 - Summary: Resource counts and governance metrics
 
 Output: Excel file with 5 worksheets
+
+Silent-collection-failure contract (Tier-3 PARTIAL — see
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md):
+This exporter always writes a workbook, including a forced Summary sheet,
+even when some scopes failed. Each of the four scopes (resources,
+permissions, settings, tags) is region-scanned with
+``collect_failures=True``; any scope's region failures are merged into one
+combined ``failed_regions`` list. If that list is non-empty, a
+``*-lakeformation-FAILED-*.txt`` marker is written via
+``utils.report_collection_failures`` and the script exits non-zero — even
+though a (partial) workbook was already written. A genuinely empty result
+(all scopes/regions succeeded, nothing found) still exits 0 with no marker.
 """
 
 import sys
@@ -31,287 +43,396 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Lake Formation resources and permissions to Excel")
 
 def _scan_lakeformation_resources_region(region: str) -> list[dict[str, Any]]:
-    """Scan Lake Formation resources in a single region."""
+    """
+    Scan Lake Formation resources in a single region.
+
+    Does NOT swallow region-level errors: an API/permission failure must
+    propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no
+    resources" (the silent-collection-loss bug).
+
+    Individual malformed resources are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_resources = []
-    try:
-        lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-        next_token = None
-        while True:
-            params = {}
-            params['MaxResults'] = 50
-            if next_token:
-                params['NextToken'] = next_token
-            page = lf_client.list_resources(**params)
-            resources = page.get('ResourceInfoList', [])
+    lf_client = utils.get_boto3_client('lakeformation', region_name=region)
+    next_token = None
+    while True:
+        params = {}
+        params['MaxResults'] = 50
+        if next_token:
+            params['NextToken'] = next_token
+        page = lf_client.list_resources(**params)
+        resources = page.get('ResourceInfoList', [])
 
-            for resource in resources:
-                resource_arn = resource.get('ResourceArn', 'N/A')
-                role_arn = resource.get('RoleArn', 'N/A')
-
-                # Extract S3 path from ARN
-                if resource_arn.startswith('arn:aws:s3:::'):
-                    s3_path = resource_arn.replace('arn:aws:s3:::', 's3://')
-                else:
-                    s3_path = resource_arn
-
-                # Extract role name from ARN
-                role_name = 'N/A'
-                if role_arn != 'N/A' and '/' in role_arn:
-                    role_name = role_arn.split('/')[-1]
-
-                # Last modified timestamp
-                last_modified = resource.get('LastModified')
-                if last_modified:
-                    last_modified_str = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-                else:
-                    last_modified_str = 'N/A'
-
-                regional_resources.append({
-                    'Region': region,
-                    'S3 Path': s3_path,
-                    'Resource ARN': resource_arn,
-                    'Role Name': role_name,
-                    'Role ARN': role_arn,
-                    'Last Modified': last_modified_str,
-                })
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-    except Exception as e:
-        utils.log_error(f"Error collecting Lake Formation resources in {region}", e)
+        for resource in resources:
+            try:
+                regional_resources.append(_build_resource_row(resource, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Lake Formation resource in {region}: "
+                    f"{resource.get('ResourceArn', '<unknown>')}",
+                    e,
+                )
+                continue
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
     return regional_resources
 
 
+def _build_resource_row(resource: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Lake Formation registered-resource export row."""
+    resource_arn = resource.get('ResourceArn', 'N/A')
+    role_arn = resource.get('RoleArn', 'N/A')
+
+    # Extract S3 path from ARN
+    if resource_arn.startswith('arn:aws:s3:::'):
+        s3_path = resource_arn.replace('arn:aws:s3:::', 's3://')
+    else:
+        s3_path = resource_arn
+
+    # Extract role name from ARN
+    role_name = 'N/A'
+    if role_arn != 'N/A' and '/' in role_arn:
+        role_name = role_arn.split('/')[-1]
+
+    # Last modified timestamp
+    last_modified = resource.get('LastModified')
+    last_modified_str = last_modified.strftime('%Y-%m-%d %H:%M:%S') if last_modified else 'N/A'
+
+    return {
+        'Region': region,
+        'S3 Path': s3_path,
+        'Resource ARN': resource_arn,
+        'Role Name': role_name,
+        'Role ARN': role_arn,
+        'Last Modified': last_modified_str,
+    }
+
+
 def _scan_lakeformation_permissions_region(region: str) -> list[dict[str, Any]]:
-    """Scan Lake Formation permissions in a single region."""
+    """
+    Scan Lake Formation permissions in a single region.
+
+    Does NOT swallow region-level errors — see
+    ``_scan_lakeformation_resources_region`` docstring for the contract.
+    Individual malformed permission entries are skipped (logged).
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_permissions = []
-    try:
-        lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-        next_token = None
-        while True:
-            params = {}
-            params['MaxResults'] = 50
-            if next_token:
-                params['NextToken'] = next_token
-            page = lf_client.list_permissions(**params)
-            permissions = page.get('PrincipalResourcePermissions', [])
+    lf_client = utils.get_boto3_client('lakeformation', region_name=region)
+    next_token = None
+    while True:
+        params = {}
+        params['MaxResults'] = 50
+        if next_token:
+            params['NextToken'] = next_token
+        page = lf_client.list_permissions(**params)
+        permissions = page.get('PrincipalResourcePermissions', [])
 
-            for perm in permissions:
-                # Principal (who has access)
-                principal = perm.get('Principal', {})
-                data_lake_principal_id = principal.get('DataLakePrincipalIdentifier', 'N/A')
-
-                # Extract principal name
-                principal_name = 'N/A'
-                if data_lake_principal_id != 'N/A':
-                    if '/' in data_lake_principal_id:
-                        principal_name = data_lake_principal_id.split('/')[-1]
-                    elif ':' in data_lake_principal_id:
-                        parts = data_lake_principal_id.split(':')
-                        principal_name = parts[-1] if len(parts) > 0 else 'N/A'
-                    else:
-                        principal_name = data_lake_principal_id
-
-                # Resource (what they have access to)
-                resource = perm.get('Resource', {})
-
-                # Determine resource type and details
-                resource_type = 'Unknown'
-                resource_details = 'N/A'
-
-                if 'Catalog' in resource:
-                    resource_type = 'Catalog'
-                    resource_details = 'Data Catalog'
-                elif 'Database' in resource:
-                    resource_type = 'Database'
-                    db_name = resource.get('Database', {}).get('Name', 'N/A')
-                    resource_details = db_name
-                elif 'Table' in resource:
-                    resource_type = 'Table'
-                    table_info = resource.get('Table', {})
-                    db_name = table_info.get('DatabaseName', 'N/A')
-                    table_name = table_info.get('Name', 'N/A')
-                    resource_details = f"{db_name}.{table_name}"
-                elif 'TableWithColumns' in resource:
-                    resource_type = 'Table with Columns'
-                    table_info = resource.get('TableWithColumns', {})
-                    db_name = table_info.get('DatabaseName', 'N/A')
-                    table_name = table_info.get('Name', 'N/A')
-                    columns = table_info.get('ColumnNames', [])
-                    columns_str = ', '.join(columns[:3]) if columns else 'All'
-                    if len(columns) > 3:
-                        columns_str += f' (+{len(columns) - 3} more)'
-                    resource_details = f"{db_name}.{table_name} ({columns_str})"
-                elif 'DataLocation' in resource:
-                    resource_type = 'Data Location'
-                    resource_arn = resource.get('DataLocation', {}).get('ResourceArn', 'N/A')
-                    if resource_arn.startswith('arn:aws:s3:::'):
-                        resource_details = resource_arn.replace('arn:aws:s3:::', 's3://')
-                    else:
-                        resource_details = resource_arn
-                elif 'LFTag' in resource:
-                    resource_type = 'LF-Tag'
-                    tag_key = resource.get('LFTag', {}).get('TagKey', 'N/A')
-                    tag_values = resource.get('LFTag', {}).get('TagValues', [])
-                    tag_values_str = ', '.join(tag_values[:3]) if tag_values else 'N/A'
-                    if len(tag_values) > 3:
-                        tag_values_str += f' (+{len(tag_values) - 3} more)'
-                    resource_details = f"{tag_key}={tag_values_str}"
-
-                # Permissions granted
-                permissions_list = perm.get('Permissions', [])
-                permissions_str = ', '.join(permissions_list) if permissions_list else 'None'
-
-                # Grantable permissions
-                permissions_with_grant = perm.get('PermissionsWithGrantOption', [])
-                grant_permissions_str = ', '.join(permissions_with_grant) if permissions_with_grant else 'None'
-
-                regional_permissions.append({
-                    'Region': region,
-                    'Principal': principal_name,
-                    'Principal ARN': data_lake_principal_id,
-                    'Resource Type': resource_type,
-                    'Resource': resource_details,
-                    'Permissions': permissions_str,
-                    'Grant Permissions': grant_permissions_str,
-                })
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-    except Exception as e:
-        utils.log_error(f"Error collecting Lake Formation permissions in {region}", e)
+        for perm in permissions:
+            try:
+                regional_permissions.append(_build_permission_row(perm, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Lake Formation permission entry in {region}", e
+                )
+                continue
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
     return regional_permissions
 
 
+def _build_permission_row(perm: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Lake Formation permission export row."""
+    # Principal (who has access)
+    principal = perm.get('Principal', {})
+    data_lake_principal_id = principal.get('DataLakePrincipalIdentifier', 'N/A')
+
+    # Extract principal name
+    principal_name = 'N/A'
+    if data_lake_principal_id != 'N/A':
+        if '/' in data_lake_principal_id:
+            principal_name = data_lake_principal_id.split('/')[-1]
+        elif ':' in data_lake_principal_id:
+            parts = data_lake_principal_id.split(':')
+            principal_name = parts[-1] if len(parts) > 0 else 'N/A'
+        else:
+            principal_name = data_lake_principal_id
+
+    # Resource (what they have access to)
+    resource = perm.get('Resource', {})
+
+    # Determine resource type and details
+    resource_type = 'Unknown'
+    resource_details = 'N/A'
+
+    if 'Catalog' in resource:
+        resource_type = 'Catalog'
+        resource_details = 'Data Catalog'
+    elif 'Database' in resource:
+        resource_type = 'Database'
+        db_name = resource.get('Database', {}).get('Name', 'N/A')
+        resource_details = db_name
+    elif 'Table' in resource:
+        resource_type = 'Table'
+        table_info = resource.get('Table', {})
+        db_name = table_info.get('DatabaseName', 'N/A')
+        table_name = table_info.get('Name', 'N/A')
+        resource_details = f"{db_name}.{table_name}"
+    elif 'TableWithColumns' in resource:
+        resource_type = 'Table with Columns'
+        table_info = resource.get('TableWithColumns', {})
+        db_name = table_info.get('DatabaseName', 'N/A')
+        table_name = table_info.get('Name', 'N/A')
+        columns = table_info.get('ColumnNames', [])
+        columns_str = ', '.join(columns[:3]) if columns else 'All'
+        if len(columns) > 3:
+            columns_str += f' (+{len(columns) - 3} more)'
+        resource_details = f"{db_name}.{table_name} ({columns_str})"
+    elif 'DataLocation' in resource:
+        resource_type = 'Data Location'
+        resource_arn = resource.get('DataLocation', {}).get('ResourceArn', 'N/A')
+        if resource_arn.startswith('arn:aws:s3:::'):
+            resource_details = resource_arn.replace('arn:aws:s3:::', 's3://')
+        else:
+            resource_details = resource_arn
+    elif 'LFTag' in resource:
+        resource_type = 'LF-Tag'
+        tag_key = resource.get('LFTag', {}).get('TagKey', 'N/A')
+        tag_values = resource.get('LFTag', {}).get('TagValues', [])
+        tag_values_str = ', '.join(tag_values[:3]) if tag_values else 'N/A'
+        if len(tag_values) > 3:
+            tag_values_str += f' (+{len(tag_values) - 3} more)'
+        resource_details = f"{tag_key}={tag_values_str}"
+
+    # Permissions granted
+    permissions_list = perm.get('Permissions', [])
+    permissions_str = ', '.join(permissions_list) if permissions_list else 'None'
+
+    # Grantable permissions
+    permissions_with_grant = perm.get('PermissionsWithGrantOption', [])
+    grant_permissions_str = ', '.join(permissions_with_grant) if permissions_with_grant else 'None'
+
+    return {
+        'Region': region,
+        'Principal': principal_name,
+        'Principal ARN': data_lake_principal_id,
+        'Resource Type': resource_type,
+        'Resource': resource_details,
+        'Permissions': permissions_str,
+        'Grant Permissions': grant_permissions_str,
+    }
+
+
 def _scan_lakeformation_settings_region(region: str) -> list[dict[str, Any]]:
-    """Scan Lake Formation settings in a single region."""
+    """
+    Scan Lake Formation settings in a single region.
+
+    Does NOT swallow region-level errors — see
+    ``_scan_lakeformation_resources_region`` docstring for the contract.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_settings = []
+    lf_client = utils.get_boto3_client('lakeformation', region_name=region)
+
+    # Get data lake settings
+    settings_response = lf_client.get_data_lake_settings()
+    settings = settings_response.get('DataLakeSettings', {})
+
     try:
-        lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-
-        # Get data lake settings
-        settings_response = lf_client.get_data_lake_settings()
-        settings = settings_response.get('DataLakeSettings', {})
-
-        # Data lake admins
-        admins = settings.get('DataLakeAdmins', [])
-        admin_arns = [admin.get('DataLakePrincipalIdentifier', '') for admin in admins]
-        admin_names = []
-        for arn in admin_arns:
-            if '/' in arn:
-                admin_names.append(arn.split('/')[-1])
-            elif ':' in arn:
-                parts = arn.split(':')
-                admin_names.append(parts[-1] if len(parts) > 0 else arn)
-            else:
-                admin_names.append(arn)
-        admins_str = ', '.join(admin_names) if admin_names else 'None'
-
-        # Create database default permissions
-        create_db_default_perms = settings.get('CreateDatabaseDefaultPermissions', [])
-        create_db_perms_str = 'N/A'
-        if create_db_default_perms:
-            perms_list = []
-            for perm_entry in create_db_default_perms:
-                principal = perm_entry.get('Principal', {}).get('DataLakePrincipalIdentifier', '')
-                permissions = perm_entry.get('Permissions', [])
-                perms_list.append(f"{principal}: {', '.join(permissions)}")
-            create_db_perms_str = ' | '.join(perms_list) if perms_list else 'Default'
-
-        # Create table default permissions
-        create_table_default_perms = settings.get('CreateTableDefaultPermissions', [])
-        create_table_perms_str = 'N/A'
-        if create_table_default_perms:
-            perms_list = []
-            for perm_entry in create_table_default_perms:
-                principal = perm_entry.get('Principal', {}).get('DataLakePrincipalIdentifier', '')
-                permissions = perm_entry.get('Permissions', [])
-                perms_list.append(f"{principal}: {', '.join(permissions)}")
-            create_table_perms_str = ' | '.join(perms_list) if perms_list else 'Default'
-
-        # Trusted resource owners
-        trusted_owners = settings.get('TrustedResourceOwners', [])
-        trusted_owners_str = ', '.join(trusted_owners) if trusted_owners else 'None'
-
-        regional_settings.append({
-            'Region': region,
-            'Data Lake Admins': admins_str,
-            'Trusted Resource Owners': trusted_owners_str,
-            'Create Database Default Permissions': create_db_perms_str,
-            'Create Table Default Permissions': create_table_perms_str,
-        })
+        regional_settings.append(_build_settings_row(settings, region))
     except Exception as e:
-        utils.log_error(f"Error collecting Lake Formation settings in {region}", e)
+        utils.log_error(f"Skipping malformed Lake Formation settings in {region}", e)
+
     return regional_settings
 
 
+def _build_settings_row(settings: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build the Lake Formation data lake settings export row for a region."""
+    # Data lake admins
+    admins = settings.get('DataLakeAdmins', [])
+    admin_arns = [admin.get('DataLakePrincipalIdentifier', '') for admin in admins]
+    admin_names = []
+    for arn in admin_arns:
+        if '/' in arn:
+            admin_names.append(arn.split('/')[-1])
+        elif ':' in arn:
+            parts = arn.split(':')
+            admin_names.append(parts[-1] if len(parts) > 0 else arn)
+        else:
+            admin_names.append(arn)
+    admins_str = ', '.join(admin_names) if admin_names else 'None'
+
+    # Create database default permissions
+    create_db_default_perms = settings.get('CreateDatabaseDefaultPermissions', [])
+    create_db_perms_str = 'N/A'
+    if create_db_default_perms:
+        perms_list = []
+        for perm_entry in create_db_default_perms:
+            principal = perm_entry.get('Principal', {}).get('DataLakePrincipalIdentifier', '')
+            permissions = perm_entry.get('Permissions', [])
+            perms_list.append(f"{principal}: {', '.join(permissions)}")
+        create_db_perms_str = ' | '.join(perms_list) if perms_list else 'Default'
+
+    # Create table default permissions
+    create_table_default_perms = settings.get('CreateTableDefaultPermissions', [])
+    create_table_perms_str = 'N/A'
+    if create_table_default_perms:
+        perms_list = []
+        for perm_entry in create_table_default_perms:
+            principal = perm_entry.get('Principal', {}).get('DataLakePrincipalIdentifier', '')
+            permissions = perm_entry.get('Permissions', [])
+            perms_list.append(f"{principal}: {', '.join(permissions)}")
+        create_table_perms_str = ' | '.join(perms_list) if perms_list else 'Default'
+
+    # Trusted resource owners
+    trusted_owners = settings.get('TrustedResourceOwners', [])
+    trusted_owners_str = ', '.join(trusted_owners) if trusted_owners else 'None'
+
+    return {
+        'Region': region,
+        'Data Lake Admins': admins_str,
+        'Trusted Resource Owners': trusted_owners_str,
+        'Create Database Default Permissions': create_db_perms_str,
+        'Create Table Default Permissions': create_table_perms_str,
+    }
+
+
 def _scan_lakeformation_tags_region(region: str) -> list[dict[str, Any]]:
-    """Scan Lake Formation LF-Tags in a single region."""
+    """
+    Scan Lake Formation LF-Tags in a single region.
+
+    Does NOT swallow region-level errors — see
+    ``_scan_lakeformation_resources_region`` docstring for the contract.
+    Individual malformed tags are skipped (logged).
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_tags = []
-    try:
-        lf_client = utils.get_boto3_client('lakeformation', region_name=region)
-        paginator = lf_client.get_paginator('list_lf_tags')
-        for page in paginator.paginate():
-            lf_tags = page.get('LFTags', [])
+    lf_client = utils.get_boto3_client('lakeformation', region_name=region)
+    paginator = lf_client.get_paginator('list_lf_tags')
+    for page in paginator.paginate():
+        lf_tags = page.get('LFTags', [])
 
-            for tag in lf_tags:
-                tag_key = tag.get('TagKey', 'N/A')
-                tag_values = tag.get('TagValues', [])
-                tag_values_str = ', '.join(tag_values) if tag_values else 'None'
+        for tag in lf_tags:
+            try:
+                regional_tags.append(_build_tag_row(tag, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Lake Formation LF-Tag in {region}: "
+                    f"{tag.get('TagKey', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                # Catalog ID
-                catalog_id = tag.get('CatalogId', 'N/A')
-
-                regional_tags.append({
-                    'Region': region,
-                    'Tag Key': tag_key,
-                    'Tag Values': tag_values_str,
-                    'Value Count': len(tag_values),
-                    'Catalog ID': catalog_id,
-                })
-    except Exception as e:
-        utils.log_error(f"Error collecting Lake Formation LF-Tags in {region}", e)
     return regional_tags
 
 
-@utils.aws_error_handler("Collecting Lake Formation resources", default_return=[])
-def collect_lakeformation_resources(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Lake Formation registered resource information from AWS regions."""
+def _build_tag_row(tag: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Lake Formation LF-Tag export row."""
+    tag_key = tag.get('TagKey', 'N/A')
+    tag_values = tag.get('TagValues', [])
+    tag_values_str = ', '.join(tag_values) if tag_values else 'None'
+
+    # Catalog ID
+    catalog_id = tag.get('CatalogId', 'N/A')
+
+    return {
+        'Region': region,
+        'Tag Key': tag_key,
+        'Tag Values': tag_values_str,
+        'Value Count': len(tag_values),
+        'Catalog ID': catalog_id,
+    }
+
+
+def collect_lakeformation_resources(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Lake Formation registered resource information from AWS regions.
+
+    Uses ``collect_failures=True`` so a region whose collection raised is
+    reported as a failed scope rather than silently collapsed into empty
+    (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+
+    Returns:
+        tuple: ``(resources, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING LAKE FORMATION RESOURCES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_lakeformation_resources_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_lakeformation_resources_region, show_progress=True, collect_failures=True
+    )
     all_resources = [res for result in results for res in result]
     utils.log_success(f"Total Lake Formation resources collected: {len(all_resources)}")
-    return all_resources
+    return all_resources, failed_regions
 
 
-@utils.aws_error_handler("Collecting Lake Formation permissions", default_return=[])
-def collect_lakeformation_permissions(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Lake Formation permissions information from AWS regions."""
+def collect_lakeformation_permissions(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Lake Formation permissions information from AWS regions.
+
+    Uses ``collect_failures=True`` — see ``collect_lakeformation_resources``.
+    """
     print("\n=== COLLECTING LAKE FORMATION PERMISSIONS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_lakeformation_permissions_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_lakeformation_permissions_region, show_progress=True, collect_failures=True
+    )
     all_permissions = [perm for result in results for perm in result]
     utils.log_success(f"Total Lake Formation permissions collected: {len(all_permissions)}")
-    return all_permissions
+    return all_permissions, failed_regions
 
 
-@utils.aws_error_handler("Collecting Lake Formation settings", default_return=[])
-def collect_lakeformation_settings(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Lake Formation data lake settings from AWS regions."""
+def collect_lakeformation_settings(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Lake Formation data lake settings from AWS regions.
+
+    Uses ``collect_failures=True`` — see ``collect_lakeformation_resources``.
+    """
     print("\n=== COLLECTING LAKE FORMATION SETTINGS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_lakeformation_settings_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_lakeformation_settings_region, show_progress=True, collect_failures=True
+    )
     all_settings = [setting for result in results for setting in result]
     utils.log_success(f"Total Lake Formation settings collected: {len(all_settings)}")
-    return all_settings
+    return all_settings, failed_regions
 
 
-@utils.aws_error_handler("Collecting Lake Formation tags", default_return=[])
-def collect_lakeformation_tags(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Lake Formation LF-Tag information from AWS regions."""
+def collect_lakeformation_tags(
+    regions: list[str],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Lake Formation LF-Tag information from AWS regions.
+
+    Uses ``collect_failures=True`` — see ``collect_lakeformation_resources``.
+    """
     print("\n=== COLLECTING LAKE FORMATION LF-TAGS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_lakeformation_tags_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_lakeformation_tags_region, show_progress=True, collect_failures=True
+    )
     all_tags = [tag for result in results for tag in result]
     utils.log_success(f"Total Lake Formation LF-Tags collected: {len(all_tags)}")
-    return all_tags
+    return all_tags, failed_regions
 
 
 def generate_summary(resources: list[dict[str, Any]],
@@ -408,12 +529,22 @@ def generate_summary(resources: list[dict[str, Any]],
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Lake Formation data and write the Excel export."""
-    # Collect data
+    # Collect data. Each scope is region-scanned with collect_failures=True;
+    # failures from all four scopes are merged into one combined
+    # failed_regions list at the end (Tier-3: the Summary sheet below is
+    # ALWAYS written — a workbook always lands — but a failed marker + exit 1
+    # is added on top when any scope failed).
     print("\n=== Collecting Lake Formation Data ===")
-    resources = collect_lakeformation_resources(regions)
-    permissions = collect_lakeformation_permissions(regions)
-    settings = collect_lakeformation_settings(regions)
-    tags = collect_lakeformation_tags(regions)
+    resources, resources_failed = collect_lakeformation_resources(regions)
+    permissions, permissions_failed = collect_lakeformation_permissions(regions)
+    settings, settings_failed = collect_lakeformation_settings(regions)
+    tags, tags_failed = collect_lakeformation_tags(regions)
+
+    failed_regions: list[tuple[str, str]] = []
+    failed_regions.extend(resources_failed)
+    failed_regions.extend(permissions_failed)
+    failed_regions.extend(settings_failed)
+    failed_regions.extend(tags_failed)
 
     # Generate summary
     summary = generate_summary(resources, permissions, settings, tags)
@@ -441,7 +572,8 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     region_suffix = regions[0] if len(regions) == 1 else 'all-regions'
     filename = utils.create_export_filename(account_name, 'lakeformation', region_suffix)
 
-    # Save to Excel with multiple sheets
+    # Save to Excel with multiple sheets — Summary is ALWAYS included, so a
+    # workbook always lands even when some scopes failed.
     print("\n=== Exporting to Excel ===")
     dataframes = {
         'Registered Resources': resources_df,
@@ -452,6 +584,18 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY scope failed in ANY region, make it loud: write a marker and
+    # exit non-zero, even though a (partial) workbook was already written.
+    # A partial export that looks complete is exactly the failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'lakeformation', failed_regions)
+        print(
+            "\nERROR: Lake Formation export completed with failures — data is incomplete. "
+            "See the *-lakeformation-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/neptune_export.py
+++ b/scripts/neptune_export.py
@@ -58,127 +58,175 @@ def calculate_neptune_instance_monthly_cost(instance_class: str, pricing_data: d
     return round(float(monthly), 2)
 
 
-@utils.aws_error_handler("Collecting Neptune clusters", default_return=[])
-def collect_neptune_clusters(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Neptune cluster information from AWS regions."""
-    all_clusters = []
+def _build_cluster_row(cluster: dict[str, Any], region: str) -> dict[str, Any]:
+    """Build a single Neptune cluster export row from a describe response."""
+    cluster_id = cluster.get('DBClusterIdentifier', 'N/A')
 
-    for region in regions:
-        utils.log_info(f"Scanning Neptune clusters in {region}...")
-        neptune_client = utils.get_boto3_client('neptune', region_name=region)
+    # Basic cluster information
+    engine = cluster.get('Engine', 'N/A')
+    engine_version = cluster.get('EngineVersion', 'N/A')
+    status = cluster.get('Status', 'unknown')
 
-        paginator = neptune_client.get_paginator('describe_db_clusters')
-        for page in paginator.paginate():
-            db_clusters = page.get('DBClusters', [])
+    # Endpoint information
+    endpoint = cluster.get('Endpoint', 'N/A')
+    reader_endpoint = cluster.get('ReaderEndpoint', 'N/A')
+    port = cluster.get('Port', 0)
 
-            for cluster in db_clusters:
-                cluster_id = cluster.get('DBClusterIdentifier', 'N/A')
+    # Member instances
+    cluster_members = cluster.get('DBClusterMembers', [])
+    member_count = len(cluster_members)
 
-                # Basic cluster information
-                engine = cluster.get('Engine', 'N/A')
-                engine_version = cluster.get('EngineVersion', 'N/A')
-                status = cluster.get('Status', 'unknown')
+    # Primary instance identifier
+    primary_instance = 'N/A'
+    for member in cluster_members:
+        if member.get('IsClusterWriter', False):
+            primary_instance = member.get('DBInstanceIdentifier', 'N/A')
+            break
 
-                # Endpoint information
-                endpoint = cluster.get('Endpoint', 'N/A')
-                reader_endpoint = cluster.get('ReaderEndpoint', 'N/A')
-                port = cluster.get('Port', 0)
+    # Multi-AZ and availability zones
+    multi_az = cluster.get('MultiAZ', False)
+    availability_zones = cluster.get('AvailabilityZones', [])
+    az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
 
-                # Member instances
-                cluster_members = cluster.get('DBClusterMembers', [])
-                member_count = len(cluster_members)
+    # Backup configuration
+    backup_retention_period = cluster.get('BackupRetentionPeriod', 0)
+    preferred_backup_window = cluster.get('PreferredBackupWindow', 'N/A')
+    preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
 
-                # Primary instance identifier
-                primary_instance = 'N/A'
-                for member in cluster_members:
-                    if member.get('IsClusterWriter', False):
-                        primary_instance = member.get('DBInstanceIdentifier', 'N/A')
-                        break
+    # Encryption
+    storage_encrypted = cluster.get('StorageEncrypted', False)
+    kms_key_id = cluster.get('KmsKeyId', 'N/A')
+    if kms_key_id != 'N/A' and '/' in kms_key_id:
+        kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
 
-                # Multi-AZ and availability zones
-                multi_az = cluster.get('MultiAZ', False)
-                availability_zones = cluster.get('AvailabilityZones', [])
-                az_list = ', '.join(availability_zones) if availability_zones else 'N/A'
+    # IAM database authentication
+    iam_database_authentication_enabled = cluster.get('IAMDatabaseAuthenticationEnabled', False)
 
-                # Backup configuration
-                backup_retention_period = cluster.get('BackupRetentionPeriod', 0)
-                preferred_backup_window = cluster.get('PreferredBackupWindow', 'N/A')
-                preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
+    # Deletion protection
+    deletion_protection = cluster.get('DeletionProtection', False)
 
-                # Encryption
-                storage_encrypted = cluster.get('StorageEncrypted', False)
-                kms_key_id = cluster.get('KmsKeyId', 'N/A')
-                if kms_key_id != 'N/A' and '/' in kms_key_id:
-                    kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
+    # Cluster creation time
+    cluster_create_time = cluster.get('ClusterCreateTime')
+    if cluster_create_time:
+        cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
+    else:
+        cluster_create_time_str = 'N/A'
 
-                # IAM database authentication
-                iam_database_authentication_enabled = cluster.get('IAMDatabaseAuthenticationEnabled', False)
+    # VPC security groups
+    vpc_security_groups = cluster.get('VpcSecurityGroups', [])
+    security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
+    security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
 
-                # Deletion protection
-                deletion_protection = cluster.get('DeletionProtection', False)
+    # DB subnet group
+    db_subnet_group = cluster.get('DBSubnetGroup', 'N/A')
 
-                # Cluster creation time
-                cluster_create_time = cluster.get('ClusterCreateTime')
-                if cluster_create_time:
-                    cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
-                else:
-                    cluster_create_time_str = 'N/A'
+    # Cluster parameter group
+    db_cluster_parameter_group = cluster.get('DBClusterParameterGroup', 'N/A')
 
-                # VPC security groups
-                vpc_security_groups = cluster.get('VpcSecurityGroups', [])
-                security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
-                security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
+    # Enabled CloudWatch logs exports
+    enabled_cloudwatch_logs_exports = cluster.get('EnabledCloudwatchLogsExports', [])
+    logs_exports_str = ', '.join(enabled_cloudwatch_logs_exports) if enabled_cloudwatch_logs_exports else 'None'
 
-                # DB subnet group
-                db_subnet_group = cluster.get('DBSubnetGroup', 'N/A')
+    # Serverless v2 scaling configuration
+    serverless_v2_scaling = cluster.get('ServerlessV2ScalingConfiguration', {})
+    if serverless_v2_scaling:
+        min_capacity = serverless_v2_scaling.get('MinCapacity', 'N/A')
+        max_capacity = serverless_v2_scaling.get('MaxCapacity', 'N/A')
+        serverless_config = f"Min: {min_capacity}, Max: {max_capacity}"
+    else:
+        serverless_config = 'N/A'
 
-                # Cluster parameter group
-                db_cluster_parameter_group = cluster.get('DBClusterParameterGroup', 'N/A')
+    return {
+        'Region': region,
+        'Cluster ID': cluster_id,
+        'Engine': engine,
+        'Engine Version': engine_version,
+        'Status': status,
+        'Endpoint': endpoint,
+        'Reader Endpoint': reader_endpoint,
+        'Port': port,
+        'Member Instances': member_count,
+        'Primary Instance': primary_instance,
+        'Multi-AZ': 'Yes' if multi_az else 'No',
+        'Availability Zones': az_list,
+        'Backup Retention (Days)': backup_retention_period,
+        'Backup Window': preferred_backup_window,
+        'Maintenance Window': preferred_maintenance_window,
+        'Storage Encrypted': 'Yes' if storage_encrypted else 'No',
+        'KMS Key ID': kms_key_id if storage_encrypted else 'N/A',
+        'IAM Auth Enabled': 'Yes' if iam_database_authentication_enabled else 'No',
+        'Deletion Protection': 'Yes' if deletion_protection else 'No',
+        'Serverless v2 Config': serverless_config,
+        'Created': cluster_create_time_str,
+        'Security Groups': security_groups_str,
+        'Subnet Group': db_subnet_group,
+        'Parameter Group': db_cluster_parameter_group,
+        'CloudWatch Logs': logs_exports_str,
+    }
 
-                # Enabled CloudWatch logs exports
-                enabled_cloudwatch_logs_exports = cluster.get('EnabledCloudwatchLogsExports', [])
-                logs_exports_str = ', '.join(enabled_cloudwatch_logs_exports) if enabled_cloudwatch_logs_exports else 'None'
 
-                # Serverless v2 scaling configuration
-                serverless_v2_scaling = cluster.get('ServerlessV2ScalingConfiguration', {})
-                if serverless_v2_scaling:
-                    min_capacity = serverless_v2_scaling.get('MinCapacity', 'N/A')
-                    max_capacity = serverless_v2_scaling.get('MaxCapacity', 'N/A')
-                    serverless_config = f"Min: {min_capacity}, Max: {max_capacity}"
-                else:
-                    serverless_config = 'N/A'
+def _scan_neptune_clusters_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Neptune clusters from a single region.
 
-                all_clusters.append({
-                    'Region': region,
-                    'Cluster ID': cluster_id,
-                    'Engine': engine,
-                    'Engine Version': engine_version,
-                    'Status': status,
-                    'Endpoint': endpoint,
-                    'Reader Endpoint': reader_endpoint,
-                    'Port': port,
-                    'Member Instances': member_count,
-                    'Primary Instance': primary_instance,
-                    'Multi-AZ': 'Yes' if multi_az else 'No',
-                    'Availability Zones': az_list,
-                    'Backup Retention (Days)': backup_retention_period,
-                    'Backup Window': preferred_backup_window,
-                    'Maintenance Window': preferred_maintenance_window,
-                    'Storage Encrypted': 'Yes' if storage_encrypted else 'No',
-                    'KMS Key ID': kms_key_id if storage_encrypted else 'N/A',
-                    'IAM Auth Enabled': 'Yes' if iam_database_authentication_enabled else 'No',
-                    'Deletion Protection': 'Yes' if deletion_protection else 'No',
-                    'Serverless v2 Config': serverless_config,
-                    'Created': cluster_create_time_str,
-                    'Security Groups': security_groups_str,
-                    'Subnet Group': db_subnet_group,
-                    'Parameter Group': db_cluster_parameter_group,
-                    'CloudWatch Logs': logs_exports_str,
-                })
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Neptune clusters" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
-        utils.log_success(f"Collected {len([c for c in all_clusters if c['Region'] == region])} Neptune clusters from {region}")
+    Individual malformed clusters are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-    return all_clusters
+    utils.log_info(f"Scanning Neptune clusters in {region}...")
+    neptune_client = utils.get_boto3_client('neptune', region_name=region)
+
+    region_clusters = []
+    paginator = neptune_client.get_paginator('describe_db_clusters')
+    for page in paginator.paginate():
+        db_clusters = page.get('DBClusters', [])
+
+        for cluster in db_clusters:
+            try:
+                region_clusters.append(_build_cluster_row(cluster, region))
+            except Exception as e:
+                # One malformed cluster is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Neptune cluster in {region}: "
+                    f"{cluster.get('DBClusterIdentifier', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_success(f"Collected {len(region_clusters)} Neptune clusters from {region}")
+    return region_clusters
+
+
+def collect_neptune_clusters(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Neptune cluster information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(clusters, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_neptune_clusters_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_clusters = [cluster for result in region_results for cluster in result]
+    return all_clusters, failed_regions
 
 
 @utils.aws_error_handler("Collecting Neptune instances", default_return=[])
@@ -586,7 +634,9 @@ def collect_neptune_graphs(regions: list[str]) -> list[dict[str, Any]]:
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Neptune data and write the Excel export."""
     print("\n=== Collecting Neptune Data ===")
-    clusters = collect_neptune_clusters(regions)
+    # PRIMARY scope: region failures must propagate as failed_regions, never
+    # collapse into "empty" (see the silent-collection-failure blast-radius audit).
+    clusters, failed_regions = collect_neptune_clusters(regions)
     instances = collect_neptune_instances(regions)
     snapshots = collect_neptune_snapshots(regions)
     endpoints = collect_neptune_endpoints(regions)
@@ -621,7 +671,8 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     region_suffix = regions[0] if len(regions) == 1 else 'all-regions'
     filename = utils.create_export_filename(account_name, 'neptune', region_suffix)
 
-    # Save to Excel with multiple sheets
+    # Save to Excel with multiple sheets — the Summary sheet is always written
+    # (even zero-row) so the workbook always lands; PRESERVE that behavior.
     print("\n=== Exporting to Excel ===")
     dataframes = {
         'Neptune Clusters': clusters_df,
@@ -633,6 +684,20 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary Neptune Clusters scope collection,
+    # make it loud: write a marker and exit non-zero, even though the
+    # workbook was written. A complete-looking file with silently missing
+    # cluster data is exactly the failure mode this guards against. A
+    # genuinely empty account (no failures, zero clusters) stays exit 0.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'neptune', failed_regions)
+        print(
+            "\nERROR: Neptune export completed with failures — data is incomplete. "
+            "See the *-neptune-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
+
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/opensearch_export.py
+++ b/scripts/opensearch_export.py
@@ -82,9 +82,178 @@ def calculate_opensearch_monthly_cost(
         return 'N/A'
 
 
+def _build_domain_row(domain: dict[str, Any], region: str, pricing_data: dict[str, Any], cost_note: str) -> dict[str, Any]:
+    """Build a single OpenSearch domain export row from a describe_domain response."""
+    domain_name = domain.get('DomainName', 'Unknown')
+    domain_id = domain.get('DomainId', 'N/A')
+    arn = domain.get('ARN', 'N/A')
+
+    # Engine version
+    engine_version = domain.get('EngineVersion', 'N/A')
+
+    # Cluster configuration
+    cluster_config = domain.get('ClusterConfig', {})
+    instance_type = cluster_config.get('InstanceType', 'N/A')
+    instance_count = cluster_config.get('InstanceCount', 0)
+    dedicated_master_enabled = cluster_config.get('DedicatedMasterEnabled', False)
+    dedicated_master_type = cluster_config.get('DedicatedMasterType', 'N/A') if dedicated_master_enabled else 'N/A'
+    dedicated_master_count = cluster_config.get('DedicatedMasterCount', 0) if dedicated_master_enabled else 0
+    zone_awareness_enabled = cluster_config.get('ZoneAwarenessEnabled', False)
+    warm_enabled = cluster_config.get('WarmEnabled', False)
+    warm_type = cluster_config.get('WarmType', 'N/A') if warm_enabled else 'N/A'
+    warm_count = cluster_config.get('WarmCount', 0) if warm_enabled else 0
+
+    # EBS storage
+    ebs_options = domain.get('EBSOptions', {})
+    ebs_enabled = ebs_options.get('EBSEnabled', False)
+    volume_type = ebs_options.get('VolumeType', 'N/A') if ebs_enabled else 'N/A'
+    volume_size = ebs_options.get('VolumeSize', 0) if ebs_enabled else 0
+    iops = ebs_options.get('Iops', 0) if ebs_enabled else 0
+
+    # VPC configuration
+    vpc_options = domain.get('VPCOptions', {})
+    vpc_id = vpc_options.get('VPCId', 'N/A')
+    subnet_ids = vpc_options.get('SubnetIds', [])
+    subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
+    security_group_ids = vpc_options.get('SecurityGroupIds', [])
+    security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
+    availability_zones = vpc_options.get('AvailabilityZones', [])
+    az_str = ', '.join(availability_zones) if availability_zones else 'N/A'
+
+    # Endpoints
+    endpoint = domain.get('Endpoint', 'N/A')
+    endpoints = domain.get('Endpoints', {})
+    vpc_endpoint = endpoints.get('vpc', 'N/A') if endpoints else 'N/A'
+
+    # Encryption settings
+    encryption_at_rest = domain.get('EncryptionAtRestOptions', {})
+    encryption_enabled = encryption_at_rest.get('Enabled', False)
+    kms_key_id = encryption_at_rest.get('KmsKeyId', 'N/A') if encryption_enabled else 'N/A'
+    if kms_key_id != 'N/A' and '/' in kms_key_id:
+        kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
+
+    # Node-to-node encryption
+    node_to_node_encryption = domain.get('NodeToNodeEncryptionOptions', {})
+    node_encryption_enabled = node_to_node_encryption.get('Enabled', False)
+
+    # Domain endpoint encryption (in-transit)
+    domain_endpoint_options = domain.get('DomainEndpointOptions', {})
+    enforce_https = domain_endpoint_options.get('EnforceHTTPS', False)
+    tls_security_policy = domain_endpoint_options.get('TLSSecurityPolicy', 'N/A')
+
+    # Advanced security options (fine-grained access control)
+    advanced_security_options = domain.get('AdvancedSecurityOptions', {})
+    fine_grained_access_enabled = advanced_security_options.get('Enabled', False)
+    internal_user_database_enabled = advanced_security_options.get('InternalUserDatabaseEnabled', False)
+
+    # Cognito options
+    cognito_options = domain.get('CognitoOptions', {})
+    cognito_enabled = cognito_options.get('Enabled', False)
+    user_pool_id = cognito_options.get('UserPoolId', 'N/A') if cognito_enabled else 'N/A'
+
+    # Snapshot configuration
+    snapshot_options = domain.get('SnapshotOptions', {})
+    automated_snapshot_start_hour = snapshot_options.get('AutomatedSnapshotStartHour', 'N/A')
+
+    # Domain status
+    processing = domain.get('Processing', False)
+    created = domain.get('Created', False)
+    deleted = domain.get('Deleted', False)
+
+    # Auto-Tune options
+    auto_tune_options = domain.get('AutoTuneOptions', {})
+    auto_tune_state = auto_tune_options.get('State', 'N/A')
+
+    # Access policies
+    access_policies = domain.get('AccessPolicies', 'N/A')
+    if access_policies != 'N/A':
+        try:
+            policy_json = json.loads(access_policies)
+            # Check if policy allows public access
+            statements = policy_json.get('Statement', [])
+            public_access = 'No'
+            for statement in statements:
+                principal = statement.get('Principal', {})
+                if principal == '*' or principal.get('AWS') == '*':
+                    public_access = 'Yes - Review Policy'
+                    break
+        except Exception:
+            public_access = 'Unknown'
+    else:
+        public_access = 'N/A'
+
+    # Domain creation time
+    created_time = domain.get('Created')
+    created_time_str = 'Yes' if created and created_time else 'Unknown'
+
+    # Cost estimation (data nodes only)
+    monthly_cost = calculate_opensearch_monthly_cost(
+        instance_type, instance_count, pricing_data
+    )
+
+    return {
+        'Region': region,
+        'Domain Name': domain_name,
+        'Domain ID': domain_id,
+        'Engine Version': engine_version,
+        'Status': 'Processing' if processing else ('Deleted' if deleted else 'Active'),
+        'Endpoint': endpoint if endpoint != 'N/A' else vpc_endpoint,
+        'Instance Type': instance_type,
+        'Instance Count': instance_count,
+        'Dedicated Master': 'Yes' if dedicated_master_enabled else 'No',
+        'Master Type': dedicated_master_type,
+        'Master Count': dedicated_master_count,
+        'Zone Awareness': 'Enabled' if zone_awareness_enabled else 'Disabled',
+        'Warm Storage': 'Enabled' if warm_enabled else 'Disabled',
+        'Warm Type': warm_type,
+        'Warm Count': warm_count,
+        'EBS Enabled': 'Yes' if ebs_enabled else 'No',
+        'Volume Type': volume_type,
+        'Volume Size (GB)': volume_size,
+        'IOPS': iops if iops > 0 else 'N/A',
+        'VPC ID': vpc_id,
+        'Subnets': subnet_ids_str,
+        'Security Groups': security_groups_str,
+        'Availability Zones': az_str,
+        'Encryption at Rest': 'Yes' if encryption_enabled else 'No',
+        'KMS Key ID': kms_key_id,
+        'Node-to-Node Encryption': 'Yes' if node_encryption_enabled else 'No',
+        'Enforce HTTPS': 'Yes' if enforce_https else 'No',
+        'TLS Policy': tls_security_policy,
+        'Fine-Grained Access Control': 'Enabled' if fine_grained_access_enabled else 'Disabled',
+        'Internal User DB': 'Yes' if internal_user_database_enabled else 'No',
+        'Cognito Auth': 'Enabled' if cognito_enabled else 'Disabled',
+        'Cognito User Pool': user_pool_id,
+        'Snapshot Start Hour': automated_snapshot_start_hour,
+        'Auto-Tune': auto_tune_state,
+        'Public Access': public_access,
+        'Created': created_time_str,
+        'ARN': arn,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
 def scan_opensearch_domains_in_region(region: str) -> list[dict[str, Any]]:
-    """Scan OpenSearch domains in a single AWS region."""
-    region_domains = []
+    """
+    Scan OpenSearch domains in a single AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here (e.g. ``list_domain_names``) must
+    propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no
+    OpenSearch domains" (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    An individual domain that fails to describe/build is skipped (logged)
+    rather than aborting the whole region.
+    """
+    region_domains: list[dict[str, Any]] = []
+
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return region_domains
+
     pricing_data = load_opensearch_pricing_data(region)
     partition = utils.detect_partition(region)
     cost_note = (
@@ -93,199 +262,57 @@ def scan_opensearch_domains_in_region(region: str) -> list[dict[str, Any]]:
         else "Estimate (us-east-1 pricing); data nodes only"
     )
 
-    try:
-        opensearch_client = utils.get_boto3_client('opensearch', region_name=region)
+    opensearch_client = utils.get_boto3_client('opensearch', region_name=region)
 
-        # List all domain names
+    # List all domain names. Deliberately not wrapped in try/except: a
+    # failure here (throttling, access denied, etc.) must raise so the
+    # region is recorded as FAILED, not silently treated as empty.
+    response = opensearch_client.list_domain_names()
+    domain_names = [
+        d.get('DomainName') for d in response.get('DomainNames', []) if d.get('DomainName')
+    ]
+
+    if not domain_names:
+        utils.log_info(f"No OpenSearch domains found in {region}")
+        return region_domains
+
+    # Describe each domain
+    for domain_name in domain_names:
         try:
-            response = opensearch_client.list_domain_names()
-            domain_names = [domain['DomainName'] for domain in response.get('DomainNames', [])]
+            domain_response = opensearch_client.describe_domain(DomainName=domain_name)
+            domain = domain_response.get('DomainStatus', {})
+            region_domains.append(_build_domain_row(domain, region, pricing_data, cost_note))
         except Exception as e:
-            utils.log_warning(f"Could not list domains in {region}: {str(e)}")
-            return region_domains
-
-        if not domain_names:
-            utils.log_info(f"No OpenSearch domains found in {region}")
-            return region_domains
-
-        # Describe each domain
-        for domain_name in domain_names:
-            try:
-                domain_response = opensearch_client.describe_domain(DomainName=domain_name)
-                domain = domain_response.get('DomainStatus', {})
-
-                domain_id = domain.get('DomainId', 'N/A')
-                arn = domain.get('ARN', 'N/A')
-
-                # Engine version
-                engine_version = domain.get('EngineVersion', 'N/A')
-
-                # Cluster configuration
-                cluster_config = domain.get('ClusterConfig', {})
-                instance_type = cluster_config.get('InstanceType', 'N/A')
-                instance_count = cluster_config.get('InstanceCount', 0)
-                dedicated_master_enabled = cluster_config.get('DedicatedMasterEnabled', False)
-                dedicated_master_type = cluster_config.get('DedicatedMasterType', 'N/A') if dedicated_master_enabled else 'N/A'
-                dedicated_master_count = cluster_config.get('DedicatedMasterCount', 0) if dedicated_master_enabled else 0
-                zone_awareness_enabled = cluster_config.get('ZoneAwarenessEnabled', False)
-                warm_enabled = cluster_config.get('WarmEnabled', False)
-                warm_type = cluster_config.get('WarmType', 'N/A') if warm_enabled else 'N/A'
-                warm_count = cluster_config.get('WarmCount', 0) if warm_enabled else 0
-
-                # EBS storage
-                ebs_options = domain.get('EBSOptions', {})
-                ebs_enabled = ebs_options.get('EBSEnabled', False)
-                volume_type = ebs_options.get('VolumeType', 'N/A') if ebs_enabled else 'N/A'
-                volume_size = ebs_options.get('VolumeSize', 0) if ebs_enabled else 0
-                iops = ebs_options.get('Iops', 0) if ebs_enabled else 0
-
-                # VPC configuration
-                vpc_options = domain.get('VPCOptions', {})
-                vpc_id = vpc_options.get('VPCId', 'N/A')
-                subnet_ids = vpc_options.get('SubnetIds', [])
-                subnet_ids_str = ', '.join(subnet_ids) if subnet_ids else 'N/A'
-                security_group_ids = vpc_options.get('SecurityGroupIds', [])
-                security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
-                availability_zones = vpc_options.get('AvailabilityZones', [])
-                az_str = ', '.join(availability_zones) if availability_zones else 'N/A'
-
-                # Endpoints
-                endpoint = domain.get('Endpoint', 'N/A')
-                endpoints = domain.get('Endpoints', {})
-                vpc_endpoint = endpoints.get('vpc', 'N/A') if endpoints else 'N/A'
-
-                # Encryption settings
-                encryption_at_rest = domain.get('EncryptionAtRestOptions', {})
-                encryption_enabled = encryption_at_rest.get('Enabled', False)
-                kms_key_id = encryption_at_rest.get('KmsKeyId', 'N/A') if encryption_enabled else 'N/A'
-                if kms_key_id != 'N/A' and '/' in kms_key_id:
-                    kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
-
-                # Node-to-node encryption
-                node_to_node_encryption = domain.get('NodeToNodeEncryptionOptions', {})
-                node_encryption_enabled = node_to_node_encryption.get('Enabled', False)
-
-                # Domain endpoint encryption (in-transit)
-                domain_endpoint_options = domain.get('DomainEndpointOptions', {})
-                enforce_https = domain_endpoint_options.get('EnforceHTTPS', False)
-                tls_security_policy = domain_endpoint_options.get('TLSSecurityPolicy', 'N/A')
-
-                # Advanced security options (fine-grained access control)
-                advanced_security_options = domain.get('AdvancedSecurityOptions', {})
-                fine_grained_access_enabled = advanced_security_options.get('Enabled', False)
-                internal_user_database_enabled = advanced_security_options.get('InternalUserDatabaseEnabled', False)
-
-                # Cognito options
-                cognito_options = domain.get('CognitoOptions', {})
-                cognito_enabled = cognito_options.get('Enabled', False)
-                user_pool_id = cognito_options.get('UserPoolId', 'N/A') if cognito_enabled else 'N/A'
-
-                # Snapshot configuration
-                snapshot_options = domain.get('SnapshotOptions', {})
-                automated_snapshot_start_hour = snapshot_options.get('AutomatedSnapshotStartHour', 'N/A')
-
-                # Domain status
-                processing = domain.get('Processing', False)
-                created = domain.get('Created', False)
-                deleted = domain.get('Deleted', False)
-
-                # Auto-Tune options
-                auto_tune_options = domain.get('AutoTuneOptions', {})
-                auto_tune_state = auto_tune_options.get('State', 'N/A')
-
-                # Access policies
-                access_policies = domain.get('AccessPolicies', 'N/A')
-                if access_policies != 'N/A':
-                    try:
-                        policy_json = json.loads(access_policies)
-                        # Check if policy allows public access
-                        statements = policy_json.get('Statement', [])
-                        public_access = 'No'
-                        for statement in statements:
-                            principal = statement.get('Principal', {})
-                            if principal == '*' or principal.get('AWS') == '*':
-                                public_access = 'Yes - Review Policy'
-                                break
-                    except Exception:
-                        public_access = 'Unknown'
-                else:
-                    public_access = 'N/A'
-
-                # Domain creation time
-                created_time = domain.get('Created')
-                created_time_str = 'Yes' if created and created_time else 'Unknown'
-
-                # Cost estimation (data nodes only)
-                monthly_cost = calculate_opensearch_monthly_cost(
-                    instance_type, instance_count, pricing_data
-                )
-
-                region_domains.append({
-                    'Region': region,
-                    'Domain Name': domain_name,
-                    'Domain ID': domain_id,
-                    'Engine Version': engine_version,
-                    'Status': 'Processing' if processing else ('Deleted' if deleted else 'Active'),
-                    'Endpoint': endpoint if endpoint != 'N/A' else vpc_endpoint,
-                    'Instance Type': instance_type,
-                    'Instance Count': instance_count,
-                    'Dedicated Master': 'Yes' if dedicated_master_enabled else 'No',
-                    'Master Type': dedicated_master_type,
-                    'Master Count': dedicated_master_count,
-                    'Zone Awareness': 'Enabled' if zone_awareness_enabled else 'Disabled',
-                    'Warm Storage': 'Enabled' if warm_enabled else 'Disabled',
-                    'Warm Type': warm_type,
-                    'Warm Count': warm_count,
-                    'EBS Enabled': 'Yes' if ebs_enabled else 'No',
-                    'Volume Type': volume_type,
-                    'Volume Size (GB)': volume_size,
-                    'IOPS': iops if iops > 0 else 'N/A',
-                    'VPC ID': vpc_id,
-                    'Subnets': subnet_ids_str,
-                    'Security Groups': security_groups_str,
-                    'Availability Zones': az_str,
-                    'Encryption at Rest': 'Yes' if encryption_enabled else 'No',
-                    'KMS Key ID': kms_key_id,
-                    'Node-to-Node Encryption': 'Yes' if node_encryption_enabled else 'No',
-                    'Enforce HTTPS': 'Yes' if enforce_https else 'No',
-                    'TLS Policy': tls_security_policy,
-                    'Fine-Grained Access Control': 'Enabled' if fine_grained_access_enabled else 'Disabled',
-                    'Internal User DB': 'Yes' if internal_user_database_enabled else 'No',
-                    'Cognito Auth': 'Enabled' if cognito_enabled else 'Disabled',
-                    'Cognito User Pool': user_pool_id,
-                    'Snapshot Start Hour': automated_snapshot_start_hour,
-                    'Auto-Tune': auto_tune_state,
-                    'Public Access': public_access,
-                    'Created': created_time_str,
-                    'ARN': arn,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': cost_note,
-                })
-
-            except Exception as e:
-                utils.log_error(f"Error describing domain {domain_name} in {region}: {str(e)}")
-                continue
-
-    except Exception as e:
-        utils.log_error(f"Error scanning OpenSearch domains in {region}", e)
+            # One malformed/unreachable domain is skipped, not fatal to the region.
+            utils.log_error(f"Skipping OpenSearch domain '{domain_name}' in {region}", e)
+            continue
 
     utils.log_info(f"Found {len(region_domains)} OpenSearch domains in {region}")
     return region_domains
 
 
-@utils.aws_error_handler("Collecting OpenSearch domains", default_return=[])
-def collect_opensearch_domains(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect OpenSearch Service domain information from AWS regions."""
+def collect_opensearch_domains(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect OpenSearch Service domain information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(domains, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    all_domains = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_opensearch_domains_in_region,
-    ):
-        all_domains.extend(region_data)
-
-    return all_domains
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_domains = [domain for result in region_results for domain in result]
+    return all_domains, failed_regions
 
 
 def scan_opensearch_tags_in_region(region: str) -> list[dict[str, Any]]:
@@ -496,9 +523,10 @@ def generate_summary(domains: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect OpenSearch data and write the Excel export."""
-    # Collect data
+    # Collect data. STEP 1 is the primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty".
     print("\n=== Collecting OpenSearch Data ===")
-    domains = collect_opensearch_domains(regions)
+    domains, failed_regions = collect_opensearch_domains(regions)
     tags = collect_opensearch_tags(regions)
 
     # Generate summary
@@ -521,7 +549,9 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     region_suffix = regions[0] if len(regions) == 1 else 'all-regions'
     filename = utils.create_export_filename(account_name, 'opensearch', region_suffix)
 
-    # Save to Excel with multiple sheets
+    # Save to Excel with multiple sheets — the Summary sheet is ALWAYS
+    # written (forced, even on a genuinely-empty account), so the workbook
+    # always lands. Preserve that behavior.
     print("\n=== Exporting to Excel ===")
     dataframes = {
         'OpenSearch Domains': domains_df,
@@ -530,6 +560,20 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary OpenSearch domains scope collection,
+    # make it loud: write a marker and exit non-zero, even though the
+    # workbook (with its always-written Summary sheet) was still exported.
+    # A complete-looking workbook that is silently missing failed-region
+    # data is exactly the failure mode this guards against. Genuinely-empty
+    # (every region succeeded, zero domains) stays exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'opensearch', failed_regions)
+        print(
+            "\nERROR: OpenSearch export completed with failures — data is incomplete. "
+            "See the *-opensearch-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/redshift_export.py
+++ b/scripts/redshift_export.py
@@ -83,12 +83,31 @@ def scan_redshift_clusters_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan Redshift clusters in a single AWS region.
 
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no Redshift clusters"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed clusters are skipped (logged) rather than aborting
+    the whole region.
+
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of Redshift cluster dictionaries for this region
+
+    Raises:
+        Exception: Any AWS/pagination error for the region (caller records
+            it as a failed region and surfaces it; it is never masked as
+            empty).
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     region_clusters = []
     pricing_data = load_redshift_pricing_data(region)
     partition = utils.detect_partition(region)
@@ -98,166 +117,192 @@ def scan_redshift_clusters_in_region(region: str) -> list[dict[str, Any]]:
         else "Estimate (us-east-1 pricing)"
     )
 
-    try:
-        redshift_client = utils.get_boto3_client('redshift', region_name=region)
+    redshift_client = utils.get_boto3_client('redshift', region_name=region)
 
-        paginator = redshift_client.get_paginator('describe_clusters')
-        for page in paginator.paginate():
-            clusters = page.get('Clusters', [])
+    paginator = redshift_client.get_paginator('describe_clusters')
+    for page in paginator.paginate():
+        clusters = page.get('Clusters', [])
 
-            for cluster in clusters:
-                cluster_id = cluster.get('ClusterIdentifier', 'N/A')
-
-                # Basic cluster information
-                cluster_status = cluster.get('ClusterStatus', 'unknown')
-                cluster_version = cluster.get('ClusterVersion', 'N/A')
-                node_type = cluster.get('NodeType', 'N/A')
-                number_of_nodes = cluster.get('NumberOfNodes', 0)
-
-                # Single node or multi-node
-                cluster_type = 'Single-node' if number_of_nodes == 1 else f'Multi-node ({number_of_nodes} nodes)'
-
-                # Database information
-                db_name = cluster.get('DBName', 'N/A')
-                master_username = cluster.get('MasterUsername', 'N/A')
-
-                # Endpoint information
-                endpoint = cluster.get('Endpoint', {})
-                endpoint_address = endpoint.get('Address', 'N/A') if endpoint else 'N/A'
-                endpoint_port = endpoint.get('Port', 0) if endpoint else 0
-
-                # VPC and networking
-                vpc_id = cluster.get('VpcId', 'N/A')
-                availability_zone = cluster.get('AvailabilityZone', 'N/A')
-
-                # VPC security groups
-                vpc_security_groups = cluster.get('VpcSecurityGroups', [])
-                security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
-                security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
-
-                # Cluster subnet group
-                cluster_subnet_group_name = cluster.get('ClusterSubnetGroupName', 'N/A')
-
-                # Public accessibility
-                publicly_accessible = cluster.get('PubliclyAccessible', False)
-
-                # Encryption
-                encrypted = cluster.get('Encrypted', False)
-                kms_key_id = cluster.get('KmsKeyId', 'N/A')
-                if kms_key_id != 'N/A' and '/' in kms_key_id:
-                    kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
-
-                # Enhanced VPC routing
-                enhanced_vpc_routing = cluster.get('EnhancedVpcRouting', False)
-
-                # Maintenance and backup windows
-                preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
-                automated_snapshot_retention_period = cluster.get('AutomatedSnapshotRetentionPeriod', 0)
-                manual_snapshot_retention_period = cluster.get('ManualSnapshotRetentionPeriod', -1)
-
-                # Snapshot copy configuration
-                cluster_snapshot_copy_status = cluster.get('ClusterSnapshotCopyStatus', {})
-                snapshot_copy_enabled = bool(cluster_snapshot_copy_status)
-                destination_region = cluster_snapshot_copy_status.get('DestinationRegion', 'N/A') if snapshot_copy_enabled else 'N/A'
-
-                # Cluster parameter group
-                cluster_parameter_groups = cluster.get('ClusterParameterGroups', [])
-                parameter_group_name = cluster_parameter_groups[0].get('ParameterGroupName', 'N/A') if cluster_parameter_groups else 'N/A'
-
-                # IAM roles
-                iam_roles = cluster.get('IamRoles', [])
-                iam_role_arns = [role.get('IamRoleArn', '') for role in iam_roles]
-                iam_roles_str = ', '.join([arn.split('/')[-1] for arn in iam_role_arns]) if iam_role_arns else 'N/A'
-
-                # Cluster creation time
-                cluster_create_time = cluster.get('ClusterCreateTime')
-                if cluster_create_time:
-                    cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
-                else:
-                    cluster_create_time_str = 'N/A'
-
-                # Allow version upgrade
-                allow_version_upgrade = cluster.get('AllowVersionUpgrade', False)
-
-                # Aqua (Advanced Query Accelerator) configuration
-                aqua_configuration = cluster.get('AquaConfiguration', {})
-                aqua_status = aqua_configuration.get('AquaStatus', 'N/A') if aqua_configuration else 'N/A'
-
-                # Total storage capacity
-                total_storage_capacity_in_megabytes = cluster.get('TotalStorageCapacityInMegaBytes', 0)
-                total_storage_gb = round(total_storage_capacity_in_megabytes / 1024, 2) if total_storage_capacity_in_megabytes else 0
-
-                # Cluster revision number
-                cluster_revision_number = cluster.get('ClusterRevisionNumber', 'N/A')
-
-                # Logging status
-                logging_status = cluster.get('LoggingStatus', {})
-                logging_enabled = logging_status.get('LoggingEnabled', False) if logging_status else False
-                s3_bucket_name = logging_status.get('BucketName', 'N/A') if logging_enabled else 'N/A'
-
-                # Cost estimation
-                monthly_cost = calculate_redshift_monthly_cost(
-                    node_type, number_of_nodes, pricing_data
+        for cluster in clusters:
+            try:
+                region_clusters.append(
+                    _build_cluster_row(cluster, region, pricing_data, cost_note)
                 )
-
-                region_clusters.append({
-                    'Region': region,
-                    'Cluster ID': cluster_id,
-                    'Status': cluster_status,
-                    'Cluster Version': cluster_version,
-                    'Node Type': node_type,
-                    'Number of Nodes': number_of_nodes,
-                    'Cluster Type': cluster_type,
-                    'Database Name': db_name,
-                    'Master Username': master_username,
-                    'Endpoint': endpoint_address,
-                    'Port': endpoint_port,
-                    'VPC ID': vpc_id,
-                    'Availability Zone': availability_zone,
-                    'Security Groups': security_groups_str,
-                    'Subnet Group': cluster_subnet_group_name,
-                    'Publicly Accessible': 'Yes' if publicly_accessible else 'No',
-                    'Encrypted': 'Yes' if encrypted else 'No',
-                    'KMS Key ID': kms_key_id if encrypted else 'N/A',
-                    'Enhanced VPC Routing': 'Yes' if enhanced_vpc_routing else 'No',
-                    'Maintenance Window': preferred_maintenance_window,
-                    'Automated Snapshot Retention (Days)': automated_snapshot_retention_period,
-                    'Manual Snapshot Retention (Days)': manual_snapshot_retention_period if manual_snapshot_retention_period >= 0 else 'Unlimited',
-                    'Snapshot Copy': 'Enabled' if snapshot_copy_enabled else 'Disabled',
-                    'Snapshot Copy Destination': destination_region,
-                    'Parameter Group': parameter_group_name,
-                    'IAM Roles': iam_roles_str,
-                    'Allow Version Upgrade': 'Yes' if allow_version_upgrade else 'No',
-                    'Aqua Status': aqua_status,
-                    'Total Storage (GB)': total_storage_gb,
-                    'Logging': 'Enabled' if logging_enabled else 'Disabled',
-                    'Log S3 Bucket': s3_bucket_name,
-                    'Created': cluster_create_time_str,
-                    'Cluster Revision': cluster_revision_number,
-                    'Monthly Cost (On-Demand)': monthly_cost,
-                    'Cost Note': cost_note,
-                })
-
-    except Exception as e:
-        utils.log_error(f"Error scanning Redshift clusters in {region}", e)
+            except Exception as e:
+                # One malformed cluster is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Redshift cluster in {region}: "
+                    f"{cluster.get('ClusterIdentifier', '<unknown>')}",
+                    e,
+                )
+                continue
 
     utils.log_info(f"Found {len(region_clusters)} Redshift clusters in {region}")
     return region_clusters
 
 
-@utils.aws_error_handler("Collecting Redshift clusters", default_return=[])
-def collect_redshift_clusters(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Redshift cluster information from AWS regions."""
+def _build_cluster_row(
+    cluster: dict[str, Any],
+    region: str,
+    pricing_data: dict[str, Any],
+    cost_note: str,
+) -> dict[str, Any]:
+    """Build a single Redshift cluster export row from a describe_clusters response."""
+    cluster_id = cluster.get('ClusterIdentifier', 'N/A')
+
+    # Basic cluster information
+    cluster_status = cluster.get('ClusterStatus', 'unknown')
+    cluster_version = cluster.get('ClusterVersion', 'N/A')
+    node_type = cluster.get('NodeType', 'N/A')
+    number_of_nodes = cluster.get('NumberOfNodes', 0)
+
+    # Single node or multi-node
+    cluster_type = 'Single-node' if number_of_nodes == 1 else f'Multi-node ({number_of_nodes} nodes)'
+
+    # Database information
+    db_name = cluster.get('DBName', 'N/A')
+    master_username = cluster.get('MasterUsername', 'N/A')
+
+    # Endpoint information
+    endpoint = cluster.get('Endpoint', {})
+    endpoint_address = endpoint.get('Address', 'N/A') if endpoint else 'N/A'
+    endpoint_port = endpoint.get('Port', 0) if endpoint else 0
+
+    # VPC and networking
+    vpc_id = cluster.get('VpcId', 'N/A')
+    availability_zone = cluster.get('AvailabilityZone', 'N/A')
+
+    # VPC security groups
+    vpc_security_groups = cluster.get('VpcSecurityGroups', [])
+    security_group_ids = [sg.get('VpcSecurityGroupId', '') for sg in vpc_security_groups]
+    security_groups_str = ', '.join(security_group_ids) if security_group_ids else 'N/A'
+
+    # Cluster subnet group
+    cluster_subnet_group_name = cluster.get('ClusterSubnetGroupName', 'N/A')
+
+    # Public accessibility
+    publicly_accessible = cluster.get('PubliclyAccessible', False)
+
+    # Encryption
+    encrypted = cluster.get('Encrypted', False)
+    kms_key_id = cluster.get('KmsKeyId', 'N/A')
+    if kms_key_id != 'N/A' and '/' in kms_key_id:
+        kms_key_id = kms_key_id.split('/')[-1]  # Extract key ID from ARN
+
+    # Enhanced VPC routing
+    enhanced_vpc_routing = cluster.get('EnhancedVpcRouting', False)
+
+    # Maintenance and backup windows
+    preferred_maintenance_window = cluster.get('PreferredMaintenanceWindow', 'N/A')
+    automated_snapshot_retention_period = cluster.get('AutomatedSnapshotRetentionPeriod', 0)
+    manual_snapshot_retention_period = cluster.get('ManualSnapshotRetentionPeriod', -1)
+
+    # Snapshot copy configuration
+    cluster_snapshot_copy_status = cluster.get('ClusterSnapshotCopyStatus', {})
+    snapshot_copy_enabled = bool(cluster_snapshot_copy_status)
+    destination_region = cluster_snapshot_copy_status.get('DestinationRegion', 'N/A') if snapshot_copy_enabled else 'N/A'
+
+    # Cluster parameter group
+    cluster_parameter_groups = cluster.get('ClusterParameterGroups', [])
+    parameter_group_name = cluster_parameter_groups[0].get('ParameterGroupName', 'N/A') if cluster_parameter_groups else 'N/A'
+
+    # IAM roles
+    iam_roles = cluster.get('IamRoles', [])
+    iam_role_arns = [role.get('IamRoleArn', '') for role in iam_roles]
+    iam_roles_str = ', '.join([arn.split('/')[-1] for arn in iam_role_arns]) if iam_role_arns else 'N/A'
+
+    # Cluster creation time
+    cluster_create_time = cluster.get('ClusterCreateTime')
+    if cluster_create_time:
+        cluster_create_time_str = cluster_create_time.strftime('%Y-%m-%d %H:%M:%S')
+    else:
+        cluster_create_time_str = 'N/A'
+
+    # Allow version upgrade
+    allow_version_upgrade = cluster.get('AllowVersionUpgrade', False)
+
+    # Aqua (Advanced Query Accelerator) configuration
+    aqua_configuration = cluster.get('AquaConfiguration', {})
+    aqua_status = aqua_configuration.get('AquaStatus', 'N/A') if aqua_configuration else 'N/A'
+
+    # Total storage capacity
+    total_storage_capacity_in_megabytes = cluster.get('TotalStorageCapacityInMegaBytes', 0)
+    total_storage_gb = round(total_storage_capacity_in_megabytes / 1024, 2) if total_storage_capacity_in_megabytes else 0
+
+    # Cluster revision number
+    cluster_revision_number = cluster.get('ClusterRevisionNumber', 'N/A')
+
+    # Logging status
+    logging_status = cluster.get('LoggingStatus', {})
+    logging_enabled = logging_status.get('LoggingEnabled', False) if logging_status else False
+    s3_bucket_name = logging_status.get('BucketName', 'N/A') if logging_enabled else 'N/A'
+
+    # Cost estimation
+    monthly_cost = calculate_redshift_monthly_cost(
+        node_type, number_of_nodes, pricing_data
+    )
+
+    return {
+        'Region': region,
+        'Cluster ID': cluster_id,
+        'Status': cluster_status,
+        'Cluster Version': cluster_version,
+        'Node Type': node_type,
+        'Number of Nodes': number_of_nodes,
+        'Cluster Type': cluster_type,
+        'Database Name': db_name,
+        'Master Username': master_username,
+        'Endpoint': endpoint_address,
+        'Port': endpoint_port,
+        'VPC ID': vpc_id,
+        'Availability Zone': availability_zone,
+        'Security Groups': security_groups_str,
+        'Subnet Group': cluster_subnet_group_name,
+        'Publicly Accessible': 'Yes' if publicly_accessible else 'No',
+        'Encrypted': 'Yes' if encrypted else 'No',
+        'KMS Key ID': kms_key_id if encrypted else 'N/A',
+        'Enhanced VPC Routing': 'Yes' if enhanced_vpc_routing else 'No',
+        'Maintenance Window': preferred_maintenance_window,
+        'Automated Snapshot Retention (Days)': automated_snapshot_retention_period,
+        'Manual Snapshot Retention (Days)': manual_snapshot_retention_period if manual_snapshot_retention_period >= 0 else 'Unlimited',
+        'Snapshot Copy': 'Enabled' if snapshot_copy_enabled else 'Disabled',
+        'Snapshot Copy Destination': destination_region,
+        'Parameter Group': parameter_group_name,
+        'IAM Roles': iam_roles_str,
+        'Allow Version Upgrade': 'Yes' if allow_version_upgrade else 'No',
+        'Aqua Status': aqua_status,
+        'Total Storage (GB)': total_storage_gb,
+        'Logging': 'Enabled' if logging_enabled else 'Disabled',
+        'Log S3 Bucket': s3_bucket_name,
+        'Created': cluster_create_time_str,
+        'Cluster Revision': cluster_revision_number,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
+def collect_redshift_clusters(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Redshift cluster information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(clusters, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    all_clusters = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_redshift_clusters_in_region,
-    ):
-        all_clusters.extend(region_data)
-
-    return all_clusters
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_clusters = [cluster for result in region_results for cluster in result]
+    return all_clusters, failed_regions
 
 
 def scan_redshift_snapshots_in_region(region: str) -> list[dict[str, Any]]:
@@ -609,7 +654,9 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Redshift data and write the Excel export."""
     # Collect data
     print("\n=== Collecting Redshift Data ===")
-    clusters = collect_redshift_clusters(regions)
+    # STEP 1: Collect Redshift clusters (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    clusters, failed_regions = collect_redshift_clusters(regions)
     snapshots = collect_redshift_snapshots(regions)
     parameter_groups = collect_redshift_parameter_groups(regions)
     subnet_groups = collect_redshift_subnet_groups(regions)
@@ -651,6 +698,21 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary cluster scope collection, make it
+    # loud: write a marker and exit non-zero, even though the always-written
+    # Summary sheet means the workbook still lands. A file that looks
+    # complete but is silently missing data is exactly the failure mode
+    # this guards against. Genuinely-empty (every region succeeded, zero
+    # clusters found) stays a normal exit 0 — no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'redshift', failed_regions)
+        print(
+            "\nERROR: Redshift export completed with failures — data is incomplete. "
+            "See the *-redshift-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
+
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/sagemaker_export.py
+++ b/scripts/sagemaker_export.py
@@ -61,537 +61,598 @@ def _load_sagemaker_pricing_data(region: str) -> dict[str, dict[str, float]]:
         return {}
 
 
+def _build_notebook_row(notebook: dict, region: str, sagemaker_client, sm_pricing_data: dict) -> dict[str, Any]:
+    """
+    Build the export row for a single SageMaker notebook instance.
+
+    Extracted so per-notebook processing can be wrapped in try/except by the
+    caller: a malformed/unreachable notebook is logged and skipped rather
+    than discarding the whole region's results.
+    """
+    notebook_name = notebook.get('NotebookInstanceName', 'N/A')
+
+    notebook_response = sagemaker_client.describe_notebook_instance(
+        NotebookInstanceName=notebook_name
+    )
+
+    instance_type = notebook_response.get('InstanceType', 'N/A')
+    status = notebook_response.get('NotebookInstanceStatus', 'N/A')
+    arn = notebook_response.get('NotebookInstanceArn', 'N/A')
+
+    creation_time = notebook_response.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_modified = notebook_response.get('LastModifiedTime', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Network configuration
+    subnet_id = notebook_response.get('SubnetId', 'N/A')
+    security_groups = notebook_response.get('SecurityGroups', [])
+    security_groups_str = ', '.join(security_groups) if security_groups else 'None'
+
+    # Access settings
+    direct_internet_access = notebook_response.get('DirectInternetAccess', 'Enabled')
+    root_access = notebook_response.get('RootAccess', 'Enabled')
+
+    # IAM role
+    role_arn = notebook_response.get('RoleArn', 'N/A')
+
+    # Volume settings
+    volume_size_gb = notebook_response.get('VolumeSizeInGB', 'N/A')
+
+    # Platform identifier
+    platform_identifier = notebook_response.get('PlatformIdentifier', 'N/A')
+
+    # URL
+    url = notebook_response.get('Url', 'N/A')
+
+    # Lifecycle config
+    lifecycle_config = notebook_response.get('NotebookInstanceLifecycleConfigName', 'None')
+
+    # KMS key
+    kms_key = notebook_response.get('KmsKeyId', 'None')
+
+    # Failure reason
+    failure_reason = notebook_response.get('FailureReason', 'N/A')
+
+    # Cost estimation — monthly if always running; $0 when stopped
+    nb_pricing = sm_pricing_data.get(instance_type, {})
+    if status == 'InService' and nb_pricing:
+        monthly_cost = nb_pricing['monthly']
+        cost_note = 'Estimate: monthly if running 24/7; $0 when stopped'
+    elif status == 'Stopped':
+        monthly_cost = 0.0
+        cost_note = 'No compute charge while stopped'
+    elif nb_pricing:
+        monthly_cost = 'N/A'
+        cost_note = f'Status={status}; cost not estimated'
+    else:
+        monthly_cost = 'N/A'
+        cost_note = 'Instance type not in pricing data'
+
+    return {
+        'Region': region,
+        'Notebook Name': notebook_name,
+        'ARN': arn,
+        'Status': status,
+        'Instance Type': instance_type,
+        'Platform': platform_identifier,
+        'Created': creation_time,
+        'Last Modified': last_modified,
+        'Volume Size (GB)': volume_size_gb,
+        'Direct Internet Access': direct_internet_access,
+        'Root Access': root_access,
+        'Subnet ID': subnet_id,
+        'Security Groups': security_groups_str,
+        'IAM Role ARN': role_arn,
+        'Lifecycle Config': lifecycle_config,
+        'KMS Key': kms_key,
+        'URL': url,
+        'Failure Reason': failure_reason,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
 def _scan_notebook_instances_region(region: str) -> list[dict[str, Any]]:
-    """Scan SageMaker notebook instances in a single region."""
+    """
+    Scan SageMaker notebook instances in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no notebook instances"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed/unreachable notebook instances are skipped (logged)
+    rather than aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_notebooks = []
+    sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
+    sm_pricing_data = _load_sagemaker_pricing_data(region)
 
-    try:
-        sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
-        sm_pricing_data = _load_sagemaker_pricing_data(region)
+    paginator = sagemaker_client.get_paginator('list_notebook_instances')
+    for page in paginator.paginate():
+        notebooks = page.get('NotebookInstances', [])
 
-        try:
-            paginator = sagemaker_client.get_paginator('list_notebook_instances')
-            for page in paginator.paginate():
-                notebooks = page.get('NotebookInstances', [])
-
-                for notebook in notebooks:
-                    notebook_name = notebook.get('NotebookInstanceName', 'N/A')
-
-                    # Get detailed notebook information
-                    try:
-                        notebook_response = sagemaker_client.describe_notebook_instance(
-                            NotebookInstanceName=notebook_name
-                        )
-
-                        instance_type = notebook_response.get('InstanceType', 'N/A')
-                        status = notebook_response.get('NotebookInstanceStatus', 'N/A')
-                        arn = notebook_response.get('NotebookInstanceArn', 'N/A')
-
-                        creation_time = notebook_response.get('CreationTime', 'N/A')
-                        if creation_time != 'N/A':
-                            creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                        last_modified = notebook_response.get('LastModifiedTime', 'N/A')
-                        if last_modified != 'N/A':
-                            last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                        # Network configuration
-                        subnet_id = notebook_response.get('SubnetId', 'N/A')
-                        security_groups = notebook_response.get('SecurityGroups', [])
-                        security_groups_str = ', '.join(security_groups) if security_groups else 'None'
-
-                        # Access settings
-                        direct_internet_access = notebook_response.get('DirectInternetAccess', 'Enabled')
-                        root_access = notebook_response.get('RootAccess', 'Enabled')
-
-                        # IAM role
-                        role_arn = notebook_response.get('RoleArn', 'N/A')
-
-                        # Volume settings
-                        volume_size_gb = notebook_response.get('VolumeSizeInGB', 'N/A')
-
-                        # Platform identifier
-                        platform_identifier = notebook_response.get('PlatformIdentifier', 'N/A')
-
-                        # URL
-                        url = notebook_response.get('Url', 'N/A')
-
-                        # Lifecycle config
-                        lifecycle_config = notebook_response.get('NotebookInstanceLifecycleConfigName', 'None')
-
-                        # KMS key
-                        kms_key = notebook_response.get('KmsKeyId', 'None')
-
-                        # Failure reason
-                        failure_reason = notebook_response.get('FailureReason', 'N/A')
-
-                        # Cost estimation — monthly if always running; $0 when stopped
-                        nb_pricing = sm_pricing_data.get(instance_type, {})
-                        if status == 'InService' and nb_pricing:
-                            monthly_cost = nb_pricing['monthly']
-                            cost_note = 'Estimate: monthly if running 24/7; $0 when stopped'
-                        elif status == 'Stopped':
-                            monthly_cost = 0.0
-                            cost_note = 'No compute charge while stopped'
-                        elif nb_pricing:
-                            monthly_cost = 'N/A'
-                            cost_note = f'Status={status}; cost not estimated'
-                        else:
-                            monthly_cost = 'N/A'
-                            cost_note = 'Instance type not in pricing data'
-
-                        regional_notebooks.append({
-                            'Region': region,
-                            'Notebook Name': notebook_name,
-                            'ARN': arn,
-                            'Status': status,
-                            'Instance Type': instance_type,
-                            'Platform': platform_identifier,
-                            'Created': creation_time,
-                            'Last Modified': last_modified,
-                            'Volume Size (GB)': volume_size_gb,
-                            'Direct Internet Access': direct_internet_access,
-                            'Root Access': root_access,
-                            'Subnet ID': subnet_id,
-                            'Security Groups': security_groups_str,
-                            'IAM Role ARN': role_arn,
-                            'Lifecycle Config': lifecycle_config,
-                            'KMS Key': kms_key,
-                            'URL': url,
-                            'Failure Reason': failure_reason,
-                            'Monthly Cost (On-Demand)': monthly_cost,
-                            'Cost Note': cost_note,
-                        })
-
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for notebook {notebook_name} in {region}: {str(e)}")
-                        continue
-
-        except Exception as e:
-            utils.log_warning(f"Error listing notebook instances in {region}: {str(e)}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting notebook instances in {region}", e)
+        for notebook in notebooks:
+            notebook_name = notebook.get('NotebookInstanceName', '<unknown>')
+            try:
+                regional_notebooks.append(
+                    _build_notebook_row(notebook, region, sagemaker_client, sm_pricing_data)
+                )
+            except Exception as e:
+                utils.log_warning(f"Could not get details for notebook {notebook_name} in {region}: {str(e)}")
+                continue
 
     return regional_notebooks
 
 
-@utils.aws_error_handler("Collecting SageMaker notebook instances", default_return=[])
-def collect_notebook_instances(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SageMaker notebook instance information from AWS regions."""
+def collect_notebook_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect SageMaker notebook instance information across regions, surfacing
+    failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(notebooks, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING SAGEMAKER NOTEBOOK INSTANCES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_notebook_instances_region)
-    all_notebooks = [nb for result in results for nb in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_notebook_instances_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_notebooks = [nb for result in region_results for nb in result]
     utils.log_success(f"Total notebook instances collected: {len(all_notebooks)}")
-    return all_notebooks
+    return all_notebooks, failed_regions
+
+
+def _build_training_job_row(job: dict, region: str, sagemaker_client, sm_pricing_data: dict) -> dict[str, Any]:
+    """Build the export row for a single SageMaker training job."""
+    job_name = job.get('TrainingJobName', 'N/A')
+
+    job_response = sagemaker_client.describe_training_job(TrainingJobName=job_name)
+
+    status = job_response.get('TrainingJobStatus', 'N/A')
+    arn = job_response.get('TrainingJobArn', 'N/A')
+
+    creation_time = job_response.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    training_start = job_response.get('TrainingStartTime', 'N/A')
+    if training_start != 'N/A':
+        training_start = training_start.strftime('%Y-%m-%d %H:%M:%S')
+
+    training_end = job_response.get('TrainingEndTime', 'N/A')
+    if training_end != 'N/A':
+        training_end = training_end.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Training duration
+    training_time_seconds = job_response.get('TrainingTimeInSeconds', 0)
+    training_time_str = f"{training_time_seconds / 60:.1f} minutes" if training_time_seconds else 'N/A'
+
+    # Billable time
+    billable_seconds = job_response.get('BillableTimeInSeconds', 0)
+    billable_time_str = f"{billable_seconds / 60:.1f} minutes" if billable_seconds else 'N/A'
+
+    # Algorithm
+    algorithm_spec = job_response.get('AlgorithmSpecification', {})
+    training_image = algorithm_spec.get('TrainingImage', 'N/A')
+    algorithm_name = algorithm_spec.get('AlgorithmName', 'N/A')
+
+    # Extract algorithm type from image
+    algorithm_type = 'Custom'
+    if 'xgboost' in training_image.lower():
+        algorithm_type = 'XGBoost'
+    elif 'blazingtext' in training_image.lower():
+        algorithm_type = 'BlazingText'
+    elif 'linear-learner' in training_image.lower():
+        algorithm_type = 'Linear Learner'
+    elif algorithm_name != 'N/A':
+        algorithm_type = algorithm_name
+
+    # Resource config
+    resource_config = job_response.get('ResourceConfig', {})
+    instance_type = resource_config.get('InstanceType', 'N/A')
+    instance_count = resource_config.get('InstanceCount', 0)
+    volume_size_gb = resource_config.get('VolumeSizeInGB', 'N/A')
+
+    # Hyperparameters
+    hyperparameters = job_response.get('HyperParameters', {})
+    hyperparam_count = len(hyperparameters)
+
+    # Metrics
+    final_metrics = job_response.get('FinalMetricDataList', [])
+    metric_count = len(final_metrics)
+
+    # Output
+    model_artifacts = job_response.get('ModelArtifacts', {})
+    s3_model_artifacts = model_artifacts.get('S3ModelArtifacts', 'N/A')
+
+    # Failure reason
+    failure_reason = job_response.get('FailureReason', 'N/A')
+
+    # Actual job cost from billable seconds (only meaningful for Completed)
+    tj_pricing = sm_pricing_data.get(instance_type, {})
+    if status == 'Completed' and billable_seconds and instance_count and tj_pricing:
+        actual_cost = round((billable_seconds / 3600) * instance_count * tj_pricing['hourly'], 4)
+        cost_note = 'Actual: (billable_sec / 3600) x instances x on-demand rate'
+    elif status == 'Completed' and not tj_pricing:
+        actual_cost = 'N/A'
+        cost_note = 'Instance type not in pricing data'
+    else:
+        actual_cost = 'N/A'
+        cost_note = f'Status={status}; actual cost unavailable'
+
+    return {
+        'Region': region,
+        'Job Name': job_name,
+        'ARN': arn,
+        'Status': status,
+        'Algorithm Type': algorithm_type,
+        'Instance Type': instance_type,
+        'Instance Count': instance_count,
+        'Volume Size (GB)': volume_size_gb,
+        'Created': creation_time,
+        'Training Start': training_start,
+        'Training End': training_end,
+        'Training Time': training_time_str,
+        'Billable Time': billable_time_str,
+        'Hyperparameters': hyperparam_count,
+        'Final Metrics': metric_count,
+        'Model Artifacts': s3_model_artifacts,
+        'Failure Reason': failure_reason,
+        'Job Cost (On-Demand)': actual_cost,
+        'Cost Note': cost_note,
+    }
 
 
 def _scan_training_jobs_region(region: str) -> list[dict[str, Any]]:
-    """Scan SageMaker training jobs in a single region (limited to 50 most recent)."""
+    """
+    Scan SageMaker training jobs in a single region (limited to 50 most
+    recent). Raises on scope-level failure; per-job failures are skipped.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_jobs = []
+    sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
+    sm_pricing_data = _load_sagemaker_pricing_data(region)
 
-    try:
-        sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
-        sm_pricing_data = _load_sagemaker_pricing_data(region)
+    paginator = sagemaker_client.get_paginator('list_training_jobs')
+    job_count = 0
+    for page in paginator.paginate(
+        SortBy='CreationTime',
+        SortOrder='Descending',
+        PaginationConfig={'MaxItems': 50}
+    ):
+        jobs = page.get('TrainingJobSummaries', [])
 
-        try:
-            # List recent training jobs (limit to 50)
-            paginator = sagemaker_client.get_paginator('list_training_jobs')
-            job_count = 0
-            for page in paginator.paginate(
-                SortBy='CreationTime',
-                SortOrder='Descending',
-                PaginationConfig={'MaxItems': 50}
-            ):
-                jobs = page.get('TrainingJobSummaries', [])
+        for job in jobs:
+            job_name = job.get('TrainingJobName', '<unknown>')
+            try:
+                regional_jobs.append(
+                    _build_training_job_row(job, region, sagemaker_client, sm_pricing_data)
+                )
+            except Exception as e:
+                utils.log_warning(f"Could not get details for training job {job_name}: {str(e)}")
+                continue
 
-                for job in jobs:
-                    job_name = job.get('TrainingJobName', 'N/A')
+            job_count += 1
 
-                    # Get detailed job information
-                    try:
-                        job_response = sagemaker_client.describe_training_job(
-                            TrainingJobName=job_name
-                        )
-
-                        status = job_response.get('TrainingJobStatus', 'N/A')
-                        arn = job_response.get('TrainingJobArn', 'N/A')
-
-                        creation_time = job_response.get('CreationTime', 'N/A')
-                        if creation_time != 'N/A':
-                            creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                        training_start = job_response.get('TrainingStartTime', 'N/A')
-                        if training_start != 'N/A':
-                            training_start = training_start.strftime('%Y-%m-%d %H:%M:%S')
-
-                        training_end = job_response.get('TrainingEndTime', 'N/A')
-                        if training_end != 'N/A':
-                            training_end = training_end.strftime('%Y-%m-%d %H:%M:%S')
-
-                        # Training duration
-                        training_time_seconds = job_response.get('TrainingTimeInSeconds', 0)
-                        training_time_str = f"{training_time_seconds / 60:.1f} minutes" if training_time_seconds else 'N/A'
-
-                        # Billable time
-                        billable_seconds = job_response.get('BillableTimeInSeconds', 0)
-                        billable_time_str = f"{billable_seconds / 60:.1f} minutes" if billable_seconds else 'N/A'
-
-                        # Algorithm
-                        algorithm_spec = job_response.get('AlgorithmSpecification', {})
-                        training_image = algorithm_spec.get('TrainingImage', 'N/A')
-                        algorithm_name = algorithm_spec.get('AlgorithmName', 'N/A')
-
-                        # Extract algorithm type from image
-                        algorithm_type = 'Custom'
-                        if 'xgboost' in training_image.lower():
-                            algorithm_type = 'XGBoost'
-                        elif 'blazingtext' in training_image.lower():
-                            algorithm_type = 'BlazingText'
-                        elif 'linear-learner' in training_image.lower():
-                            algorithm_type = 'Linear Learner'
-                        elif algorithm_name != 'N/A':
-                            algorithm_type = algorithm_name
-
-                        # Resource config
-                        resource_config = job_response.get('ResourceConfig', {})
-                        instance_type = resource_config.get('InstanceType', 'N/A')
-                        instance_count = resource_config.get('InstanceCount', 0)
-                        volume_size_gb = resource_config.get('VolumeSizeInGB', 'N/A')
-
-                        # Hyperparameters
-                        hyperparameters = job_response.get('HyperParameters', {})
-                        hyperparam_count = len(hyperparameters)
-
-                        # Metrics
-                        final_metrics = job_response.get('FinalMetricDataList', [])
-                        metric_count = len(final_metrics)
-
-                        # Output
-                        model_artifacts = job_response.get('ModelArtifacts', {})
-                        s3_model_artifacts = model_artifacts.get('S3ModelArtifacts', 'N/A')
-
-                        # Failure reason
-                        failure_reason = job_response.get('FailureReason', 'N/A')
-
-                        # Actual job cost from billable seconds (only meaningful for Completed)
-                        tj_pricing = sm_pricing_data.get(instance_type, {})
-                        if status == 'Completed' and billable_seconds and instance_count and tj_pricing:
-                            actual_cost = round((billable_seconds / 3600) * instance_count * tj_pricing['hourly'], 4)
-                            cost_note = 'Actual: (billable_sec / 3600) x instances x on-demand rate'
-                        elif status == 'Completed' and not tj_pricing:
-                            actual_cost = 'N/A'
-                            cost_note = 'Instance type not in pricing data'
-                        else:
-                            actual_cost = 'N/A'
-                            cost_note = f'Status={status}; actual cost unavailable'
-
-                        regional_jobs.append({
-                            'Region': region,
-                            'Job Name': job_name,
-                            'ARN': arn,
-                            'Status': status,
-                            'Algorithm Type': algorithm_type,
-                            'Instance Type': instance_type,
-                            'Instance Count': instance_count,
-                            'Volume Size (GB)': volume_size_gb,
-                            'Created': creation_time,
-                            'Training Start': training_start,
-                            'Training End': training_end,
-                            'Training Time': training_time_str,
-                            'Billable Time': billable_time_str,
-                            'Hyperparameters': hyperparam_count,
-                            'Final Metrics': metric_count,
-                            'Model Artifacts': s3_model_artifacts,
-                            'Failure Reason': failure_reason,
-                            'Job Cost (On-Demand)': actual_cost,
-                            'Cost Note': cost_note,
-                        })
-
-                        job_count += 1
-
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for training job {job_name}: {str(e)}")
-                        continue
-
-                if job_count >= 50:
-                    break
-
-        except Exception as e:
-            utils.log_warning(f"Error listing training jobs in {region}: {str(e)}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting training jobs in {region}", e)
+        if job_count >= 50:
+            break
 
     return regional_jobs
 
 
-@utils.aws_error_handler("Collecting SageMaker training jobs", default_return=[])
-def collect_training_jobs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SageMaker training job information (limited to recent 50 per region)."""
+def collect_training_jobs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect SageMaker training job information (limited to recent 50 per region), surfacing failures."""
     print("\n=== COLLECTING SAGEMAKER TRAINING JOBS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_training_jobs_region)
-    all_jobs = [job for result in results for job in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_training_jobs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_jobs = [job for result in region_results for job in result]
     utils.log_success(f"Total training jobs collected: {len(all_jobs)} (limited to 50 per region)")
-    return all_jobs
+    return all_jobs, failed_regions
+
+
+def _build_model_row(model: dict, region: str, sagemaker_client) -> dict[str, Any]:
+    """Build the export row for a single SageMaker model."""
+    model_name = model.get('ModelName', 'N/A')
+
+    model_response = sagemaker_client.describe_model(ModelName=model_name)
+
+    arn = model_response.get('ModelArn', 'N/A')
+    role_arn = model_response.get('ExecutionRoleArn', 'N/A')
+
+    creation_time = model_response.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Primary container
+    primary_container = model_response.get('PrimaryContainer', {})
+    container_image = primary_container.get('Image', 'N/A')
+    model_data_url = primary_container.get('ModelDataUrl', 'N/A')
+    container_mode = primary_container.get('Mode', 'N/A')
+
+    # VPC config
+    vpc_config = model_response.get('VpcConfig', {})
+    subnets = vpc_config.get('Subnets', [])
+    vpc_enabled = 'Yes' if subnets else 'No'
+
+    # Network isolation
+    enable_network_isolation = model_response.get('EnableNetworkIsolation', False)
+
+    # Containers
+    containers = model_response.get('Containers', [])
+    container_count = len(containers) if containers else (1 if primary_container else 0)
+
+    return {
+        'Region': region,
+        'Model Name': model_name,
+        'ARN': arn,
+        'Created': creation_time,
+        'Execution Role ARN': role_arn,
+        'Container Image': container_image,
+        'Model Data URL': model_data_url,
+        'Container Mode': container_mode,
+        'Container Count': container_count,
+        'VPC Enabled': vpc_enabled,
+        'Network Isolation': enable_network_isolation
+    }
 
 
 def _scan_models_region(region: str) -> list[dict[str, Any]]:
-    """Scan SageMaker models in a single region."""
+    """
+    Scan SageMaker models in a single region. Raises on scope-level failure;
+    per-model failures are skipped.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_models = []
+    sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
 
-    try:
-        sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
+    paginator = sagemaker_client.get_paginator('list_models')
+    for page in paginator.paginate():
+        models = page.get('Models', [])
 
-        try:
-            paginator = sagemaker_client.get_paginator('list_models')
-            for page in paginator.paginate():
-                models = page.get('Models', [])
-
-                for model in models:
-                    model_name = model.get('ModelName', 'N/A')
-
-                    # Get detailed model information
-                    try:
-                        model_response = sagemaker_client.describe_model(ModelName=model_name)
-
-                        arn = model_response.get('ModelArn', 'N/A')
-                        role_arn = model_response.get('ExecutionRoleArn', 'N/A')
-
-                        creation_time = model_response.get('CreationTime', 'N/A')
-                        if creation_time != 'N/A':
-                            creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                        # Primary container
-                        primary_container = model_response.get('PrimaryContainer', {})
-                        container_image = primary_container.get('Image', 'N/A')
-                        model_data_url = primary_container.get('ModelDataUrl', 'N/A')
-                        container_mode = primary_container.get('Mode', 'N/A')
-
-                        # VPC config
-                        vpc_config = model_response.get('VpcConfig', {})
-                        subnets = vpc_config.get('Subnets', [])
-                        vpc_enabled = 'Yes' if subnets else 'No'
-
-                        # Network isolation
-                        enable_network_isolation = model_response.get('EnableNetworkIsolation', False)
-
-                        # Containers
-                        containers = model_response.get('Containers', [])
-                        container_count = len(containers) if containers else (1 if primary_container else 0)
-
-                        regional_models.append({
-                            'Region': region,
-                            'Model Name': model_name,
-                            'ARN': arn,
-                            'Created': creation_time,
-                            'Execution Role ARN': role_arn,
-                            'Container Image': container_image,
-                            'Model Data URL': model_data_url,
-                            'Container Mode': container_mode,
-                            'Container Count': container_count,
-                            'VPC Enabled': vpc_enabled,
-                            'Network Isolation': enable_network_isolation
-                        })
-
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for model {model_name}: {str(e)}")
-                        continue
-
-        except Exception as e:
-            utils.log_warning(f"Error listing models in {region}: {str(e)}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting models in {region}", e)
+        for model in models:
+            model_name = model.get('ModelName', '<unknown>')
+            try:
+                regional_models.append(_build_model_row(model, region, sagemaker_client))
+            except Exception as e:
+                utils.log_warning(f"Could not get details for model {model_name}: {str(e)}")
+                continue
 
     return regional_models
 
 
-@utils.aws_error_handler("Collecting SageMaker models", default_return=[])
-def collect_models(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SageMaker model information."""
+def collect_models(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect SageMaker model information, surfacing failures."""
     print("\n=== COLLECTING SAGEMAKER MODELS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_models_region)
-    all_models = [model for result in results for model in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_models_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_models = [model for result in region_results for model in result]
     utils.log_success(f"Total models collected: {len(all_models)}")
-    return all_models
+    return all_models, failed_regions
+
+
+def _build_endpoint_row(endpoint: dict, region: str, sagemaker_client, sm_pricing_data: dict) -> dict[str, Any]:
+    """Build the export row for a single SageMaker endpoint."""
+    endpoint_name = endpoint.get('EndpointName', 'N/A')
+
+    endpoint_response = sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
+
+    status = endpoint_response.get('EndpointStatus', 'N/A')
+    arn = endpoint_response.get('EndpointArn', 'N/A')
+    config_name = endpoint_response.get('EndpointConfigName', 'N/A')
+
+    creation_time = endpoint_response.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_modified = endpoint_response.get('LastModifiedTime', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Production variants
+    production_variants = endpoint_response.get('ProductionVariants', [])
+    variant_count = len(production_variants)
+
+    # Get instance info from first variant
+    instance_type = 'N/A'
+    current_instance_count = 0
+    desired_instance_count = 0
+
+    if production_variants:
+        first_variant = production_variants[0]
+        instance_type = first_variant.get('InstanceType', 'N/A')
+        current_instance_count = first_variant.get('CurrentInstanceCount', 0)
+        desired_instance_count = first_variant.get('DesiredInstanceCount', 0)
+
+    # Data capture config
+    data_capture_config = endpoint_response.get('DataCaptureConfig', {})
+    data_capture_enabled = data_capture_config.get('EnableCapture', False)
+
+    # Failure reason
+    failure_reason = endpoint_response.get('FailureReason', 'N/A')
+
+    # Monthly cost for InService endpoints (first variant × current count)
+    ep_pricing = sm_pricing_data.get(instance_type, {})
+    instance_count_for_cost = current_instance_count or desired_instance_count
+    if status == 'InService' and ep_pricing and instance_count_for_cost:
+        monthly_cost = round(ep_pricing['monthly'] * instance_count_for_cost, 2)
+        cost_note = 'Estimate: first variant × instance count × 730 hr/mo; multi-variant may be higher'
+    elif status == 'InService' and not ep_pricing:
+        monthly_cost = 'N/A'
+        cost_note = 'Instance type not in pricing data'
+    else:
+        monthly_cost = 'N/A'
+        cost_note = f'Status={status}; cost not estimated'
+
+    return {
+        'Region': region,
+        'Endpoint Name': endpoint_name,
+        'ARN': arn,
+        'Status': status,
+        'Config Name': config_name,
+        'Created': creation_time,
+        'Last Modified': last_modified,
+        'Instance Type': instance_type,
+        'Current Instances': current_instance_count,
+        'Desired Instances': desired_instance_count,
+        'Production Variants': variant_count,
+        'Data Capture Enabled': data_capture_enabled,
+        'Failure Reason': failure_reason,
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
 
 
 def _scan_endpoints_region(region: str) -> list[dict[str, Any]]:
-    """Scan SageMaker endpoints in a single region."""
+    """
+    Scan SageMaker endpoints in a single region. Raises on scope-level
+    failure; per-endpoint failures are skipped.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_endpoints = []
+    sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
+    sm_pricing_data = _load_sagemaker_pricing_data(region)
 
-    try:
-        sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
-        sm_pricing_data = _load_sagemaker_pricing_data(region)
+    paginator = sagemaker_client.get_paginator('list_endpoints')
+    for page in paginator.paginate():
+        endpoints = page.get('Endpoints', [])
 
-        try:
-            paginator = sagemaker_client.get_paginator('list_endpoints')
-            for page in paginator.paginate():
-                endpoints = page.get('Endpoints', [])
-
-                for endpoint in endpoints:
-                    endpoint_name = endpoint.get('EndpointName', 'N/A')
-
-                    # Get detailed endpoint information
-                    try:
-                        endpoint_response = sagemaker_client.describe_endpoint(
-                            EndpointName=endpoint_name
-                        )
-
-                        status = endpoint_response.get('EndpointStatus', 'N/A')
-                        arn = endpoint_response.get('EndpointArn', 'N/A')
-                        config_name = endpoint_response.get('EndpointConfigName', 'N/A')
-
-                        creation_time = endpoint_response.get('CreationTime', 'N/A')
-                        if creation_time != 'N/A':
-                            creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                        last_modified = endpoint_response.get('LastModifiedTime', 'N/A')
-                        if last_modified != 'N/A':
-                            last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                        # Production variants
-                        production_variants = endpoint_response.get('ProductionVariants', [])
-                        variant_count = len(production_variants)
-
-                        # Get instance info from first variant
-                        instance_type = 'N/A'
-                        current_instance_count = 0
-                        desired_instance_count = 0
-
-                        if production_variants:
-                            first_variant = production_variants[0]
-                            instance_type = first_variant.get('InstanceType', 'N/A')
-                            current_instance_count = first_variant.get('CurrentInstanceCount', 0)
-                            desired_instance_count = first_variant.get('DesiredInstanceCount', 0)
-
-                        # Data capture config
-                        data_capture_config = endpoint_response.get('DataCaptureConfig', {})
-                        data_capture_enabled = data_capture_config.get('EnableCapture', False)
-
-                        # Failure reason
-                        failure_reason = endpoint_response.get('FailureReason', 'N/A')
-
-                        # Monthly cost for InService endpoints (first variant × current count)
-                        ep_pricing = sm_pricing_data.get(instance_type, {})
-                        instance_count_for_cost = current_instance_count or desired_instance_count
-                        if status == 'InService' and ep_pricing and instance_count_for_cost:
-                            monthly_cost = round(ep_pricing['monthly'] * instance_count_for_cost, 2)
-                            cost_note = 'Estimate: first variant × instance count × 730 hr/mo; multi-variant may be higher'
-                        elif status == 'InService' and not ep_pricing:
-                            monthly_cost = 'N/A'
-                            cost_note = 'Instance type not in pricing data'
-                        else:
-                            monthly_cost = 'N/A'
-                            cost_note = f'Status={status}; cost not estimated'
-
-                        regional_endpoints.append({
-                            'Region': region,
-                            'Endpoint Name': endpoint_name,
-                            'ARN': arn,
-                            'Status': status,
-                            'Config Name': config_name,
-                            'Created': creation_time,
-                            'Last Modified': last_modified,
-                            'Instance Type': instance_type,
-                            'Current Instances': current_instance_count,
-                            'Desired Instances': desired_instance_count,
-                            'Production Variants': variant_count,
-                            'Data Capture Enabled': data_capture_enabled,
-                            'Failure Reason': failure_reason,
-                            'Monthly Cost (On-Demand)': monthly_cost,
-                            'Cost Note': cost_note,
-                        })
-
-                    except Exception as e:
-                        utils.log_warning(f"Could not get details for endpoint {endpoint_name}: {str(e)}")
-                        continue
-
-        except Exception as e:
-            utils.log_warning(f"Error listing endpoints in {region}: {str(e)}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting endpoints in {region}", e)
+        for endpoint in endpoints:
+            endpoint_name = endpoint.get('EndpointName', '<unknown>')
+            try:
+                regional_endpoints.append(
+                    _build_endpoint_row(endpoint, region, sagemaker_client, sm_pricing_data)
+                )
+            except Exception as e:
+                utils.log_warning(f"Could not get details for endpoint {endpoint_name}: {str(e)}")
+                continue
 
     return regional_endpoints
 
 
-@utils.aws_error_handler("Collecting SageMaker endpoints", default_return=[])
-def collect_endpoints(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SageMaker endpoint information."""
+def collect_endpoints(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect SageMaker endpoint information, surfacing failures."""
     print("\n=== COLLECTING SAGEMAKER ENDPOINTS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_endpoints_region)
-    all_endpoints = [ep for result in results for ep in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_endpoints_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_endpoints = [ep for result in region_results for ep in result]
     utils.log_success(f"Total endpoints collected: {len(all_endpoints)}")
-    return all_endpoints
+    return all_endpoints, failed_regions
+
+
+def _build_processing_job_row(job: dict, region: str) -> dict[str, Any]:
+    """Build the export row for a single SageMaker processing job summary."""
+    job_name = job.get('ProcessingJobName', 'N/A')
+    status = job.get('ProcessingJobStatus', 'N/A')
+    arn = job.get('ProcessingJobArn', 'N/A')
+
+    creation_time = job.get('CreationTime', 'N/A')
+    if creation_time != 'N/A':
+        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    processing_end = job.get('ProcessingEndTime', 'N/A')
+    if processing_end != 'N/A':
+        processing_end = processing_end.strftime('%Y-%m-%d %H:%M:%S')
+
+    failure_reason = job.get('FailureReason', 'N/A')
+
+    return {
+        'Region': region,
+        'Job Name': job_name,
+        'ARN': arn,
+        'Status': status,
+        'Created': creation_time,
+        'Processing End': processing_end,
+        'Failure Reason': failure_reason
+    }
 
 
 def _scan_processing_jobs_region(region: str) -> list[dict[str, Any]]:
-    """Scan SageMaker processing jobs in a single region (limited to 30 most recent)."""
+    """
+    Scan SageMaker processing jobs in a single region (limited to 30 most
+    recent). Raises on scope-level failure; per-job failures are skipped.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_jobs = []
+    sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
 
-    try:
-        sagemaker_client = utils.get_boto3_client('sagemaker', region_name=region)
+    paginator = sagemaker_client.get_paginator('list_processing_jobs')
+    job_count = 0
+    for page in paginator.paginate(
+        SortBy='CreationTime',
+        SortOrder='Descending',
+        PaginationConfig={'MaxItems': 30}
+    ):
+        jobs = page.get('ProcessingJobSummaries', [])
 
-        try:
-            # List recent processing jobs (limit to 30)
-            paginator = sagemaker_client.get_paginator('list_processing_jobs')
-            job_count = 0
-            for page in paginator.paginate(
-                SortBy='CreationTime',
-                SortOrder='Descending',
-                PaginationConfig={'MaxItems': 30}
-            ):
-                jobs = page.get('ProcessingJobSummaries', [])
+        for job in jobs:
+            job_name = job.get('ProcessingJobName', '<unknown>')
+            try:
+                regional_jobs.append(_build_processing_job_row(job, region))
+            except Exception as e:
+                utils.log_warning(f"Skipping malformed processing job {job_name} in {region}: {str(e)}")
+                continue
 
-                for job in jobs:
-                    job_name = job.get('ProcessingJobName', 'N/A')
-                    status = job.get('ProcessingJobStatus', 'N/A')
-                    arn = job.get('ProcessingJobArn', 'N/A')
-
-                    creation_time = job.get('CreationTime', 'N/A')
-                    if creation_time != 'N/A':
-                        creation_time = creation_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    processing_end = job.get('ProcessingEndTime', 'N/A')
-                    if processing_end != 'N/A':
-                        processing_end = processing_end.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Get additional details if needed
-                    failure_reason = job.get('FailureReason', 'N/A')
-
-                    regional_jobs.append({
-                        'Region': region,
-                        'Job Name': job_name,
-                        'ARN': arn,
-                        'Status': status,
-                        'Created': creation_time,
-                        'Processing End': processing_end,
-                        'Failure Reason': failure_reason
-                    })
-
-                    job_count += 1
-                    if job_count >= 30:
-                        break
-
-        except Exception as e:
-            utils.log_warning(f"Error listing processing jobs in {region}: {str(e)}")
-
-    except Exception as e:
-        utils.log_error(f"Error collecting processing jobs in {region}", e)
+            job_count += 1
+            if job_count >= 30:
+                break
 
     return regional_jobs
 
 
-@utils.aws_error_handler("Collecting SageMaker processing jobs", default_return=[])
-def collect_processing_jobs(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SageMaker processing job information (limited to recent 30 per region)."""
+def collect_processing_jobs(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect SageMaker processing job information (limited to recent 30 per region), surfacing failures."""
     print("\n=== COLLECTING SAGEMAKER PROCESSING JOBS ===")
-    results = utils.scan_regions_concurrent(regions, _scan_processing_jobs_region)
-    all_jobs = [job for result in results for job in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_processing_jobs_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_jobs = [job for result in region_results for job in result]
     utils.log_success(f"Total processing jobs collected: {len(all_jobs)} (limited to 30 per region)")
-    return all_jobs
+    return all_jobs, failed_regions
 
 
 def generate_summary(notebooks: list[dict[str, Any]],
@@ -693,14 +754,20 @@ def main():
 
     # Detect partition for region examples
     regions = utils.prompt_region_selection()
-    # Collect data
+    # Collect data. Each scope collector surfaces its own failed regions
+    # (rather than swallowing collection errors into an empty result — see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md);
+    # all scopes' failures are merged below into one combined list.
     print("\nCollecting SageMaker data...")
 
-    notebooks = collect_notebook_instances(regions)
-    training_jobs = collect_training_jobs(regions)
-    models = collect_models(regions)
-    endpoints = collect_endpoints(regions)
-    processing_jobs = collect_processing_jobs(regions)
+    notebooks, failed_notebooks = collect_notebook_instances(regions)
+    training_jobs, failed_training = collect_training_jobs(regions)
+    models, failed_models = collect_models(regions)
+    endpoints, failed_endpoints = collect_endpoints(regions)
+    processing_jobs, failed_processing = collect_processing_jobs(regions)
+
+    failed_regions = failed_notebooks + failed_training + failed_models + failed_endpoints + failed_processing
+
     summary = generate_summary(notebooks, training_jobs, models, endpoints, processing_jobs)
 
     # Create DataFrames
@@ -733,6 +800,9 @@ def main():
         df_processing = utils.prepare_dataframe_for_export(df_processing)
         dataframes['Processing Jobs'] = df_processing
 
+    # The Summary sheet is always built (even when every scope is empty), so
+    # a workbook always lands. Preserve that: it is what keeps this exporter
+    # a PARTIAL rather than a VULNERABLE case in the audit.
     if summary:
         df_summary = pd.DataFrame(summary)
         df_summary = utils.prepare_dataframe_for_export(df_summary)
@@ -749,6 +819,19 @@ def main():
         # Log summary
     else:
         utils.log_warning("No SageMaker data found to export")
+
+    # If ANY scope failed to collect in ANY region, make it loud: write a
+    # failure marker and exit non-zero, even though the Summary sheet made
+    # the workbook look complete. A zero-row sheet that is actually a failed
+    # collection (not a genuinely empty account) is exactly the failure mode
+    # this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'sagemaker', failed_regions)
+        print(
+            "\nERROR: SageMaker export completed with failures — data is incomplete. "
+            "See the *-sagemaker-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("SageMaker export completed successfully")
 

--- a/tests/test_exporters/test_documentdb_export.py
+++ b/tests/test_exporters/test_documentdb_export.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Tests for documentdb_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto: moto's ``docdb`` client backend rejects
+``Engine='docdb'`` on ``create_db_cluster`` (it only accepts the RDS/Neptune
+engine set), so a real DocumentDB cluster cannot be created through moto.
+``describe_db_clusters`` itself works fine (returns an empty list), so the
+empty-region path is exercised against moto directly; everything that needs
+an actual cluster in the response is exercised via a small fake docdb client
+substituted for ``utils.get_boto3_client``.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import documentdb_export  # noqa: E402
+from documentdb_export import _scan_documentdb_clusters_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _cluster(cluster_id, **overrides):
+    """Build a minimal describe_db_clusters-shaped cluster dict."""
+    cluster = {
+        "DBClusterIdentifier": cluster_id,
+        "Engine": "docdb",
+        "EngineVersion": "5.0.0",
+        "Status": "available",
+        "Endpoint": f"{cluster_id}.cluster.docdb.amazonaws.com",
+        "ReaderEndpoint": f"{cluster_id}.cluster-ro.docdb.amazonaws.com",
+        "Port": 27017,
+        "DBClusterMembers": [],
+        "MultiAZ": False,
+        "AvailabilityZones": [f"{REGION}a"],
+        "BackupRetentionPeriod": 1,
+        "PreferredBackupWindow": "07:00-08:00",
+        "PreferredMaintenanceWindow": "sun:05:00-sun:06:00",
+        "StorageEncrypted": False,
+        "KmsKeyId": "N/A",
+        "DeletionProtection": False,
+        "ClusterCreateTime": None,
+        "VpcSecurityGroups": [],
+        "DBSubnetGroup": "default",
+        "DBClusterParameterGroup": "default.docdb5.0",
+        "EnabledCloudwatchLogsExports": [],
+    }
+    cluster.update(overrides)
+    return cluster
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in returning a single canned page."""
+
+    def __init__(self, page):
+        self._page = page
+
+    def paginate(self, **kwargs):
+        return iter([self._page])
+
+
+class _FakeDocDBClient:
+    """Minimal docdb client stand-in — moto cannot create DocumentDB clusters."""
+
+    def __init__(self, clusters):
+        self._clusters = clusters
+
+    def get_paginator(self, operation_name):
+        assert operation_name == "describe_db_clusters"
+        return _FakePaginator({"DBClusters": self._clusters})
+
+
+class TestScanDocumentdbClustersRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_clusters(self, monkeypatch):
+        fake_client = _FakeDocDBClient([_cluster("docdb-cluster")])
+        monkeypatch.setattr(
+            documentdb_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_documentdb_clusters_region(REGION)
+
+        names = {row["Cluster ID"] for row in rows}
+        assert "docdb-cluster" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("docdb", region_name=REGION)  # region exists, no clusters
+
+        rows = _scan_documentdb_clusters_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region. documentdb_export.py is
+    a Tier-3 PARTIAL exporter: it always writes a forced Summary sheet (a
+    workbook always lands), so the fix must ADD failed-scope tracking on top
+    of that — a scope failure must ALSO write the FAILED marker and exit
+    non-zero, while a genuinely empty account still exits 0 with no marker.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One cluster that fails to process must not discard the whole region."""
+        fake_client = _FakeDocDBClient(
+            [_cluster("good-cluster"), _cluster("bad-cluster")]
+        )
+        monkeypatch.setattr(
+            documentdb_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        original = documentdb_export._build_cluster_row
+
+        def raise_for_bad(cluster, region):
+            if cluster.get("DBClusterIdentifier") == "bad-cluster":
+                raise KeyError("SomeUnexpectedField")
+            return original(cluster, region)
+
+        monkeypatch.setattr(documentdb_export, "_build_cluster_row", raise_for_bad)
+
+        rows = _scan_documentdb_clusters_region(REGION)
+
+        names = {row["Cluster ID"] for row in rows}
+        assert "good-cluster" in names, "healthy cluster was lost when a sibling failed"
+        assert "bad-cluster" not in names, "malformed cluster should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeDBClusters",
+            )
+
+        monkeypatch.setattr(documentdb_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_documentdb_clusters_region(REGION)
+
+    @mock_aws
+    def test_collect_documentdb_clusters_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the Summary sheet always makes a workbook land.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeDBClusters",
+            )
+
+        monkeypatch.setattr(documentdb_export, "_scan_documentdb_clusters_region", boom)
+
+        clusters, failed_regions = documentdb_export.collect_documentdb_clusters([REGION])
+
+        assert clusters == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_glacier_export.py
+++ b/tests/test_exporters/test_glacier_export.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for glacier_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+glacier_export.py already writes a forced Summary sheet, so a workbook
+always lands. The contract this fix adds is failed-scope tracking: any
+region-level scope failure must ALSO write the FAILED marker and exit
+non-zero, while a genuinely-empty account (every region succeeds, zero
+vaults) stays exit 0 with no marker.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import glacier_export  # noqa: E402
+from glacier_export import _scan_vaults_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_vault(client, name):
+    """Create a Glacier vault named ``name``."""
+    client.create_vault(vaultName=name)
+
+
+class TestScanVaultsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_vaults(self):
+        client = boto3.client("glacier", region_name=REGION)
+        _create_vault(client, "cold-vault")
+
+        rows = _scan_vaults_region(REGION)
+
+        names = {row["Vault Name"] for row in rows}
+        assert "cold-vault" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("glacier", region_name=REGION)  # region exists, no vaults
+
+        rows = _scan_vaults_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list
+    (or, for PARTIAL exporters like this one, an always-written Summary
+    sheet with silently zero rows), indistinguishable from a genuinely
+    empty account.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One vault that fails to process must not discard the whole region."""
+        client = boto3.client("glacier", region_name=REGION)
+        _create_vault(client, "good-vault")
+        _create_vault(client, "bad-vault")
+
+        original = glacier_export._build_vault_row
+
+        def raise_for_bad(vault, region, glacier_client):
+            if vault.get("VaultName") == "bad-vault":
+                raise KeyError("SomeUnexpectedField")
+            return original(vault, region, glacier_client)
+
+        monkeypatch.setattr(glacier_export, "_build_vault_row", raise_for_bad)
+
+        rows = _scan_vaults_region(REGION)
+
+        names = {row["Vault Name"] for row in rows}
+        assert "good-vault" in names, "healthy vault was lost when a sibling failed"
+        assert "bad-vault" not in names, "malformed vault should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListVaults",
+            )
+
+        monkeypatch.setattr(glacier_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_vaults_region(REGION)
+
+    @mock_aws
+    def test_collect_vaults_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the Summary sheet always lands.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListVaults",
+            )
+
+        monkeypatch.setattr(glacier_export, "_scan_vaults_region", boom)
+
+        vaults, failed_regions = glacier_export.collect_vaults([REGION])
+
+        assert vaults == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_glue_athena_export.py
+++ b/tests/test_exporters/test_glue_athena_export.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for glue_athena_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Unlike the Tier-2 VULNERABLE exporters (e.g. autoscaling_export.py), this
+script already writes a forced Summary sheet, so a workbook always lands even
+when a scope fails. That must not mask the failure: on any scope failure the
+export must ALSO write the ``*-glue-athena-FAILED-*.txt`` marker and exit
+non-zero. A genuinely empty account (every scope succeeded, nothing found)
+must stay exit 0 with no marker.
+
+These tests target the Glue databases scope (``_scan_glue_databases_region`` /
+``collect_glue_databases``), the primary scope per the audit.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import glue_athena_export  # noqa: E402
+from glue_athena_export import _scan_glue_databases_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+class TestScanGlueDatabasesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_databases(self):
+        client = boto3.client("glue", region_name=REGION)
+        client.create_database(DatabaseInput={"Name": "analytics-db"})
+
+        rows = _scan_glue_databases_region(REGION)
+
+        names = {row["Database Name"] for row in rows}
+        assert "analytics-db" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("glue", region_name=REGION)  # region exists, no databases
+
+        rows = _scan_glue_databases_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+
+    glue_athena_export.py is a Tier-3 PARTIAL exporter: it already forces a
+    Summary sheet so a workbook is always written. The fix here adds
+    failed-scope tracking on top of that so a scope failure is also
+    surfaced via the FAILED marker + non-zero exit, instead of hiding
+    inside a complete-looking zero-row workbook.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One database that fails to process must not discard the whole region."""
+        client = boto3.client("glue", region_name=REGION)
+        client.create_database(DatabaseInput={"Name": "good-db"})
+        client.create_database(DatabaseInput={"Name": "bad-db"})
+
+        original = glue_athena_export._build_database_row
+
+        def raise_for_bad(db, region):
+            if db.get("Name") == "bad-db":
+                raise KeyError("SomeUnexpectedField")
+            return original(db, region)
+
+        monkeypatch.setattr(glue_athena_export, "_build_database_row", raise_for_bad)
+
+        rows = _scan_glue_databases_region(REGION)
+
+        names = {row["Database Name"] for row in rows}
+        assert "good-db" in names, "healthy database was lost when a sibling failed"
+        assert "bad-db" not in names, "malformed database should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "GetDatabases",
+            )
+
+        monkeypatch.setattr(glue_athena_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_glue_databases_region(REGION)
+
+    @mock_aws
+    def test_collect_glue_databases_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets the export write a FAILED marker +
+        exit 1 even though the forced Summary sheet still lands a workbook.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "GetDatabases",
+            )
+
+        monkeypatch.setattr(glue_athena_export, "_scan_glue_databases_region", boom)
+
+        databases, failed_regions = glue_athena_export.collect_glue_databases([REGION])
+
+        assert databases == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_lakeformation_export.py
+++ b/tests/test_exporters/test_lakeformation_export.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Tests for lakeformation_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on mocking strategy: moto's Lake Formation support is limited (no
+``list_resources``/``list_permissions`` backend as of the moto version
+pinned in this project), so these tests do not use ``@mock_aws``. Instead
+they monkeypatch ``utils.get_boto3_client`` with a small fake client object
+that mimics the subset of the boto3 Lake Formation API surface
+``_scan_lakeformation_resources_region`` calls (``list_resources``). This
+keeps the tests focused on the collection-failure contract (raise vs.
+skip-and-continue vs. surfaced failed_regions) rather than on AWS API
+fidelity.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import lakeformation_export  # noqa: E402
+from lakeformation_export import _scan_lakeformation_resources_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakeLakeFormationClient:
+    """Minimal fake Lake Formation client for ``list_resources`` paging."""
+
+    def __init__(self, resource_pages):
+        self._pages = list(resource_pages)
+
+    def list_resources(self, **kwargs):
+        if not self._pages:
+            return {"ResourceInfoList": []}
+        return self._pages.pop(0)
+
+
+def _resource(arn="arn:aws:s3:::my-bucket/prefix", role_arn="arn:aws:iam::123456789012:role/LFRole"):
+    return {
+        "ResourceArn": arn,
+        "RoleArn": role_arn,
+        "LastModified": None,
+    }
+
+
+class TestScanLakeformationResourcesRegion:
+    """Happy-path collection."""
+
+    def test_collects_resources(self, monkeypatch):
+        fake_client = _FakeLakeFormationClient(
+            [{"ResourceInfoList": [_resource()], "NextToken": None}]
+        )
+        monkeypatch.setattr(
+            lakeformation_export.utils, "get_boto3_client", lambda *a, **k: fake_client
+        )
+
+        rows = _scan_lakeformation_resources_region(REGION)
+
+        arns = {row["Resource ARN"] for row in rows}
+        assert "arn:aws:s3:::my-bucket/prefix" in arns
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _FakeLakeFormationClient([{"ResourceInfoList": [], "NextToken": None}])
+        monkeypatch.setattr(
+            lakeformation_export.utils, "get_boto3_client", lambda *a, **k: fake_client
+        )
+
+        rows = _scan_lakeformation_resources_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One resource that fails to process must not discard the whole region."""
+        fake_client = _FakeLakeFormationClient(
+            [
+                {
+                    "ResourceInfoList": [
+                        _resource(arn="arn:aws:s3:::good-bucket"),
+                        _resource(arn="arn:aws:s3:::bad-bucket"),
+                    ],
+                    "NextToken": None,
+                }
+            ]
+        )
+        monkeypatch.setattr(
+            lakeformation_export.utils, "get_boto3_client", lambda *a, **k: fake_client
+        )
+
+        original = lakeformation_export._build_resource_row
+
+        def raise_for_bad(resource, region):
+            if resource.get("ResourceArn") == "arn:aws:s3:::bad-bucket":
+                raise KeyError("SomeUnexpectedField")
+            return original(resource, region)
+
+        monkeypatch.setattr(lakeformation_export, "_build_resource_row", raise_for_bad)
+
+        rows = _scan_lakeformation_resources_region(REGION)
+
+        arns = {row["Resource ARN"] for row in rows}
+        assert "arn:aws:s3:::good-bucket" in arns, "healthy resource was lost when a sibling failed"
+        assert "arn:aws:s3:::bad-bucket" not in arns, "malformed resource should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("Rate exceeded")
+
+        monkeypatch.setattr(lakeformation_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(RuntimeError):
+            _scan_lakeformation_resources_region(REGION)
+
+    def test_collect_resources_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise RuntimeError("AccessDenied: nope")
+
+        monkeypatch.setattr(lakeformation_export, "_scan_lakeformation_resources_region", boom)
+
+        resources, failed_regions = lakeformation_export.collect_lakeformation_resources([REGION])
+
+        assert resources == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_neptune_export.py
+++ b/tests/test_exporters/test_neptune_export.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for neptune_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's Neptune support rides on the RDS backend (``describe_db_clusters``
+etc. are served by the same moto RDS backend Neptune's API shape reuses), so
+``@mock_aws`` covers ``create_db_cluster`` / ``describe_db_clusters`` against
+the ``neptune`` boto3 client directly — no monkeypatch workaround needed.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import neptune_export  # noqa: E402
+from neptune_export import _scan_neptune_clusters_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_cluster(client, name):
+    """Create a Neptune DB cluster named ``name``."""
+    client.create_db_cluster(
+        DBClusterIdentifier=name,
+        Engine="neptune",
+        MasterUsername="admin",
+        MasterUserPassword="password123",
+    )
+
+
+class TestScanNeptuneClustersRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_clusters(self):
+        client = boto3.client("neptune", region_name=REGION)
+        _create_cluster(client, "graph-cluster")
+
+        rows = _scan_neptune_clusters_region(REGION)
+
+        names = {row["Cluster ID"] for row in rows}
+        assert "graph-cluster" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("neptune", region_name=REGION)  # region exists, no clusters
+
+        rows = _scan_neptune_clusters_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region. Neptune previously wrote
+    a forced Summary sheet on every run (so the workbook always landed), but
+    could not tell a failed region apart from a genuinely empty one — this
+    suite locks in the failed-scope tracking added on top of that.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One cluster that fails to process must not discard the whole region."""
+        client = boto3.client("neptune", region_name=REGION)
+        _create_cluster(client, "good-cluster")
+        _create_cluster(client, "bad-cluster")
+
+        original = neptune_export._build_cluster_row
+
+        def raise_for_bad(cluster, region):
+            if cluster.get("DBClusterIdentifier") == "bad-cluster":
+                raise KeyError("SomeUnexpectedField")
+            return original(cluster, region)
+
+        monkeypatch.setattr(neptune_export, "_build_cluster_row", raise_for_bad)
+
+        rows = _scan_neptune_clusters_region(REGION)
+
+        names = {row["Cluster ID"] for row in rows}
+        assert "good-cluster" in names, "healthy cluster was lost when a sibling failed"
+        assert "bad-cluster" not in names, "malformed cluster should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeDBClusters",
+            )
+
+        monkeypatch.setattr(neptune_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_neptune_clusters_region(REGION)
+
+    @mock_aws
+    def test_collect_neptune_clusters_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets the export write a FAILED marker + exit 1
+        even though the always-written Summary sheet still lands.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeDBClusters",
+            )
+
+        monkeypatch.setattr(neptune_export, "_scan_neptune_clusters_region", boom)
+
+        clusters, failed_regions = neptune_export.collect_neptune_clusters([REGION])
+
+        assert clusters == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_opensearch_export.py
+++ b/tests/test_exporters/test_opensearch_export.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for opensearch_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's OpenSearch support is limited (no simulated API throttling /
+access-denied errors, and DescribeDomain returns a fixed shape), so the
+failure-path tests below monkeypatch the relevant call/function directly
+instead of trying to coax moto into raising.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import opensearch_export  # noqa: E402
+from opensearch_export import scan_opensearch_domains_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_domain(client, name):
+    """Create an OpenSearch domain named ``name``."""
+    client.create_domain(DomainName=name)
+
+
+class TestScanOpensearchDomainsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_domains(self):
+        client = boto3.client("opensearch", region_name=REGION)
+        _create_domain(client, "search-domain")
+
+        rows = scan_opensearch_domains_in_region(REGION)
+
+        names = {row["Domain Name"] for row in rows}
+        assert "search-domain" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("opensearch", region_name=REGION)  # region exists, no domains
+
+        rows = scan_opensearch_domains_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One domain that fails to describe/build must not discard the whole region."""
+        client = boto3.client("opensearch", region_name=REGION)
+        _create_domain(client, "good-domain")
+        _create_domain(client, "bad-domain")
+
+        original = opensearch_export._build_domain_row
+
+        def raise_for_bad(domain, region, pricing_data, cost_note):
+            if domain.get("DomainName") == "bad-domain":
+                raise KeyError("SomeUnexpectedField")
+            return original(domain, region, pricing_data, cost_note)
+
+        monkeypatch.setattr(opensearch_export, "_build_domain_row", raise_for_bad)
+
+        rows = scan_opensearch_domains_in_region(REGION)
+
+        names = {row["Domain Name"] for row in rows}
+        assert "good-domain" in names, "healthy domain was lost when a sibling failed"
+        assert "bad-domain" not in names, "malformed domain should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure (e.g. list_domain_names) must propagate (so
+        the caller can record a FAILED region) rather than being swallowed
+        into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListDomainNames",
+            )
+
+        monkeypatch.setattr(opensearch_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_opensearch_domains_in_region(REGION)
+
+    @mock_aws
+    def test_collect_opensearch_domains_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListDomainNames",
+            )
+
+        monkeypatch.setattr(opensearch_export, "scan_opensearch_domains_in_region", boom)
+
+        domains, failed_regions = opensearch_export.collect_opensearch_domains([REGION])
+
+        assert domains == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_redshift_export.py
+++ b/tests/test_exporters/test_redshift_export.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for redshift_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import redshift_export  # noqa: E402
+from redshift_export import scan_redshift_clusters_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_cluster(client, name):
+    """Create a Redshift cluster named ``name``."""
+    client.create_cluster(
+        ClusterIdentifier=name,
+        NodeType="dc2.large",
+        MasterUsername="admin",
+        MasterUserPassword="Password123!",
+        DBName="mydb",
+        ClusterType="single-node",
+    )
+
+
+class TestScanRedshiftClustersInRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_clusters(self):
+        client = boto3.client("redshift", region_name=REGION)
+        _create_cluster(client, "web-cluster")
+
+        rows = scan_redshift_clusters_in_region(REGION)
+
+        ids = {row["Cluster ID"] for row in rows}
+        assert "web-cluster" in ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("redshift", region_name=REGION)  # region exists, no clusters
+
+        rows = scan_redshift_clusters_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list (or, for
+    Tier-3 PARTIAL scripts, into a zero-row sheet buried inside an
+    always-written Summary workbook), indistinguishable from a genuinely
+    empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One cluster that fails to process must not discard the whole region."""
+        client = boto3.client("redshift", region_name=REGION)
+        _create_cluster(client, "good-cluster")
+        _create_cluster(client, "bad-cluster")
+
+        original = redshift_export._build_cluster_row
+
+        def raise_for_bad(cluster, region, pricing_data, cost_note):
+            if cluster.get("ClusterIdentifier") == "bad-cluster":
+                raise KeyError("SomeUnexpectedField")
+            return original(cluster, region, pricing_data, cost_note)
+
+        monkeypatch.setattr(redshift_export, "_build_cluster_row", raise_for_bad)
+
+        rows = scan_redshift_clusters_in_region(REGION)
+
+        ids = {row["Cluster ID"] for row in rows}
+        assert "good-cluster" in ids, "healthy cluster was lost when a sibling failed"
+        assert "bad-cluster" not in ids, "malformed cluster should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeClusters",
+            )
+
+        monkeypatch.setattr(redshift_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_redshift_clusters_in_region(REGION)
+
+    @mock_aws
+    def test_collect_redshift_clusters_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the always-written Summary sheet means a workbook still
+        lands (Tier-3 PARTIAL nuance).
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeClusters",
+            )
+
+        monkeypatch.setattr(redshift_export, "scan_redshift_clusters_in_region", boom)
+
+        clusters, failed_regions = redshift_export.collect_redshift_clusters([REGION])
+
+        assert clusters == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_sagemaker_export.py
+++ b/tests/test_exporters/test_sagemaker_export.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for sagemaker_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import sagemaker_export  # noqa: E402
+from sagemaker_export import _scan_notebook_instances_region  # noqa: E402
+
+REGION = "us-east-1"
+ROLE_ARN = "arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_notebook(client, name):
+    """Create a SageMaker notebook instance named ``name``."""
+    client.create_notebook_instance(
+        NotebookInstanceName=name,
+        InstanceType="ml.t2.medium",
+        RoleArn=ROLE_ARN,
+    )
+
+
+class TestScanNotebookInstancesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_notebook_instances(self):
+        client = boto3.client("sagemaker", region_name=REGION)
+        _create_notebook(client, "dev-notebook")
+
+        rows = _scan_notebook_instances_region(REGION)
+
+        names = {row["Notebook Name"] for row in rows}
+        assert "dev-notebook" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("sagemaker", region_name=REGION)  # region exists, no notebooks
+
+        rows = _scan_notebook_instances_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One notebook that fails to process must not discard the whole region."""
+        client = boto3.client("sagemaker", region_name=REGION)
+        _create_notebook(client, "good-notebook")
+        _create_notebook(client, "bad-notebook")
+
+        original = sagemaker_export._build_notebook_row
+
+        def raise_for_bad(notebook, region, sagemaker_client, sm_pricing_data):
+            if notebook.get("NotebookInstanceName") == "bad-notebook":
+                raise KeyError("SomeUnexpectedField")
+            return original(notebook, region, sagemaker_client, sm_pricing_data)
+
+        monkeypatch.setattr(sagemaker_export, "_build_notebook_row", raise_for_bad)
+
+        rows = _scan_notebook_instances_region(REGION)
+
+        names = {row["Notebook Name"] for row in rows}
+        assert "good-notebook" in names, "healthy notebook was lost when a sibling failed"
+        assert "bad-notebook" not in names, "malformed notebook should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListNotebookInstances",
+            )
+
+        monkeypatch.setattr(sagemaker_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_notebook_instances_region(REGION)
+
+    @mock_aws
+    def test_collect_notebook_instances_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListNotebookInstances",
+            )
+
+        monkeypatch.setattr(sagemaker_export, "_scan_notebook_instances_region", boom)
+
+        notebooks, failed_regions = sagemaker_export.collect_notebook_instances([REGION])
+
+        assert notebooks == []
+        assert [r for r, _ in failed_regions] == [REGION]


### PR DESCRIPTION
Part of #233. **Second Tier-3 (PARTIAL) phase — Batch G: data & analytics (8 exporters).**

Tier-3 nuance: these already write a forced Summary sheet (workbook always lands); the fix **preserves** that and **layers** failed-scope tracking + `*-FAILED-*.txt` marker + non-zero exit on top.

| Exporter | Scopes | Slug |
|---|---|---|
| documentdb | 1 | `documentdb` |
| neptune | 1 | `neptune` |
| redshift | 1 | `redshift` |
| opensearch | 1 | `opensearch` |
| glacier | 1 | `glacier` |
| sagemaker | 5 | `sagemaker` |
| glue_athena | 6 | `glue-athena` |
| lakeformation | 4 | `lakeformation` |

Each primary/region scope collector RAISES on error → `scan_regions_concurrent(collect_failures=True)` → per-item `_build_*_row` guard → preserved Summary → `report_collection_failures` + `sys.exit(1)`. Multi-scope exporters merge all scopes' failures into one list. Enrichment sheets stay graceful.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite. **All 8 pass smoke under moto — no new `_EXCLUDED` entries.** Batch-G suites: 40 passed. Full suite: **1026 passed, 2 skipped**. `ruff check .` clean (py39 floor).

## Remaining
Tier-3 batches **H** security/identity, **I** devops/governance, **J** cost/compute, **K** networking/misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)