### PR TITLE
Silent collection failure: Tier-3h (security & identity exporters)

### DIFF
--- a/scripts/acm_export.py
+++ b/scripts/acm_export.py
@@ -46,9 +46,148 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Certificate Manager certificates to Excel")
 
 
+def _build_certificate_row(cert_summary: dict, region: str, acm_client) -> dict[str, Any]:
+    """
+    Build a single ACM certificate export row, enriching the summary with a
+    ``describe_certificate`` call.
+
+    Raises on any failure (including the enrichment call) so the caller's
+    per-item ``try/except + continue`` can skip just this certificate. This
+    keeps certificate-detail enrichment failures graceful (one bad certificate
+    is skipped, not fatal to the region) while still routing every failure
+    through a single, auditable path.
+    """
+    cert_arn = cert_summary.get('CertificateArn', '')
+    domain_name = cert_summary.get('DomainName', '')
+
+    # Get detailed certificate information
+    cert_response = acm_client.describe_certificate(CertificateArn=cert_arn)
+    cert = cert_response.get('Certificate', {})
+
+    # Status
+    status = cert.get('Status', '')
+
+    # Type
+    cert_type = cert.get('Type', '')
+
+    # Key algorithm
+    key_algorithm = cert.get('KeyAlgorithm', 'N/A')
+
+    # Signature algorithm
+    signature_algorithm = cert.get('SignatureAlgorithm', 'N/A')
+
+    # Subject Alternative Names
+    subject_alternative_names = cert.get('SubjectAlternativeNames', [])
+    san_count = len(subject_alternative_names)
+    san_str = ', '.join(subject_alternative_names[:5])  # First 5 SANs
+    if san_count > 5:
+        san_str += f" ... ({san_count - 5} more)"
+
+    # Validation method
+    domain_validation_options = cert.get('DomainValidationOptions', [])
+    validation_method = 'N/A'
+    if domain_validation_options:
+        validation_method = domain_validation_options[0].get('ValidationMethod', 'N/A')
+
+    # Validation status
+    validation_status = 'N/A'
+    if domain_validation_options:
+        validation_status = domain_validation_options[0].get('ValidationStatus', 'N/A')
+
+    # In use by (resources using this certificate)
+    in_use_by = cert.get('InUseBy', [])
+    in_use_count = len(in_use_by)
+    in_use_str = ', '.join([arn.split('/')[-1] for arn in in_use_by[:3]])  # First 3 resources
+    if in_use_count > 3:
+        in_use_str += f" ... ({in_use_count - 3} more)"
+    if not in_use_str:
+        in_use_str = 'Not in use'
+
+    # Created date
+    created_at = cert.get('CreatedAt', '')
+    if created_at:
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
+
+    # Issued date
+    issued_at = cert.get('IssuedAt', '')
+    if issued_at:
+        issued_at = issued_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(issued_at, datetime.datetime) else str(issued_at)
+
+    # Not before
+    not_before = cert.get('NotBefore', '')
+    if not_before:
+        not_before = not_before.strftime('%Y-%m-%d %H:%M:%S') if isinstance(not_before, datetime.datetime) else str(not_before)
+
+    # Not after (expiration)
+    not_after = cert.get('NotAfter', '')
+    days_to_expiry = 'N/A'
+    if not_after:
+        not_after_dt = not_after if isinstance(not_after, datetime.datetime) else datetime.datetime.fromisoformat(str(not_after))
+        not_after = not_after_dt.strftime('%Y-%m-%d %H:%M:%S')
+        # Calculate days to expiry
+        days_to_expiry = (not_after_dt.replace(tzinfo=None) - datetime.datetime.now()).days
+
+    # Renewal eligibility
+    renewal_eligibility = cert.get('RenewalEligibility', 'N/A')
+
+    # Renewal summary
+    renewal_summary = cert.get('RenewalSummary', {})
+    renewal_status = renewal_summary.get('RenewalStatus', 'N/A')
+
+    # Certificate transparency logging
+    options = cert.get('Options', {})
+    certificate_transparency_logging = options.get('CertificateTransparencyLoggingPreference', 'N/A')
+
+    # Issuer
+    issuer = cert.get('Issuer', 'N/A')
+
+    # Subject
+    subject = cert.get('Subject', 'N/A')
+
+    # Serial
+    serial = cert.get('Serial', 'N/A')
+
+    return {
+        'Region': region,
+        'Domain Name': domain_name,
+        'Status': status,
+        'Type': cert_type,
+        'Validation Method': validation_method,
+        'Validation Status': validation_status,
+        'SAN Count': san_count,
+        'Subject Alternative Names': san_str,
+        'In Use By Count': in_use_count,
+        'In Use By': in_use_str,
+        'Days to Expiry': days_to_expiry,
+        'Expiration Date': not_after if not_after else 'N/A',
+        'Renewal Eligibility': renewal_eligibility,
+        'Renewal Status': renewal_status,
+        'Key Algorithm': key_algorithm,
+        'Signature Algorithm': signature_algorithm,
+        'Certificate Transparency': certificate_transparency_logging,
+        'Issuer': issuer,
+        'Subject': subject,
+        'Serial': serial,
+        'Created Date': created_at,
+        'Issued Date': issued_at if issued_at else 'N/A',
+        'Not Before': not_before if not_before else 'N/A',
+        'Certificate ARN': cert_arn
+    }
+
+
 def scan_acm_certificates_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan ACM certificates in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no certificates" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual certificates that fail detail enrichment (describe_certificate)
+    are skipped (logged) rather than aborting the whole region.
 
     Args:
         region: AWS region to scan
@@ -56,171 +195,62 @@ def scan_acm_certificates_in_region(region: str) -> list[dict[str, Any]]:
     Returns:
         list: List of dictionaries with certificate information from this region
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    acm_client = utils.get_boto3_client('acm', region_name=region)
+
+    # Get certificates
+    paginator = acm_client.get_paginator('list_certificates')
     regional_certificates = []
 
-    try:
-        acm_client = utils.get_boto3_client('acm', region_name=region)
+    for page in paginator.paginate():
+        certificates = page.get('CertificateSummaryList', [])
 
-        # Get certificates
-        paginator = acm_client.get_paginator('list_certificates')
+        for cert_summary in certificates:
+            try:
+                regional_certificates.append(_build_certificate_row(cert_summary, region, acm_client))
+            except Exception as e:
+                utils.log_warning(
+                    f"Could not get details for certificate "
+                    f"{cert_summary.get('CertificateArn', '<unknown>')}: {e}"
+                )
+                continue
 
-        for page in paginator.paginate():
-            certificates = page.get('CertificateSummaryList', [])
-
-            for cert_summary in certificates:
-                cert_arn = cert_summary.get('CertificateArn', '')
-                domain_name = cert_summary.get('DomainName', '')
-
-                try:
-                    # Get detailed certificate information
-                    cert_response = acm_client.describe_certificate(CertificateArn=cert_arn)
-                    cert = cert_response.get('Certificate', {})
-
-                    # Status
-                    status = cert.get('Status', '')
-
-                    # Type
-                    cert_type = cert.get('Type', '')
-
-                    # Key algorithm
-                    key_algorithm = cert.get('KeyAlgorithm', 'N/A')
-
-                    # Signature algorithm
-                    signature_algorithm = cert.get('SignatureAlgorithm', 'N/A')
-
-                    # Subject Alternative Names
-                    subject_alternative_names = cert.get('SubjectAlternativeNames', [])
-                    san_count = len(subject_alternative_names)
-                    san_str = ', '.join(subject_alternative_names[:5])  # First 5 SANs
-                    if san_count > 5:
-                        san_str += f" ... ({san_count - 5} more)"
-
-                    # Validation method
-                    domain_validation_options = cert.get('DomainValidationOptions', [])
-                    validation_method = 'N/A'
-                    if domain_validation_options:
-                        validation_method = domain_validation_options[0].get('ValidationMethod', 'N/A')
-
-                    # Validation status
-                    validation_status = 'N/A'
-                    if domain_validation_options:
-                        validation_status = domain_validation_options[0].get('ValidationStatus', 'N/A')
-
-                    # In use by (resources using this certificate)
-                    in_use_by = cert.get('InUseBy', [])
-                    in_use_count = len(in_use_by)
-                    in_use_str = ', '.join([arn.split('/')[-1] for arn in in_use_by[:3]])  # First 3 resources
-                    if in_use_count > 3:
-                        in_use_str += f" ... ({in_use_count - 3} more)"
-                    if not in_use_str:
-                        in_use_str = 'Not in use'
-
-                    # Created date
-                    created_at = cert.get('CreatedAt', '')
-                    if created_at:
-                        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(created_at, datetime.datetime) else str(created_at)
-
-                    # Issued date
-                    issued_at = cert.get('IssuedAt', '')
-                    if issued_at:
-                        issued_at = issued_at.strftime('%Y-%m-%d %H:%M:%S') if isinstance(issued_at, datetime.datetime) else str(issued_at)
-
-                    # Not before
-                    not_before = cert.get('NotBefore', '')
-                    if not_before:
-                        not_before = not_before.strftime('%Y-%m-%d %H:%M:%S') if isinstance(not_before, datetime.datetime) else str(not_before)
-
-                    # Not after (expiration)
-                    not_after = cert.get('NotAfter', '')
-                    days_to_expiry = 'N/A'
-                    if not_after:
-                        not_after_dt = not_after if isinstance(not_after, datetime.datetime) else datetime.datetime.fromisoformat(str(not_after))
-                        not_after = not_after_dt.strftime('%Y-%m-%d %H:%M:%S')
-                        # Calculate days to expiry
-                        days_to_expiry = (not_after_dt.replace(tzinfo=None) - datetime.datetime.now()).days
-
-                    # Renewal eligibility
-                    renewal_eligibility = cert.get('RenewalEligibility', 'N/A')
-
-                    # Renewal summary
-                    renewal_summary = cert.get('RenewalSummary', {})
-                    renewal_status = renewal_summary.get('RenewalStatus', 'N/A')
-
-                    # Certificate transparency logging
-                    options = cert.get('Options', {})
-                    certificate_transparency_logging = options.get('CertificateTransparencyLoggingPreference', 'N/A')
-
-                    # Issuer
-                    issuer = cert.get('Issuer', 'N/A')
-
-                    # Subject
-                    subject = cert.get('Subject', 'N/A')
-
-                    # Serial
-                    serial = cert.get('Serial', 'N/A')
-
-                    regional_certificates.append({
-                        'Region': region,
-                        'Domain Name': domain_name,
-                        'Status': status,
-                        'Type': cert_type,
-                        'Validation Method': validation_method,
-                        'Validation Status': validation_status,
-                        'SAN Count': san_count,
-                        'Subject Alternative Names': san_str,
-                        'In Use By Count': in_use_count,
-                        'In Use By': in_use_str,
-                        'Days to Expiry': days_to_expiry,
-                        'Expiration Date': not_after if not_after else 'N/A',
-                        'Renewal Eligibility': renewal_eligibility,
-                        'Renewal Status': renewal_status,
-                        'Key Algorithm': key_algorithm,
-                        'Signature Algorithm': signature_algorithm,
-                        'Certificate Transparency': certificate_transparency_logging,
-                        'Issuer': issuer,
-                        'Subject': subject,
-                        'Serial': serial,
-                        'Created Date': created_at,
-                        'Issued Date': issued_at if issued_at else 'N/A',
-                        'Not Before': not_before if not_before else 'N/A',
-                        'Certificate ARN': cert_arn
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for certificate {cert_arn}: {e}")
-
-        utils.log_info(f"Found {len(regional_certificates)} ACM certificates in {region}")
-
-    except Exception as e:
-        utils.log_error(f"Error processing region {region} for ACM certificates", e)
+    utils.log_info(f"Found {len(regional_certificates)} ACM certificates in {region}")
 
     return regional_certificates
 
 
-@utils.aws_error_handler("Collecting ACM certificates", default_return=[])
-def collect_acm_certificates(regions: list[str]) -> list[dict[str, Any]]:
+def collect_acm_certificates(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect ACM certificate information from AWS regions using concurrent scanning.
+    Collect ACM certificate information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with certificate information
+        tuple: ``(certificates, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING ACM CERTIFICATES ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    # Use concurrent scanning
-    all_certificates = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_acm_certificates_in_region,
-    ):
-        all_certificates.extend(region_data)
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_certificates = [cert for result in region_results for cert in result]
 
     utils.log_success(f"Total ACM certificates collected: {len(all_certificates)}")
-    return all_certificates
+    return all_certificates, failed_regions
 
 
 def scan_certificate_validation_details_in_region(region: str) -> list[dict[str, Any]]:
@@ -337,8 +367,9 @@ def export_acm_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect certificates
-    certificates = collect_acm_certificates(regions)
+    # STEP 1: Collect certificates (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    certificates, failed_regions = collect_acm_certificates(regions)
     if certificates:
         data_frames['Certificates'] = pd.DataFrame(certificates)
 
@@ -348,42 +379,54 @@ def export_acm_data(account_id: str, account_name: str):
         data_frames['Validation Details'] = pd.DataFrame(validations)
 
     # Check if we have any data
-    if not data_frames:
+    if data_frames:
+        # STEP 3: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 4: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'acm',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("ACM data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No ACM data was collected. Nothing to export.")
         print("\nNo ACM certificates found in the selected region(s).")
-        return
 
-    # STEP 3: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 4: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'acm',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("ACM data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary certificate scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was exported.
+    # A partial export that looks complete is exactly the failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'acm', failed_regions)
+        print(
+            "\nERROR: ACM export completed with failures — data is incomplete. "
+            "See the *-acm-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/acm_privateca_export.py
+++ b/scripts/acm_privateca_export.py
@@ -27,147 +27,186 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export ACM Private Certificate Authority resources to Excel")
 
+def _build_ca_row(item: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build a single Private CA export row from a ``list_certificate_authorities``
+    entry.
+
+    ``ListCertificateAuthorities`` already returns the full ``CertificateAuthority``
+    shape (same fields as ``DescribeCertificateAuthority``), so no secondary
+    per-item describe call is needed. Every field is read with ``.get()`` and a
+    safe default so a malformed/partial entry raises predictably and is caught by
+    the caller rather than aborting the whole region.
+    """
+    ca_arn = item.get('Arn', 'N/A')
+    ca_type = item.get('Type', 'N/A')
+    status = item.get('Status', 'N/A')
+
+    config = item.get('CertificateAuthorityConfiguration', {}) or {}
+    key_algorithm = config.get('KeyAlgorithm', 'N/A')
+    signing_algorithm = config.get('SigningAlgorithm', 'N/A')
+
+    # Subject information
+    subject = config.get('Subject', {}) or {}
+    common_name = subject.get('CommonName', 'N/A')
+    organization = subject.get('Organization', 'N/A')
+    organizational_unit = subject.get('OrganizationalUnit', 'N/A')
+    country = subject.get('Country', 'N/A')
+    state = subject.get('State', 'N/A')
+    locality = subject.get('Locality', 'N/A')
+
+    # Dates
+    created_at = item.get('CreatedAt', 'N/A')
+    if created_at != 'N/A':
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    not_before = item.get('NotBefore', 'N/A')
+    if not_before != 'N/A':
+        not_before = not_before.strftime('%Y-%m-%d %H:%M:%S')
+
+    not_after = item.get('NotAfter', 'N/A')
+    if not_after != 'N/A':
+        not_after = not_after.strftime('%Y-%m-%d %H:%M:%S')
+
+    last_state_change = item.get('LastStateChangeAt', 'N/A')
+    if last_state_change != 'N/A':
+        last_state_change = last_state_change.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Revocation configuration
+    revocation_config = item.get('RevocationConfiguration', {}) or {}
+    crl_config = revocation_config.get('CrlConfiguration', {}) or {}
+    crl_enabled = crl_config.get('Enabled', False)
+    crl_s3_bucket = crl_config.get('S3BucketName', 'N/A')
+    crl_s3_object_acl = crl_config.get('S3ObjectAcl', 'N/A')
+    crl_expiration_days = crl_config.get('ExpirationInDays', 'N/A')
+
+    ocsp_config = revocation_config.get('OcspConfiguration', {}) or {}
+    ocsp_enabled = ocsp_config.get('Enabled', False)
+    ocsp_custom_cname = ocsp_config.get('OcspCustomCname', 'N/A')
+
+    # Key storage security standard
+    key_storage = item.get('KeyStorageSecurityStandard', 'N/A')
+
+    # Usage mode
+    usage_mode = item.get('UsageMode', 'N/A')
+
+    # Owner account
+    owner_account = item.get('OwnerAccount', 'N/A')
+
+    # Failure reason
+    failure_reason = item.get('FailureReason', 'N/A')
+
+    # Serial number
+    serial = item.get('Serial', 'N/A')
+
+    return {
+        'Region': region,
+        'CA ARN': ca_arn,
+        'Type': ca_type,
+        'Status': status,
+        'Common Name': common_name,
+        'Organization': organization,
+        'Organizational Unit': organizational_unit,
+        'Country': country,
+        'State': state,
+        'Locality': locality,
+        'Key Algorithm': key_algorithm,
+        'Signing Algorithm': signing_algorithm,
+        'Key Storage Security Standard': key_storage,
+        'Usage Mode': usage_mode,
+        'Serial Number': serial,
+        'Created At': created_at,
+        'Not Before': not_before,
+        'Not After': not_after,
+        'Last State Change': last_state_change,
+        'CRL Enabled': crl_enabled,
+        'CRL S3 Bucket': crl_s3_bucket,
+        'CRL S3 Object ACL': crl_s3_object_acl,
+        'CRL Expiration Days': crl_expiration_days,
+        'OCSP Enabled': ocsp_enabled,
+        'OCSP Custom CNAME': ocsp_custom_cname,
+        'Owner Account': owner_account,
+        'Failure Reason': failure_reason,
+        'Tags': 'N/A',
+    }
+
+
 def _scan_private_cas_region(region: str) -> list[dict[str, Any]]:
-    """Scan Private CAs in a single region."""
+    """
+    Scan Private CAs in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no Private CAs" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed CAs are skipped (logged) rather than aborting the
+    whole region. Tag lookup is best-effort enrichment: a failure there does
+    not drop the CA row, it just leaves ``Tags`` as ``'N/A'``.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_cas = []
     acmpca_client = utils.get_boto3_client('acm-pca', region_name=region)
 
-    try:
-        paginator = acmpca_client.get_paginator('list_certificate_authorities')
-        for page in paginator.paginate():
-            cas = page.get('CertificateAuthorities', [])
+    paginator = acmpca_client.get_paginator('list_certificate_authorities')
+    for page in paginator.paginate():
+        cas = page.get('CertificateAuthorities', [])
 
-            for ca in cas:
-                ca_arn = ca.get('Arn', 'N/A')
+        for ca in cas:
+            ca_arn = ca.get('Arn', '<unknown>')
 
-                # Get detailed CA information
-                try:
-                    ca_response = acmpca_client.describe_certificate_authority(
-                        CertificateAuthorityArn=ca_arn
+            try:
+                row = _build_ca_row(ca, region)
+            except Exception as e:
+                utils.log_warning(f"Could not process CA {ca_arn} in {region}: {str(e)}")
+                continue
+
+            # Get tags (best-effort — no policy/tags is normal, don't fail the row)
+            try:
+                tags_response = acmpca_client.list_tags(
+                    CertificateAuthorityArn=ca_arn
+                )
+                tags = tags_response.get('Tags', [])
+                if tags:
+                    row['Tags'] = ', '.join(
+                        f"{tag.get('Key')}={tag.get('Value')}" for tag in tags
                     )
-                    ca_details = ca_response.get('CertificateAuthority', {})
+            except Exception:
+                pass
 
-                    # Basic information
-                    ca_arn = ca_details.get('Arn', 'N/A')
-                    ca_type = ca_details.get('Type', 'N/A')
-                    status = ca_details.get('Status', 'N/A')
-                    key_algorithm = ca_details.get('CertificateAuthorityConfiguration', {}).get('KeyAlgorithm', 'N/A')
-                    signing_algorithm = ca_details.get('CertificateAuthorityConfiguration', {}).get('SigningAlgorithm', 'N/A')
-
-                    # Subject information
-                    subject = ca_details.get('CertificateAuthorityConfiguration', {}).get('Subject', {})
-                    common_name = subject.get('CommonName', 'N/A')
-                    organization = subject.get('Organization', 'N/A')
-                    organizational_unit = subject.get('OrganizationalUnit', 'N/A')
-                    country = subject.get('Country', 'N/A')
-                    state = subject.get('State', 'N/A')
-                    locality = subject.get('Locality', 'N/A')
-
-                    # Dates
-                    created_at = ca_details.get('CreatedAt', 'N/A')
-                    if created_at != 'N/A':
-                        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
-
-                    not_before = ca_details.get('NotBefore', 'N/A')
-                    if not_before != 'N/A':
-                        not_before = not_before.strftime('%Y-%m-%d %H:%M:%S')
-
-                    not_after = ca_details.get('NotAfter', 'N/A')
-                    if not_after != 'N/A':
-                        not_after = not_after.strftime('%Y-%m-%d %H:%M:%S')
-
-                    last_state_change = ca_details.get('LastStateChangeAt', 'N/A')
-                    if last_state_change != 'N/A':
-                        last_state_change = last_state_change.strftime('%Y-%m-%d %H:%M:%S')
-
-                    # Revocation configuration
-                    revocation_config = ca_details.get('RevocationConfiguration', {})
-                    crl_config = revocation_config.get('CrlConfiguration', {})
-                    crl_enabled = crl_config.get('Enabled', False)
-                    crl_s3_bucket = crl_config.get('S3BucketName', 'N/A')
-                    crl_s3_object_acl = crl_config.get('S3ObjectAcl', 'N/A')
-                    crl_expiration_days = crl_config.get('ExpirationInDays', 'N/A')
-
-                    ocsp_config = revocation_config.get('OcspConfiguration', {})
-                    ocsp_enabled = ocsp_config.get('Enabled', False)
-                    ocsp_custom_cname = ocsp_config.get('OcspCustomCname', 'N/A')
-
-                    # Key storage security standard
-                    key_storage = ca_details.get('KeyStorageSecurityStandard', 'N/A')
-
-                    # Usage mode
-                    usage_mode = ca_details.get('UsageMode', 'N/A')
-
-                    # Owner account
-                    owner_account = ca_details.get('OwnerAccount', 'N/A')
-
-                    # Failure reason
-                    failure_reason = ca_details.get('FailureReason', 'N/A')
-
-                    # Serial number
-                    serial = ca_details.get('Serial', 'N/A')
-
-                    # Get tags
-                    tags_str = 'N/A'
-                    try:
-                        tags_response = acmpca_client.list_tags(
-                            CertificateAuthorityArn=ca_arn
-                        )
-                        tags = tags_response.get('Tags', [])
-                        if tags:
-                            tags_str = ', '.join([f"{tag['Key']}={tag['Value']}" for tag in tags])
-                    except Exception:
-                        pass
-
-                    regional_cas.append({
-                        'Region': region,
-                        'CA ARN': ca_arn,
-                        'Type': ca_type,
-                        'Status': status,
-                        'Common Name': common_name,
-                        'Organization': organization,
-                        'Organizational Unit': organizational_unit,
-                        'Country': country,
-                        'State': state,
-                        'Locality': locality,
-                        'Key Algorithm': key_algorithm,
-                        'Signing Algorithm': signing_algorithm,
-                        'Key Storage Security Standard': key_storage,
-                        'Usage Mode': usage_mode,
-                        'Serial Number': serial,
-                        'Created At': created_at,
-                        'Not Before': not_before,
-                        'Not After': not_after,
-                        'Last State Change': last_state_change,
-                        'CRL Enabled': crl_enabled,
-                        'CRL S3 Bucket': crl_s3_bucket,
-                        'CRL S3 Object ACL': crl_s3_object_acl,
-                        'CRL Expiration Days': crl_expiration_days,
-                        'OCSP Enabled': ocsp_enabled,
-                        'OCSP Custom CNAME': ocsp_custom_cname,
-                        'Owner Account': owner_account,
-                        'Failure Reason': failure_reason,
-                        'Tags': tags_str
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for CA {ca_arn} in {region}: {str(e)}")
-                    continue
-
-    except Exception as e:
-        utils.log_warning(f"Error listing Private CAs in {region}: {str(e)}")
+            regional_cas.append(row)
 
     return regional_cas
 
 
-@utils.aws_error_handler("Collecting Private Certificate Authorities", default_return=[])
-def collect_private_cas(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect ACM Private CA certificate authority information from AWS regions."""
+def collect_private_cas(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect ACM Private CA certificate authority information from AWS regions,
+    surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(cas, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING PRIVATE CERTIFICATE AUTHORITIES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_private_cas_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_private_cas_region,
+        show_progress=True,
+        collect_failures=True,
+    )
     all_cas = [ca for result in results for ca in result]
     utils.log_success(f"Total Private CAs collected: {len(all_cas)}")
-    return all_cas
+    return all_cas, failed_regions
 
 
 @utils.aws_error_handler("Collecting issued certificates", default_return=[])
@@ -388,7 +427,9 @@ def main():
     # Collect data
     print("\nCollecting ACM Private CA data...")
 
-    cas = collect_private_cas(regions)
+    # Primary scope — region failures must propagate as failed_regions, never
+    # collapse into "empty" (see .collab/audit/07.16.2026-...).
+    cas, failed_regions = collect_private_cas(regions)
     certificates = collect_issued_certificates(regions)
     permissions = collect_ca_permissions(regions)
     summary = generate_summary(cas, certificates, permissions)
@@ -418,7 +459,11 @@ def main():
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    # Export to Excel. The Summary sheet is always non-empty (generate_summary
+    # always returns at least the top-level counters), so ``dataframes`` is
+    # always truthy and a workbook always lands here — this is the Tier-3
+    # PARTIAL behavior we preserve. It does NOT mean the export succeeded;
+    # see the failed_regions check below.
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'acm-privateca', region_suffix)
@@ -429,6 +474,20 @@ def main():
         # Log summary
     else:
         utils.log_warning("No ACM Private CA data found to export")
+
+    # If any region failed the primary Private CA scope collection, make it
+    # loud: write a marker and exit non-zero, even though the forced Summary
+    # sheet means a workbook still landed. A complete-looking file that is
+    # silently missing data is exactly the failure mode this guards against.
+    # A genuinely empty result (every region succeeded, none had CAs) stays
+    # exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'acm-privateca', failed_regions)
+        print(
+            "\nERROR: ACM Private CA export completed with failures — data is incomplete. "
+            "See the *-acm-privateca-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("ACM Private CA export completed successfully")
 

--- a/scripts/iam_identity_providers_export.py
+++ b/scripts/iam_identity_providers_export.py
@@ -26,9 +26,103 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export IAM identity providers to Excel")
 
-@utils.aws_error_handler("Collecting SAML providers", default_return=[])
+def _build_saml_row(iam_client, provider: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single SAML provider.
+
+    Extracted so per-provider processing can be wrapped in try/except by
+    the caller: a malformed provider entry (or a per-provider API error)
+    must not sink the whole account-scope collection.
+
+    Args:
+        iam_client: The boto3 IAM client.
+        provider (dict): A single SAMLProviderList entry from
+            list_saml_providers.
+
+    Returns:
+        dict: The assembled SAML provider row.
+
+    Raises:
+        Exception: Any error building this row (caller skips the entry).
+    """
+    provider_arn = provider.get('Arn', 'N/A')
+
+    # Get detailed information about the SAML provider
+    provider_response = iam_client.get_saml_provider(SAMLProviderArn=provider_arn)
+
+    saml_metadata = provider_response.get('SAMLMetadataDocument', 'N/A')
+    create_date = provider_response.get('CreateDate', 'N/A')
+    valid_until = provider_response.get('ValidUntil', 'N/A')
+
+    # Format dates
+    if create_date != 'N/A':
+        create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
+
+    if valid_until != 'N/A':
+        valid_until = valid_until.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Extract provider name from ARN
+    # ARN format: arn:aws:iam::account-id:saml-provider/provider-name
+    provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
+
+    # Truncate SAML metadata for display
+    saml_metadata_display = 'N/A'
+    if saml_metadata != 'N/A':
+        # Extract some information from metadata if possible
+        if 'entityID' in saml_metadata:
+            try:
+                # Try to extract entity ID from XML
+                entity_id_start = saml_metadata.find('entityID="') + 10
+                entity_id_end = saml_metadata.find('"', entity_id_start)
+                entity_id = saml_metadata[entity_id_start:entity_id_end]
+                saml_metadata_display = f"Entity ID: {entity_id} (metadata truncated)"
+            except Exception:
+                saml_metadata_display = "Metadata present (truncated)"
+        else:
+            saml_metadata_display = "Metadata present (truncated)"
+
+    # Get tags for this provider (enrichment — degrades gracefully)
+    tags_str = 'N/A'
+    try:
+        tags_response = iam_client.list_saml_provider_tags(SAMLProviderArn=provider_arn)
+        tags = tags_response.get('Tags', [])
+        if tags:
+            tags_str = ', '.join([f"{tag.get('Key')}={tag.get('Value')}" for tag in tags])
+    except Exception:
+        pass
+
+    return {
+        'Provider Name': provider_name,
+        'ARN': provider_arn,
+        'Created': create_date,
+        'Valid Until': valid_until,
+        'SAML Metadata': saml_metadata_display,
+        'Tags': tags_str
+    }
+
+
 def collect_saml_providers() -> list[dict[str, Any]]:
-    """Collect IAM SAML provider information."""
+    """
+    Collect IAM SAML provider information.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no SAML providers configured), producing
+    silent data loss (see the 07.15.2026 / 07.16.2026 silent-collection-
+    failure audits). IAM identity providers are a global, account-scope
+    resource (not multi-region — see scripts/shield_export.py for the
+    account-scope reference pattern this follows). Account-scope failures
+    (client creation, list_saml_providers) are allowed to raise so the
+    caller (main) can record this scope as *failed* rather than *empty*.
+    Per-provider errors are contained internally (logged and skipped).
+
+    Returns:
+        list: List of SAML provider information dictionaries.
+
+    Raises:
+        Exception: Any AWS error for the account scope (caller records it
+            as a failed scope; it is never masked as empty).
+    """
     utils.log_info("Collecting SAML providers...")
     all_saml_providers = []
 
@@ -39,93 +133,135 @@ def collect_saml_providers() -> list[dict[str, Any]]:
 
     iam_client = utils.get_boto3_client('iam', region_name=home_region)
 
-    try:
-        # List all SAML providers
-        response = iam_client.list_saml_providers()
-        saml_provider_list = response.get('SAMLProviderList', [])
+    # List all SAML providers
+    response = iam_client.list_saml_providers()
+    saml_provider_list = response.get('SAMLProviderList', [])
 
-        utils.log_info(f"Found {len(saml_provider_list)} SAML providers")
+    utils.log_info(f"Found {len(saml_provider_list)} SAML providers")
 
-        for provider in saml_provider_list:
-            provider_arn = provider.get('Arn', 'N/A')
+    for provider in saml_provider_list:
+        provider_arn = provider.get('Arn', 'N/A') if isinstance(provider, dict) else 'N/A'
 
-            try:
-                # Get detailed information about the SAML provider
-                provider_response = iam_client.get_saml_provider(SAMLProviderArn=provider_arn)
+        try:
+            row = _build_saml_row(iam_client, provider)
+        except Exception as e:
+            utils.log_warning(f"Could not get details for SAML provider {provider_arn}: {str(e)}")
+            continue
 
-                saml_metadata = provider_response.get('SAMLMetadataDocument', 'N/A')
-                create_date = provider_response.get('CreateDate', 'N/A')
-                valid_until = provider_response.get('ValidUntil', 'N/A')
-
-                # Format dates
-                if create_date != 'N/A':
-                    create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
-
-                if valid_until != 'N/A':
-                    valid_until = valid_until.strftime('%Y-%m-%d %H:%M:%S')
-
-                # Extract provider name from ARN
-                # ARN format: arn:aws:iam::account-id:saml-provider/provider-name
-                provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
-
-                # Truncate SAML metadata for display
-                saml_metadata_display = 'N/A'
-                if saml_metadata != 'N/A':
-                    # Extract some information from metadata if possible
-                    if 'entityID' in saml_metadata:
-                        try:
-                            # Try to extract entity ID from XML
-                            entity_id_start = saml_metadata.find('entityID="') + 10
-                            entity_id_end = saml_metadata.find('"', entity_id_start)
-                            entity_id = saml_metadata[entity_id_start:entity_id_end]
-                            saml_metadata_display = f"Entity ID: {entity_id} (metadata truncated)"
-                        except Exception:
-                            saml_metadata_display = "Metadata present (truncated)"
-                    else:
-                        saml_metadata_display = "Metadata present (truncated)"
-
-                # Get tags for this provider
-                tags_str = 'N/A'
-                try:
-                    tags_response = iam_client.list_saml_provider_tags(SAMLProviderArn=provider_arn)
-                    tags = tags_response.get('Tags', [])
-                    if tags:
-                        tags_str = ', '.join([f"{tag['Key']}={tag['Value']}" for tag in tags])
-                except Exception:
-                    pass
-
-                all_saml_providers.append({
-                    'Provider Name': provider_name,
-                    'ARN': provider_arn,
-                    'Created': create_date,
-                    'Valid Until': valid_until,
-                    'SAML Metadata': saml_metadata_display,
-                    'Tags': tags_str
-                })
-
-            except Exception as e:
-                utils.log_warning(f"Could not get details for SAML provider {provider_arn}: {str(e)}")
-                # Add basic info
-                provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
-                all_saml_providers.append({
-                    'Provider Name': provider_name,
-                    'ARN': provider_arn,
-                    'Created': 'N/A',
-                    'Valid Until': 'N/A',
-                    'SAML Metadata': 'Error retrieving',
-                    'Tags': 'N/A'
-                })
-
-    except Exception as e:
-        utils.log_warning(f"Error listing SAML providers: {str(e)}")
+        all_saml_providers.append(row)
 
     utils.log_info(f"Collected {len(all_saml_providers)} SAML providers")
     return all_saml_providers
 
 
-@utils.aws_error_handler("Collecting OIDC providers", default_return=[])
+def _build_oidc_row(iam_client, provider: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single OIDC provider.
+
+    Extracted so per-provider processing can be wrapped in try/except by
+    the caller: a malformed provider entry (or a per-provider API error)
+    must not sink the whole account-scope collection.
+
+    Args:
+        iam_client: The boto3 IAM client.
+        provider (dict): A single OpenIDConnectProviderList entry from
+            list_open_id_connect_providers.
+
+    Returns:
+        dict: The assembled OIDC provider row.
+
+    Raises:
+        Exception: Any error building this row (caller skips the entry).
+    """
+    provider_arn = provider.get('Arn', 'N/A')
+
+    # Get detailed information about the OIDC provider
+    provider_response = iam_client.get_open_id_connect_provider(
+        OpenIDConnectProviderArn=provider_arn
+    )
+
+    url = provider_response.get('Url', 'N/A')
+    client_id_list = provider_response.get('ClientIDList', [])
+    thumbprint_list = provider_response.get('ThumbprintList', [])
+    create_date = provider_response.get('CreateDate', 'N/A')
+
+    # Format date
+    if create_date != 'N/A':
+        create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Extract provider name from ARN
+    # ARN format: arn:aws:iam::account-id:oidc-provider/provider-url
+    provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
+
+    # Format client IDs
+    client_ids_str = ', '.join(client_id_list) if client_id_list else 'None'
+
+    # Format thumbprints
+    thumbprints_str = ', '.join(thumbprint_list) if thumbprint_list else 'None'
+    thumbprint_count = len(thumbprint_list)
+
+    # Get tags for this provider (enrichment — degrades gracefully)
+    tags_str = 'N/A'
+    try:
+        tags_response = iam_client.list_open_id_connect_provider_tags(
+            OpenIDConnectProviderArn=provider_arn
+        )
+        tags = tags_response.get('Tags', [])
+        if tags:
+            tags_str = ', '.join([f"{tag.get('Key')}={tag.get('Value')}" for tag in tags])
+    except Exception:
+        pass
+
+    # Determine provider type based on URL
+    provider_type = 'Generic OIDC'
+    if 'amazonaws.com' in url:
+        provider_type = 'Amazon EKS' if 'eks' in url else 'AWS Service'
+    elif 'accounts.google.com' in url:
+        provider_type = 'Google'
+    elif 'login.microsoftonline.com' in url or 'sts.windows.net' in url:
+        provider_type = 'Microsoft Azure AD'
+    elif 'appleid.apple.com' in url:
+        provider_type = 'Apple'
+    elif 'token.actions.githubusercontent.com' in url:
+        provider_type = 'GitHub Actions'
+
+    return {
+        'Provider Name': provider_name,
+        'ARN': provider_arn,
+        'Provider Type': provider_type,
+        'URL': url,
+        'Created': create_date,
+        'Client IDs': client_ids_str,
+        'Client ID Count': len(client_id_list),
+        'Thumbprints': thumbprints_str,
+        'Thumbprint Count': thumbprint_count,
+        'Tags': tags_str
+    }
+
+
 def collect_oidc_providers() -> list[dict[str, Any]]:
-    """Collect IAM OIDC (OpenID Connect) provider information."""
+    """
+    Collect IAM OIDC (OpenID Connect) provider information.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no OIDC providers configured), producing
+    silent data loss (see the 07.15.2026 / 07.16.2026 silent-collection-
+    failure audits). IAM identity providers are a global, account-scope
+    resource (not multi-region — see scripts/shield_export.py for the
+    account-scope reference pattern this follows). Account-scope failures
+    (client creation, list_open_id_connect_providers) are allowed to raise
+    so the caller (main) can record this scope as *failed* rather than
+    *empty*. Per-provider errors are contained internally (logged and
+    skipped).
+
+    Returns:
+        list: List of OIDC provider information dictionaries.
+
+    Raises:
+        Exception: Any AWS error for the account scope (caller records it
+            as a failed scope; it is never masked as empty).
+    """
     utils.log_info("Collecting OIDC providers...")
     all_oidc_providers = []
 
@@ -136,99 +272,22 @@ def collect_oidc_providers() -> list[dict[str, Any]]:
 
     iam_client = utils.get_boto3_client('iam', region_name=home_region)
 
-    try:
-        # List all OIDC providers
-        response = iam_client.list_open_id_connect_providers()
-        oidc_provider_list = response.get('OpenIDConnectProviderList', [])
+    # List all OIDC providers
+    response = iam_client.list_open_id_connect_providers()
+    oidc_provider_list = response.get('OpenIDConnectProviderList', [])
 
-        utils.log_info(f"Found {len(oidc_provider_list)} OIDC providers")
+    utils.log_info(f"Found {len(oidc_provider_list)} OIDC providers")
 
-        for provider in oidc_provider_list:
-            provider_arn = provider.get('Arn', 'N/A')
+    for provider in oidc_provider_list:
+        provider_arn = provider.get('Arn', 'N/A') if isinstance(provider, dict) else 'N/A'
 
-            try:
-                # Get detailed information about the OIDC provider
-                provider_response = iam_client.get_open_id_connect_provider(
-                    OpenIDConnectProviderArn=provider_arn
-                )
+        try:
+            row = _build_oidc_row(iam_client, provider)
+        except Exception as e:
+            utils.log_warning(f"Could not get details for OIDC provider {provider_arn}: {str(e)}")
+            continue
 
-                url = provider_response.get('Url', 'N/A')
-                client_id_list = provider_response.get('ClientIDList', [])
-                thumbprint_list = provider_response.get('ThumbprintList', [])
-                create_date = provider_response.get('CreateDate', 'N/A')
-
-                # Format date
-                if create_date != 'N/A':
-                    create_date = create_date.strftime('%Y-%m-%d %H:%M:%S')
-
-                # Extract provider name from ARN
-                # ARN format: arn:aws:iam::account-id:oidc-provider/provider-url
-                provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
-
-                # Format client IDs
-                client_ids_str = ', '.join(client_id_list) if client_id_list else 'None'
-
-                # Format thumbprints
-                thumbprints_str = ', '.join(thumbprint_list) if thumbprint_list else 'None'
-                thumbprint_count = len(thumbprint_list)
-
-                # Get tags for this provider
-                tags_str = 'N/A'
-                try:
-                    tags_response = iam_client.list_open_id_connect_provider_tags(
-                        OpenIDConnectProviderArn=provider_arn
-                    )
-                    tags = tags_response.get('Tags', [])
-                    if tags:
-                        tags_str = ', '.join([f"{tag['Key']}={tag['Value']}" for tag in tags])
-                except Exception:
-                    pass
-
-                # Determine provider type based on URL
-                provider_type = 'Generic OIDC'
-                if 'amazonaws.com' in url:
-                    provider_type = 'Amazon EKS' if 'eks' in url else 'AWS Service'
-                elif 'accounts.google.com' in url:
-                    provider_type = 'Google'
-                elif 'login.microsoftonline.com' in url or 'sts.windows.net' in url:
-                    provider_type = 'Microsoft Azure AD'
-                elif 'appleid.apple.com' in url:
-                    provider_type = 'Apple'
-                elif 'token.actions.githubusercontent.com' in url:
-                    provider_type = 'GitHub Actions'
-
-                all_oidc_providers.append({
-                    'Provider Name': provider_name,
-                    'ARN': provider_arn,
-                    'Provider Type': provider_type,
-                    'URL': url,
-                    'Created': create_date,
-                    'Client IDs': client_ids_str,
-                    'Client ID Count': len(client_id_list),
-                    'Thumbprints': thumbprints_str,
-                    'Thumbprint Count': thumbprint_count,
-                    'Tags': tags_str
-                })
-
-            except Exception as e:
-                utils.log_warning(f"Could not get details for OIDC provider {provider_arn}: {str(e)}")
-                # Add basic info
-                provider_name = provider_arn.split('/')[-1] if '/' in provider_arn else 'N/A'
-                all_oidc_providers.append({
-                    'Provider Name': provider_name,
-                    'ARN': provider_arn,
-                    'Provider Type': 'Unknown',
-                    'URL': 'N/A',
-                    'Created': 'N/A',
-                    'Client IDs': 'Error retrieving',
-                    'Client ID Count': 0,
-                    'Thumbprints': 'Error retrieving',
-                    'Thumbprint Count': 0,
-                    'Tags': 'N/A'
-                })
-
-    except Exception as e:
-        utils.log_warning(f"Error listing OIDC providers: {str(e)}")
+        all_oidc_providers.append(row)
 
     utils.log_info(f"Collected {len(all_oidc_providers)} OIDC providers")
     return all_oidc_providers
@@ -414,7 +473,19 @@ def generate_summary(saml_providers: list[dict[str, Any]],
 
 
 def main():
-    """Main execution function."""
+    """
+    Main execution function.
+
+    IAM identity providers are a global, account-scope resource (not
+    multi-region), so failures are tracked per account-scope collector
+    rather than via ``utils.scan_regions_concurrent`` (see
+    scripts/shield_export.py for the account-scope reference pattern).
+    A failure on either primary scope (SAML or OIDC providers) is exported
+    as a partial result (the forced Summary sheet, plus any other data that
+    did collect) and always surfaced via ``utils.report_collection_failures``
+    plus a non-zero exit — it must never be silently collapsed into "no
+    providers" (07.15.2026 / 07.16.2026 audits).
+    """
     if not utils.ensure_dependencies('pandas', 'openpyxl'):
         return
     global pd
@@ -433,8 +504,30 @@ def main():
     # Collect data (IAM is global)
     print("\nCollecting IAM identity provider data...")
 
-    saml_providers = collect_saml_providers()
-    oidc_providers = collect_oidc_providers()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect SAML providers (PRIMARY scope — a real API error here
+    # must propagate to failed_scopes, never collapse into an empty list
+    # that reads as "no SAML providers configured").
+    try:
+        saml_providers = collect_saml_providers()
+    except Exception as e:
+        failed_scopes.append(('saml_providers', str(e)))
+        utils.log_error(f"SAML providers collection failed: {e}")
+        saml_providers = []
+
+    # STEP 2: Collect OIDC providers (PRIMARY scope — same treatment).
+    try:
+        oidc_providers = collect_oidc_providers()
+    except Exception as e:
+        failed_scopes.append(('oidc_providers', str(e)))
+        utils.log_error(f"OIDC providers collection failed: {e}")
+        oidc_providers = []
+
+    # STEP 3+: Enrichment collectors — degrade gracefully to a safe default
+    # via their own aws_error_handler decorator; a failure here does not
+    # fail the whole export.
     roles_with_providers = collect_roles_using_providers(saml_providers, oidc_providers)
     summary = generate_summary(saml_providers, oidc_providers, roles_with_providers)
 
@@ -458,21 +551,42 @@ def main():
         df_roles = utils.prepare_dataframe_for_export(df_roles)
         dataframes['Roles Using Providers'] = df_roles
 
+    # Summary sheet is always written (generate_summary always returns at
+    # least the SAML/OIDC/role counts) — this forced Summary sheet is what
+    # guarantees the workbook always lands, even on a total account-scope
+    # failure. PRESERVE this.
     if summary:
         df_summary = pd.DataFrame(summary)
         df_summary = utils.prepare_dataframe_for_export(df_summary)
         dataframes['Summary'] = df_summary
 
-    # Export to Excel
+    slug = 'iam-identity-providers'
+
+    # Export whatever succeeded — a partial export is required even when a
+    # primary scope failed (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
     if dataframes:
-        filename = utils.create_export_filename(account_name, 'iam-identity-providers', 'global')
+        filename = utils.create_export_filename(account_name, slug, 'global')
 
         utils.log_info(f"Exporting to {filename}...")
         utils.save_multiple_dataframes_to_excel(dataframes, filename)
-
-        # Log summary
-    else:
+    elif not failed_scopes:
+        # Genuinely empty: both primary scopes succeeded and there is
+        # simply nothing configured.
         utils.log_warning("No IAM identity provider data found to export")
+
+    # If either primary scope failed, make it loud: write a marker and
+    # exit non-zero, even though the forced Summary sheet (and any partial
+    # SAML/OIDC data) was still exported. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, slug, failed_scopes)
+        print(
+            "\nERROR: IAM identity providers export completed with failures — "
+            "data is incomplete. See the *-iam-identity-providers-FAILED-*.txt "
+            "marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("IAM Identity Providers export completed successfully")
 

--- a/scripts/iam_rolesanywhere_export.py
+++ b/scripts/iam_rolesanywhere_export.py
@@ -41,173 +41,232 @@ def format_tags(tags: list[dict[str, str]]) -> str:
     """Format tags for display."""
     if not tags:
         return "None"
-    tag_strings = [f"{tag['key']}={tag['value']}" for tag in tags]
+    tag_strings = [f"{tag.get('key', 'N/A')}={tag.get('value', 'N/A')}" for tag in tags]
     return ", ".join(tag_strings)
 
-@utils.aws_error_handler("Collecting Trust Anchors", default_return=[])
+
+def _build_trust_anchor_row(rolesanywhere, anchor: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single IAM Roles Anywhere trust anchor.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed trust anchor entry must not sink the whole
+    account-scope collection. Fields are read with ``.get()`` and a safe
+    default for the same reason.
+
+    Args:
+        rolesanywhere: The boto3 IAM Roles Anywhere client.
+        anchor: A single trustAnchors entry from list_trust_anchors.
+
+    Returns:
+        dict: The assembled trust anchor row.
+    """
+    trust_anchor_id = anchor.get('trustAnchorId', 'N/A')
+    utils.log_info(f"Processing trust anchor: {anchor.get('name', trust_anchor_id)}")
+
+    detail_response = rolesanywhere.get_trust_anchor(trustAnchorId=trust_anchor_id)
+    anchor_detail = detail_response.get('trustAnchor', {})
+
+    source = anchor_detail.get('source', {})
+    source_type = source.get('sourceType', 'N/A')
+    source_data = source.get('sourceData', {})
+
+    # Extract source ARN for ACM PCA
+    if source_type == 'AWS_ACM_PCA':
+        source_arn = source_data.get('acmPcaArn', 'N/A')
+    elif source_type == 'CERTIFICATE_BUNDLE':
+        source_arn = 'Certificate Bundle'
+    else:
+        source_arn = 'N/A'
+
+    created_at = anchor_detail.get('createdAt')
+    updated_at = anchor_detail.get('updatedAt')
+
+    return {
+        'Trust Anchor ARN': anchor_detail.get('trustAnchorArn', 'N/A'),
+        'Trust Anchor ID': trust_anchor_id,
+        'Name': anchor_detail.get('name', 'N/A'),
+        'Status': 'Enabled' if anchor_detail.get('enabled', False) else 'Disabled',
+        'Source Type': source_type,
+        'Source ARN/Reference': source_arn,
+        'Created At': created_at.strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(created_at, datetime.datetime) else 'N/A',
+        'Updated At': updated_at.strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(updated_at, datetime.datetime) else 'N/A',
+        'Tags': format_tags(anchor_detail.get('tags', []))
+    }
+
+
 def collect_trust_anchors() -> list[dict[str, Any]]:
-    """Collect IAM Roles Anywhere Trust Anchors."""
+    """
+    Collect IAM Roles Anywhere Trust Anchors.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no trust anchors configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). IAM Roles Anywhere is a global, account-scope service (not
+    multi-region -- see scripts/iam_export.py for the account-scope
+    reference pattern this follows, and scripts/shield_export.py /
+    scripts/lambda_export.py for the same fix applied there). Account-scope
+    failures (client creation, pagination, a real API error) are allowed to
+    raise so the caller (main) can record this scope as *failed* rather than
+    *empty*. Per-item errors are contained internally (logged and skipped).
+
+    Returns:
+        list: List of trust anchor information dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     utils.log_info("Collecting IAM Roles Anywhere Trust Anchors...")
 
     # IAM Roles Anywhere is a global service - use partition-aware home region
-
-
     home_region = utils.get_partition_default_region()
-
-
     rolesanywhere = utils.get_boto3_client('rolesanywhere', region_name=home_region)
     trust_anchors = []
 
-    try:
-        # List all trust anchors
-        paginator = rolesanywhere.get_paginator('list_trust_anchors')
+    # List all trust anchors
+    paginator = rolesanywhere.get_paginator('list_trust_anchors')
+    total_anchors = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            for anchor in page.get('trustAnchors', []):
-                trust_anchor_id = anchor.get('trustAnchorId', 'N/A')
-                utils.log_info(f"Processing trust anchor: {anchor.get('name', trust_anchor_id)}")
+    for page in paginator.paginate():
+        anchors = page.get('trustAnchors', [])
+        total_anchors += len(anchors)
 
-                # Get detailed information
-                try:
-                    detail_response = rolesanywhere.get_trust_anchor(trustAnchorId=trust_anchor_id)
-                    anchor_detail = detail_response.get('trustAnchor', {})
+        for anchor in anchors:
+            try:
+                trust_anchors.append(_build_trust_anchor_row(rolesanywhere, anchor))
+            except Exception as e:
+                skipped += 1
+                anchor_id = anchor.get('trustAnchorId', 'Unknown') if isinstance(anchor, dict) else 'Unknown'
+                utils.log_error(f"Skipping trust anchor '{anchor_id}' due to a processing error", e)
+                continue
 
-                    source = anchor_detail.get('source', {})
-                    source_type = source.get('sourceType', 'N/A')
-                    source_data = source.get('sourceData', {})
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_anchors} trust anchor(s) were skipped due to "
+            "processing errors (see log above); the remaining trust anchors were still collected."
+        )
 
-                    # Extract source ARN for ACM PCA
-                    if source_type == 'AWS_ACM_PCA':
-                        source_arn = source_data.get('acmPcaArn', 'N/A')
-                    elif source_type == 'CERTIFICATE_BUNDLE':
-                        source_arn = 'Certificate Bundle'
-                    else:
-                        source_arn = 'N/A'
-
-                    trust_anchor_info = {
-                        'Trust Anchor ARN': anchor_detail.get('trustAnchorArn', 'N/A'),
-                        'Trust Anchor ID': trust_anchor_id,
-                        'Name': anchor_detail.get('name', 'N/A'),
-                        'Status': 'Enabled' if anchor_detail.get('enabled', False) else 'Disabled',
-                        'Source Type': source_type,
-                        'Source ARN/Reference': source_arn,
-                        'Created At': anchor_detail.get('createdAt', 'N/A').strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(anchor_detail.get('createdAt'), datetime.datetime) else 'N/A',
-                        'Updated At': anchor_detail.get('updatedAt', 'N/A').strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(anchor_detail.get('updatedAt'), datetime.datetime) else 'N/A',
-                        'Tags': format_tags(anchor_detail.get('tags', []))
-                    }
-
-                    trust_anchors.append(trust_anchor_info)
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for trust anchor {trust_anchor_id}: {e}")
-                    # Add basic info even if details fail
-                    trust_anchors.append({
-                        'Trust Anchor ARN': anchor.get('trustAnchorArn', 'N/A'),
-                        'Trust Anchor ID': trust_anchor_id,
-                        'Name': anchor.get('name', 'N/A'),
-                        'Status': 'Enabled' if anchor.get('enabled', False) else 'Disabled',
-                        'Source Type': 'Unknown',
-                        'Source ARN/Reference': 'Unknown',
-                        'Created At': 'Unknown',
-                        'Updated At': 'Unknown',
-                        'Tags': 'Unknown'
-                    })
-
-        utils.log_success(f"Successfully collected {len(trust_anchors)} trust anchors")
-
-    except Exception as e:
-        utils.log_warning(f"No trust anchors found or service not configured: {e}")
+    utils.log_success(f"Successfully collected {len(trust_anchors)} trust anchors")
 
     return trust_anchors
 
-@utils.aws_error_handler("Collecting Profiles", default_return=[])
+def _build_profile_row(rolesanywhere, profile: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single IAM Roles Anywhere profile.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed profile entry must not sink the whole account-scope
+    collection. Fields are read with ``.get()`` and a safe default for the
+    same reason.
+
+    Args:
+        rolesanywhere: The boto3 IAM Roles Anywhere client.
+        profile: A single profiles entry from list_profiles.
+
+    Returns:
+        dict: The assembled profile row.
+    """
+    profile_id = profile.get('profileId', 'N/A')
+    utils.log_info(f"Processing profile: {profile.get('name', profile_id)}")
+
+    detail_response = rolesanywhere.get_profile(profileId=profile_id)
+    profile_detail = detail_response.get('profile', {})
+
+    # Extract role ARNs
+    role_arns = profile_detail.get('roleArns', [])
+    role_arns_str = ", ".join(role_arns) if role_arns else "None"
+
+    # Extract managed policy ARNs
+    managed_policies = profile_detail.get('managedPolicyArns', [])
+    managed_policies_str = ", ".join(managed_policies) if managed_policies else "None"
+
+    # Count inline policies
+    inline_policy_count = len(profile_detail.get('sessionPolicy', ''))
+
+    # Session duration in seconds
+    session_duration = profile_detail.get('durationSeconds', 3600)
+    session_duration_hours = session_duration / 3600
+
+    created_at = profile_detail.get('createdAt')
+    updated_at = profile_detail.get('updatedAt')
+
+    return {
+        'Profile ARN': profile_detail.get('profileArn', 'N/A'),
+        'Profile ID': profile_id,
+        'Name': profile_detail.get('name', 'N/A'),
+        'Status': 'Enabled' if profile_detail.get('enabled', False) else 'Disabled',
+        'Session Duration (Hours)': f"{session_duration_hours:.2f}",
+        'Session Duration (Seconds)': session_duration,
+        'Role ARNs': role_arns_str,
+        'Role Count': len(role_arns),
+        'Managed Policy ARNs': managed_policies_str,
+        'Managed Policy Count': len(managed_policies),
+        'Has Inline Policy': 'Yes' if inline_policy_count > 0 else 'No',
+        'Require Instance Properties': 'Yes' if profile_detail.get('requireInstanceProperties', False) else 'No',
+        'Created At': created_at.strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(created_at, datetime.datetime) else 'N/A',
+        'Updated At': updated_at.strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(updated_at, datetime.datetime) else 'N/A',
+        'Tags': format_tags(profile_detail.get('tags', []))
+    }
+
+
 def collect_profiles() -> list[dict[str, Any]]:
-    """Collect IAM Roles Anywhere Profiles."""
+    """
+    Collect IAM Roles Anywhere Profiles.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no profiles configured), producing silent data
+    loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure audits).
+    IAM Roles Anywhere is a global, account-scope service (not multi-region
+    -- see scripts/iam_export.py for the account-scope reference pattern
+    this follows, and scripts/shield_export.py / scripts/lambda_export.py
+    for the same fix applied there). Account-scope failures (client
+    creation, pagination, a real API error) are allowed to raise so the
+    caller (main) can record this scope as *failed* rather than *empty*.
+    Per-item errors are contained internally (logged and skipped).
+
+    Returns:
+        list: List of profile information dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     utils.log_info("Collecting IAM Roles Anywhere Profiles...")
 
     # IAM Roles Anywhere is a global service - use partition-aware home region
-
-
     home_region = utils.get_partition_default_region()
-
-
     rolesanywhere = utils.get_boto3_client('rolesanywhere', region_name=home_region)
     profiles = []
 
-    try:
-        # List all profiles
-        paginator = rolesanywhere.get_paginator('list_profiles')
+    # List all profiles
+    paginator = rolesanywhere.get_paginator('list_profiles')
+    total_profiles = 0
+    skipped = 0
 
-        for page in paginator.paginate():
-            for profile in page.get('profiles', []):
-                profile_id = profile.get('profileId', 'N/A')
-                utils.log_info(f"Processing profile: {profile.get('name', profile_id)}")
+    for page in paginator.paginate():
+        page_profiles = page.get('profiles', [])
+        total_profiles += len(page_profiles)
 
-                # Get detailed information
-                try:
-                    detail_response = rolesanywhere.get_profile(profileId=profile_id)
-                    profile_detail = detail_response.get('profile', {})
+        for profile in page_profiles:
+            try:
+                profiles.append(_build_profile_row(rolesanywhere, profile))
+            except Exception as e:
+                skipped += 1
+                profile_id = profile.get('profileId', 'Unknown') if isinstance(profile, dict) else 'Unknown'
+                utils.log_error(f"Skipping profile '{profile_id}' due to a processing error", e)
+                continue
 
-                    # Extract role ARNs
-                    role_arns = profile_detail.get('roleArns', [])
-                    role_arns_str = ", ".join(role_arns) if role_arns else "None"
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_profiles} profile(s) were skipped due to "
+            "processing errors (see log above); the remaining profiles were still collected."
+        )
 
-                    # Extract managed policy ARNs
-                    managed_policies = profile_detail.get('managedPolicyArns', [])
-                    managed_policies_str = ", ".join(managed_policies) if managed_policies else "None"
-
-                    # Count inline policies
-                    inline_policy_count = len(profile_detail.get('sessionPolicy', ''))
-
-                    # Session duration in seconds
-                    session_duration = profile_detail.get('durationSeconds', 3600)
-                    session_duration_hours = session_duration / 3600
-
-                    profile_info = {
-                        'Profile ARN': profile_detail.get('profileArn', 'N/A'),
-                        'Profile ID': profile_id,
-                        'Name': profile_detail.get('name', 'N/A'),
-                        'Status': 'Enabled' if profile_detail.get('enabled', False) else 'Disabled',
-                        'Session Duration (Hours)': f"{session_duration_hours:.2f}",
-                        'Session Duration (Seconds)': session_duration,
-                        'Role ARNs': role_arns_str,
-                        'Role Count': len(role_arns),
-                        'Managed Policy ARNs': managed_policies_str,
-                        'Managed Policy Count': len(managed_policies),
-                        'Has Inline Policy': 'Yes' if inline_policy_count > 0 else 'No',
-                        'Require Instance Properties': 'Yes' if profile_detail.get('requireInstanceProperties', False) else 'No',
-                        'Created At': profile_detail.get('createdAt', 'N/A').strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(profile_detail.get('createdAt'), datetime.datetime) else 'N/A',
-                        'Updated At': profile_detail.get('updatedAt', 'N/A').strftime('%Y-%m-%d %H:%M:%S UTC') if isinstance(profile_detail.get('updatedAt'), datetime.datetime) else 'N/A',
-                        'Tags': format_tags(profile_detail.get('tags', []))
-                    }
-
-                    profiles.append(profile_info)
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for profile {profile_id}: {e}")
-                    # Add basic info even if details fail
-                    profiles.append({
-                        'Profile ARN': profile.get('profileArn', 'N/A'),
-                        'Profile ID': profile_id,
-                        'Name': profile.get('name', 'N/A'),
-                        'Status': 'Enabled' if profile.get('enabled', False) else 'Disabled',
-                        'Session Duration (Hours)': 'Unknown',
-                        'Session Duration (Seconds)': 'Unknown',
-                        'Role ARNs': 'Unknown',
-                        'Role Count': 0,
-                        'Managed Policy ARNs': 'Unknown',
-                        'Managed Policy Count': 0,
-                        'Has Inline Policy': 'Unknown',
-                        'Require Instance Properties': 'Unknown',
-                        'Created At': 'Unknown',
-                        'Updated At': 'Unknown',
-                        'Tags': 'Unknown'
-                    })
-
-        utils.log_success(f"Successfully collected {len(profiles)} profiles")
-
-    except Exception as e:
-        utils.log_warning(f"No profiles found or service not configured: {e}")
+    utils.log_success(f"Successfully collected {len(profiles)} profiles")
 
     return profiles
 
@@ -402,7 +461,25 @@ def export_to_excel(trust_anchors: list[dict], profiles: list[dict], crls: list[
         return None
 
 def main():
-    """Main function to orchestrate IAM Roles Anywhere data collection."""
+    """
+    Main function to orchestrate IAM Roles Anywhere data collection.
+
+    IAM Roles Anywhere is a global, account-scope service (not
+    multi-region), so failures are tracked per account-scope collector
+    rather than via ``utils.scan_regions_concurrent`` (see
+    scripts/iam_export.py for the account-scope reference pattern, and
+    scripts/shield_export.py / scripts/lambda_export.py for the finalize
+    shape this follows). Trust anchors and profiles are the two PRIMARY
+    scopes: a real API error in either must propagate to ``failed_scopes``,
+    never collapse into "not configured". This exporter always writes a
+    workbook (a forced Summary sheet plus placeholder sheets for empty
+    categories), so a partial/failed export still lands a file -- but a
+    failed scope is always also surfaced via
+    ``utils.report_collection_failures`` + a non-zero exit; it must never be
+    silently collapsed into "genuinely empty" (07.15.2026 / 07.16.2026
+    audits). CRLs remain an enrichment scope that degrades gracefully via
+    its own ``aws_error_handler`` decorator.
+    """
     try:
         # Check dependencies
         if not utils.ensure_dependencies('pandas', 'openpyxl'):
@@ -431,13 +508,33 @@ def main():
         print("will create a report indicating the service is not in use.")
         print("====================================================================\n")
 
+        # Account-scope failure tracking (see scripts/iam_export.py).
+        failed_scopes = []
+
         # Collect data
+        # STEP 1: Collect Trust Anchors (PRIMARY scope -- a real API error
+        # here must propagate to failed_scopes, never collapse into an
+        # empty list that reads as "not configured").
         utils.log_info("Phase 1: Collecting Trust Anchors...")
-        trust_anchors = collect_trust_anchors()
+        try:
+            trust_anchors = collect_trust_anchors()
+        except Exception as e:
+            failed_scopes.append(('trust_anchors', str(e)))
+            utils.log_error(f"Trust anchors collection failed: {e}")
+            trust_anchors = []
 
+        # STEP 2: Collect Profiles (PRIMARY scope -- same rule as above).
         utils.log_info("Phase 2: Collecting Profiles...")
-        profiles = collect_profiles()
+        try:
+            profiles = collect_profiles()
+        except Exception as e:
+            failed_scopes.append(('profiles', str(e)))
+            utils.log_error(f"Profiles collection failed: {e}")
+            profiles = []
 
+        # STEP 3: Collect CRLs (enrichment -- degrades gracefully via its
+        # own aws_error_handler decorator; a failure here does not fail the
+        # whole export).
         utils.log_info("Phase 3: Collecting CRLs...")
         crls = collect_crls()
 
@@ -445,11 +542,16 @@ def main():
         print("COLLECTION COMPLETE")
         print("====================================================================")
 
-        # Export even if empty (with helpful messaging)
+        # Export whatever succeeded -- this exporter always writes a
+        # workbook (forced Summary sheet + placeholder sheets), even when a
+        # primary scope failed (see
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
         filename = export_to_excel(trust_anchors, profiles, crls, account_id, account_name)
 
         if filename:
-            if not trust_anchors and not profiles and not crls:
+            if not trust_anchors and not profiles and not crls and not failed_scopes:
+                # Genuinely empty: both primary scopes succeeded and there is
+                # simply nothing configured.
                 utils.log_info("IAM Roles Anywhere is not configured in this account")
                 utils.log_info("The export file contains informational placeholders")
             else:
@@ -460,6 +562,20 @@ def main():
             print("\nScript execution completed successfully.")
         else:
             utils.log_error("Export failed. Please check the logs.")
+
+        # If a primary scope (trust anchors or profiles) failed, make it
+        # loud: write a marker and exit non-zero, even though a workbook
+        # (with the forced Summary sheet) was still written. A partial
+        # export that looks complete is exactly the failure mode this
+        # guards against.
+        if failed_scopes:
+            utils.report_collection_failures(account_name, 'iam-rolesanywhere', failed_scopes)
+            print(
+                "\nERROR: IAM Roles Anywhere export completed with failures — data is "
+                "incomplete. See the *-iam-rolesanywhere-FAILED-*.txt marker in the "
+                "output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/macie_export.py
+++ b/scripts/macie_export.py
@@ -45,69 +45,102 @@ except ImportError:
 utils.setup_logging("macie-export")
 
 
-@utils.aws_error_handler("Collecting Macie status from region", default_return=[])
+def _build_macie_status_row(status_response: dict, region: str) -> dict[str, Any]:
+    """Build a single Macie status export row from a get_macie_session response."""
+    status = status_response.get('status', 'N/A')
+    finding_publishing_frequency = status_response.get('findingPublishingFrequency', 'N/A')
+    service_role = status_response.get('serviceRole', 'N/A')
+
+    # Extract role name
+    role_name = 'N/A'
+    if service_role != 'N/A' and '/' in service_role:
+        role_name = service_role.split('/')[-1]
+
+    # Created and updated timestamps
+    created_at = status_response.get('createdAt')
+    created_at_str = created_at.strftime('%Y-%m-%d %H:%M:%S') if created_at else 'N/A'
+
+    updated_at = status_response.get('updatedAt')
+    updated_at_str = updated_at.strftime('%Y-%m-%d %H:%M:%S') if updated_at else 'N/A'
+
+    return {
+        'Region': region,
+        'Status': status,
+        'Finding Publishing Frequency': finding_publishing_frequency,
+        'Service Role': role_name,
+        'Created': created_at_str,
+        'Updated': updated_at_str,
+    }
+
+
 def collect_macie_status_from_region(region: str) -> list[dict[str, Any]]:
-    """Collect Macie account status from a single AWS region."""
+    """
+    Collect Macie account status from a single AWS region.
+
+    This is the primary scope collector. A real API error (throttling,
+    access-denied, etc.) is deliberately NOT swallowed here: it must
+    propagate so ``scan_regions_concurrent(..., collect_failures=True)``
+    records the region as failed instead of silently reporting "no Macie
+    status" (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Macie simply not being enabled in a region is a legitimate, non-failure
+    state and is reported as a normal 'Not Enabled' row, not a failed scope.
+    """
     if not utils.is_aws_region(region):
         return []
 
-    status_data = []
     macie_client = utils.get_boto3_client('macie2', region_name=region)
 
     try:
-        # Get Macie status
         status_response = macie_client.get_macie_session()
-
-        status = status_response.get('status', 'N/A')
-        finding_publishing_frequency = status_response.get('findingPublishingFrequency', 'N/A')
-        service_role = status_response.get('serviceRole', 'N/A')
-
-        # Extract role name
-        role_name = 'N/A'
-        if service_role != 'N/A' and '/' in service_role:
-            role_name = service_role.split('/')[-1]
-
-        # Created and updated timestamps
-        created_at = status_response.get('createdAt')
-        created_at_str = created_at.strftime('%Y-%m-%d %H:%M:%S') if created_at else 'N/A'
-
-        updated_at = status_response.get('updatedAt')
-        updated_at_str = updated_at.strftime('%Y-%m-%d %H:%M:%S') if updated_at else 'N/A'
-
-        status_data.append({
-            'Region': region,
-            'Status': status,
-            'Finding Publishing Frequency': finding_publishing_frequency,
-            'Service Role': role_name,
-            'Created': created_at_str,
-            'Updated': updated_at_str,
-        })
-
     except Exception as e:
-        # Macie might not be enabled in this region
-        utils.log_warning(f"Macie not enabled or error in {region}: {str(e)}")
-        status_data.append({
-            'Region': region,
-            'Status': 'Not Enabled',
-            'Finding Publishing Frequency': 'N/A',
-            'Service Role': 'N/A',
-            'Created': 'N/A',
-            'Updated': 'N/A',
-        })
+        error_code = getattr(e, 'response', {}).get('Error', {}).get('Code', '') if hasattr(e, 'response') else ''
+        if error_code == 'ResourceNotFoundException':
+            # This is the documented GetMacieSession signal for "Macie is not
+            # enabled for this account in this region" — a legitimate,
+            # non-failure, disabled state. Report it as a normal row.
+            utils.log_info(f"Macie not enabled in {region}: {str(e)}")
+            return [{
+                'Region': region,
+                'Status': 'Not Enabled',
+                'Finding Publishing Frequency': 'N/A',
+                'Service Role': 'N/A',
+                'Created': 'N/A',
+                'Updated': 'N/A',
+            }]
+        # A real API error (throttling, access-denied, etc.) — let it
+        # propagate so the region is recorded as failed rather than
+        # silently reported as empty/disabled.
+        raise
 
+    status_data = [_build_macie_status_row(status_response, region)]
     utils.log_info(f"Found {len(status_data)} status entries in {region}")
     return status_data
 
 
-def collect_macie_status(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Macie account status using concurrent scanning."""
+def collect_macie_status(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Macie account status across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result. A region where Macie is simply not enabled is NOT a failure —
+    it comes back as a normal 'Not Enabled' row from
+    ``collect_macie_status_from_region``.
+
+    Returns:
+        tuple: ``(status_entries, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING MACIE STATUS ===")
     utils.log_info(f"Scanning {len(regions)} regions for Macie status...")
 
-    region_results = utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=collect_macie_status_from_region,
-        show_progress=True
+        show_progress=True,
+        collect_failures=True,
     )
 
     # Flatten results
@@ -116,7 +149,7 @@ def collect_macie_status(regions: list[str]) -> list[dict[str, Any]]:
         all_status.extend(status_in_region)
 
     utils.log_success(f"Total Macie status entries collected: {len(all_status)}")
-    return all_status
+    return all_status, failed_regions
 
 
 @utils.aws_error_handler("Collecting Macie classification jobs from region", default_return=[])
@@ -556,8 +589,10 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
         return
 
     # Collect data
+    # STEP 1: Collect Macie status (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty"/"not enabled").
     print("\n=== Collecting Macie Data ===")
-    status = collect_macie_status(regions)
+    status, failed_regions = collect_macie_status(regions)
     jobs = collect_classification_jobs(regions)
     findings = collect_findings(regions)
     buckets = collect_s3_buckets(regions)
@@ -604,6 +639,21 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the Macie status scope collection, make it loud:
+    # write a marker and exit non-zero, even though the Summary sheet always
+    # lands. A complete-looking workbook with silently missing regions is
+    # exactly the failure mode this guards against. A region where Macie is
+    # simply not enabled is NOT in failed_regions (see
+    # collect_macie_status_from_region) and does not trigger this path.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'macie', failed_regions)
+        print(
+            "\nERROR: Macie export completed with failures — data is incomplete. "
+            "See the *-macie-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
+
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/scripts/security_hub_export.py
+++ b/scripts/security_hub_export.py
@@ -104,111 +104,136 @@ def get_available_regions():
 
     return available_regions if available_regions else aws_regions  # Fallback to configured regions
 
+def _build_finding_row(finding, region):
+    """Build a single Security Hub finding export row from a get_findings item."""
+    remediation = extract_remediation_info(finding)
+    resources = extract_resource_info(finding)
+    compliance = extract_compliance_info(finding)
+
+    return {
+        'Region': region,
+        'Finding ID': finding.get('Id', 'N/A'),
+        'Product ARN': finding.get('ProductArn', 'N/A'),
+        'Product Name': extract_product_name(finding.get('ProductArn', '')),
+        'Company Name': finding.get('CompanyName', 'N/A'),
+        'Title': finding.get('Title', 'N/A'),
+        'Description': finding.get('Description', 'N/A'),
+        'Severity Label': finding.get('Severity', {}).get('Label', 'N/A'),
+        'Severity Score': finding.get('Severity', {}).get('Normalized', 'N/A'),
+        'Confidence': finding.get('Confidence', 'N/A'),
+        'Criticality': finding.get('Criticality', 'N/A'),
+        'Workflow Status': finding.get('Workflow', {}).get('Status', 'N/A'),
+        'Record State': finding.get('RecordState', 'N/A'),
+        'Compliance Status': compliance['status'],
+        'Compliance Standards': compliance['standards'],
+        'Affected Resources': resources['summary'],
+        'Resource Types': resources['types'],
+        'Remediation Available': 'Yes' if remediation['available'] else 'No',
+        'Remediation URL': remediation['url'],
+        'Remediation Text': remediation['text'],
+        'Source URL': finding.get('SourceUrl', 'N/A'),
+        'First Observed': finding.get('FirstObservedAt', 'N/A'),
+        'Last Observed': finding.get('LastObservedAt', 'N/A'),
+        'Created At': finding.get('CreatedAt', 'N/A'),
+        'Updated At': finding.get('UpdatedAt', 'N/A'),
+        'Note': extract_note_info(finding),
+    }
+
+
 def collect_security_hub_findings(region):
     """
     Collect Security Hub findings from a specific region.
+
+    This is the primary scope collector. A real API error (throttling, access
+    denied, etc.) is allowed to raise so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no findings" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Security Hub not being enabled in a region (``InvalidAccessException`` /
+    ``SubscriptionRequiredException``) is a legitimate, non-failure state and
+    is treated as a normal skip, not a failure.
+
+    Individual malformed findings are skipped (logged) rather than aborting
+    the whole region.
 
     Args:
         region: AWS region to collect findings from
 
     Returns:
-        list: List of finding information dictionaries
+        tuple: (findings_data, cap_reached)
+
+    Raises:
+        ClientError: Any Security Hub API error other than "not enabled".
     """
     findings_data = []
     cap_reached = False
 
-    # Keep try-except for business logic: InvalidAccessException means Security Hub not enabled
+    client = utils.get_boto3_client('securityhub', region_name=region)
+
+    # Check if Security Hub is enabled. "Not enabled" is a legitimate skip,
+    # not a failure — every other error must propagate to the caller.
     try:
-        client = utils.get_boto3_client('securityhub', region_name=region)
+        client.describe_hub()
+        utils.log_success(f"Security Hub is enabled in {region}")
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code in ('InvalidAccessException', 'SubscriptionRequiredException'):
+            utils.log_warning(f"Security Hub is not enabled in {region}. Skipping this region.")
+            return [], False
+        raise
 
-        # Check if Security Hub is enabled
-        try:
-            client.describe_hub()
-            utils.log_success(f"Security Hub is enabled in {region}")
-        except ClientError as e:
-            error_code = e.response['Error']['Code']
-            if error_code == 'InvalidAccessException':
-                utils.log_warning(f"Security Hub is not enabled in {region}. Skipping this region.")
-                return [], False
-            else:
-                utils.log_error(f"Error accessing Security Hub in {region}: {e}")
-                return [], False
+    # Get findings using pagination
+    paginator = client.get_paginator('get_findings')
 
-        # Get findings using pagination
-        paginator = client.get_paginator('get_findings')
+    # Exclude INFORMATIONAL — too noisy for audits; filter at API level
+    filters = {
+        'WorkflowStatus': [
+            {'Value': 'NEW', 'Comparison': 'EQUALS'},
+            {'Value': 'NOTIFIED', 'Comparison': 'EQUALS'},
+        ],
+        'RecordState': [
+            {'Value': 'ACTIVE', 'Comparison': 'EQUALS'},
+        ],
+        'SeverityLabel': [
+            {'Value': 'CRITICAL', 'Comparison': 'EQUALS'},
+            {'Value': 'HIGH', 'Comparison': 'EQUALS'},
+            {'Value': 'MEDIUM', 'Comparison': 'EQUALS'},
+            {'Value': 'LOW', 'Comparison': 'EQUALS'},
+        ],
+    }
 
-        # Exclude INFORMATIONAL — too noisy for audits; filter at API level
-        filters = {
-            'WorkflowStatus': [
-                {'Value': 'NEW', 'Comparison': 'EQUALS'},
-                {'Value': 'NOTIFIED', 'Comparison': 'EQUALS'},
-            ],
-            'RecordState': [
-                {'Value': 'ACTIVE', 'Comparison': 'EQUALS'},
-            ],
-            'SeverityLabel': [
-                {'Value': 'CRITICAL', 'Comparison': 'EQUALS'},
-                {'Value': 'HIGH', 'Comparison': 'EQUALS'},
-                {'Value': 'MEDIUM', 'Comparison': 'EQUALS'},
-                {'Value': 'LOW', 'Comparison': 'EQUALS'},
-            ],
-        }
+    FINDINGS_CAP = 10_000
+    processed = 0
 
-        FINDINGS_CAP = 10_000
-        processed = 0
-
-        for page in paginator.paginate(Filters=filters, MaxResults=100):
-            for finding in page.get('Findings', []):
-                if processed >= FINDINGS_CAP:
-                    cap_reached = True
-                    break
-
-                remediation = extract_remediation_info(finding)
-                resources = extract_resource_info(finding)
-                compliance = extract_compliance_info(finding)
-
-                findings_data.append({
-                    'Region': region,
-                    'Finding ID': finding.get('Id', 'N/A'),
-                    'Product ARN': finding.get('ProductArn', 'N/A'),
-                    'Product Name': extract_product_name(finding.get('ProductArn', '')),
-                    'Company Name': finding.get('CompanyName', 'N/A'),
-                    'Title': finding.get('Title', 'N/A'),
-                    'Description': finding.get('Description', 'N/A'),
-                    'Severity Label': finding.get('Severity', {}).get('Label', 'N/A'),
-                    'Severity Score': finding.get('Severity', {}).get('Normalized', 'N/A'),
-                    'Confidence': finding.get('Confidence', 'N/A'),
-                    'Criticality': finding.get('Criticality', 'N/A'),
-                    'Workflow Status': finding.get('Workflow', {}).get('Status', 'N/A'),
-                    'Record State': finding.get('RecordState', 'N/A'),
-                    'Compliance Status': compliance['status'],
-                    'Compliance Standards': compliance['standards'],
-                    'Affected Resources': resources['summary'],
-                    'Resource Types': resources['types'],
-                    'Remediation Available': 'Yes' if remediation['available'] else 'No',
-                    'Remediation URL': remediation['url'],
-                    'Remediation Text': remediation['text'],
-                    'Source URL': finding.get('SourceUrl', 'N/A'),
-                    'First Observed': finding.get('FirstObservedAt', 'N/A'),
-                    'Last Observed': finding.get('LastObservedAt', 'N/A'),
-                    'Created At': finding.get('CreatedAt', 'N/A'),
-                    'Updated At': finding.get('UpdatedAt', 'N/A'),
-                    'Note': extract_note_info(finding),
-                })
-
-                processed += 1
-                if processed % 500 == 0:
-                    utils.log_info(f"Processed {processed} findings in {region}...")
-
-            if cap_reached:
-                utils.log_warning(
-                    f"Finding cap of {FINDINGS_CAP:,} reached in {region} — export truncated. "
-                    "Re-run with a severity filter or split by region to get remaining findings."
-                )
+    for page in paginator.paginate(Filters=filters, MaxResults=100):
+        for finding in page.get('Findings', []):
+            if processed >= FINDINGS_CAP:
+                cap_reached = True
                 break
 
-    except Exception as e:
-        utils.log_error(f"Error collecting Security Hub findings from {region}", e)
+            try:
+                findings_data.append(_build_finding_row(finding, region))
+            except Exception as e:
+                # One malformed finding is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Security Hub finding in {region}: "
+                    f"{finding.get('Id', '<unknown>')}",
+                    e,
+                )
+                continue
+
+            processed += 1
+            if processed % 500 == 0:
+                utils.log_info(f"Processed {processed} findings in {region}...")
+
+        if cap_reached:
+            utils.log_warning(
+                f"Finding cap of {FINDINGS_CAP:,} reached in {region} — export truncated. "
+                "Re-run with a severity filter or split by region to get remaining findings."
+            )
+            break
 
     return findings_data, cap_reached
 
@@ -502,9 +527,14 @@ def main():
 
         utils.log_info(f"Will scan Security Hub in regions: {', '.join(available_regions)}")
 
-        # Collect findings from all available regions using concurrent scanning
+        # Collect findings from all available regions using concurrent scanning.
+        # Primary scope collection — region failures must propagate as
+        # failed_regions, never collapse into "empty" (see
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
         print("\n=== COLLECTING SECURITY HUB FINDINGS ===")
-        results = utils.scan_regions_concurrent(available_regions, collect_security_hub_findings)
+        results, failed_regions = utils.scan_regions_concurrent(
+            available_regions, collect_security_hub_findings, collect_failures=True
+        )
         all_findings_data = []
         any_truncated = False
         for findings, cap_reached in results:
@@ -513,33 +543,48 @@ def main():
                 any_truncated = True
         utils.log_success(f"Total Security Hub findings collected: {len(all_findings_data)}")
 
-        if not all_findings_data:
+        if not all_findings_data and not failed_regions:
+            # Genuinely empty: every region succeeded (or legitimately had
+            # Security Hub disabled) and returned nothing.
             utils.log_warning("No Security Hub findings collected from any region. Exiting.")
             return
 
-        print("\n====================================================================")
-        print("COLLECTION COMPLETE")
-        print("====================================================================")
+        if all_findings_data:
+            print("\n====================================================================")
+            print("COLLECTION COMPLETE")
+            print("====================================================================")
 
-        # Export to Excel
-        filename = export_to_excel(all_findings_data, account_id, account_name, truncated=any_truncated)
+            # Export to Excel
+            filename = export_to_excel(all_findings_data, account_id, account_name, truncated=any_truncated)
 
-        if filename:
-            utils.log_info("Results exported with AWS compliance markers")
-            utils.log_info(f"Total findings processed: {len(all_findings_data)}")
+            if filename:
+                utils.log_info("Results exported with AWS compliance markers")
+                utils.log_info(f"Total findings processed: {len(all_findings_data)}")
 
-            # Display summary statistics
-            critical_high = len([f for f in all_findings_data if f.get('Severity Label') in ['CRITICAL', 'HIGH']])
-            failed_compliance = len([f for f in all_findings_data if f.get('Compliance Status') == 'FAILED'])
-            with_remediation = len([f for f in all_findings_data if f.get('Remediation Available') == 'Yes'])
+                # Display summary statistics
+                critical_high = len([f for f in all_findings_data if f.get('Severity Label') in ['CRITICAL', 'HIGH']])
+                failed_compliance = len([f for f in all_findings_data if f.get('Compliance Status') == 'FAILED'])
+                with_remediation = len([f for f in all_findings_data if f.get('Remediation Available') == 'Yes'])
 
-            utils.log_info(f"Critical/High severity findings: {critical_high}")
-            utils.log_info(f"Failed compliance findings: {failed_compliance}")
-            utils.log_info(f"Findings with remediation guidance: {with_remediation}")
+                utils.log_info(f"Critical/High severity findings: {critical_high}")
+                utils.log_info(f"Failed compliance findings: {failed_compliance}")
+                utils.log_info(f"Findings with remediation guidance: {with_remediation}")
 
-            print("\nScript execution completed.")
-        else:
-            utils.log_error("Export failed. Please check the logs.")
+                print("\nScript execution completed.")
+            else:
+                utils.log_error("Export failed. Please check the logs.")
+
+        # If ANY region failed the primary findings-collection scope, make it
+        # loud: write a marker and exit non-zero, even if some data was
+        # exported. A partial export that looks complete is exactly the
+        # failure mode this guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'security-hub', failed_regions)
+            print(
+                "\nERROR: Security Hub export completed with failures — data is incomplete. "
+                "See the *-security-hub-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/verifiedaccess_export.py
+++ b/scripts/verifiedaccess_export.py
@@ -41,12 +41,42 @@ def format_tags(tags: list[dict[str, str]]) -> str:
     """Format tags for display."""
     if not tags:
         return "None"
-    tag_strings = [f"{tag['Key']}={tag['Value']}" for tag in tags]
+    tag_strings = [f"{tag.get('Key', '')}={tag.get('Value', '')}" for tag in tags]
     return ", ".join(tag_strings)
 
-@utils.aws_error_handler("Collecting Verified Access Instances", default_return=[])
-def collect_verified_access_instances(region: str) -> list[dict[str, Any]]:
-    """Collect Verified Access Instances in a region."""
+def _build_instance_row(instance: dict, region: str) -> dict[str, Any]:
+    """Build a single Verified Access Instance export row from a describe response."""
+    instance_id = instance.get('VerifiedAccessInstanceId', 'N/A')
+    utils.log_info(f"Processing instance: {instance_id}")
+
+    return {
+        'Region': region,
+        'Instance ID': instance_id,
+        'Description': instance.get('Description', 'N/A'),
+        'Creation Time': instance.get('CreationTime', 'N/A'),
+        'Last Updated Time': instance.get('LastUpdatedTime', 'N/A'),
+        'Trust Provider Count': len(instance.get('VerifiedAccessTrustProviders', [])),
+        'Tags': format_tags(instance.get('Tags', []))
+    }
+
+def _scan_verified_access_instances_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Verified Access Instances from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no instances" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed instances are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     utils.log_info(f"Collecting Verified Access Instances in {region}...")
 
     # Verified Access APIs are part of EC2 — there is no 'verifiedaccess' boto3
@@ -54,34 +84,47 @@ def collect_verified_access_instances(region: str) -> list[dict[str, Any]]:
     va_client = utils.get_boto3_client('ec2', region_name=region)
     instances = []
 
-    try:
-        # List all instances
-        paginator = va_client.get_paginator('describe_verified_access_instances')
+    # List all instances
+    paginator = va_client.get_paginator('describe_verified_access_instances')
 
-        for page in paginator.paginate():
-            for instance in page.get('VerifiedAccessInstances', []):
-                instance_id = instance.get('VerifiedAccessInstanceId', 'N/A')
-                utils.log_info(f"Processing instance: {instance_id}")
+    for page in paginator.paginate():
+        for instance in page.get('VerifiedAccessInstances', []):
+            try:
+                instances.append(_build_instance_row(instance, region))
+            except Exception as e:
+                # One malformed instance is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Verified Access instance in {region}: "
+                    f"{instance.get('VerifiedAccessInstanceId', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                instance_info = {
-                    'Region': region,
-                    'Instance ID': instance_id,
-                    'Description': instance.get('Description', 'N/A'),
-                    'Creation Time': instance.get('CreationTime', 'N/A'),
-                    'Last Updated Time': instance.get('LastUpdatedTime', 'N/A'),
-                    'Trust Provider Count': len(instance.get('VerifiedAccessTrustProviders', [])),
-                    'Tags': format_tags(instance.get('Tags', []))
-                }
-
-                instances.append(instance_info)
-
-        if instances:
-            utils.log_success(f"Found {len(instances)} Verified Access instances in {region}")
-
-    except Exception as e:
-        utils.log_warning(f"No instances found in {region} or service not available: {e}")
+    if instances:
+        utils.log_success(f"Found {len(instances)} Verified Access instances in {region}")
 
     return instances
+
+def collect_verified_access_instances_all_regions(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Verified Access Instances across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(instances, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_verified_access_instances_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_instances = [inst for result in region_results for inst in result]
+    return all_instances, failed_regions
 
 @utils.aws_error_handler("Collecting Trust Providers", default_return=[])
 def collect_trust_providers(region: str) -> list[dict[str, Any]]:
@@ -537,10 +580,11 @@ def main():
         # Collect data across all regions using concurrent scanning
         print("\n=== COLLECTING VERIFIED ACCESS RESOURCES ===")
 
-        # Collect instances, trust providers, groups, and endpoints concurrently
+        # Collect instances (primary scope — region failures must propagate as
+        # failed_regions, never collapse into "empty"). See
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md.
         print("Collecting Verified Access Instances...")
-        instances_results = utils.scan_regions_concurrent(regions, collect_verified_access_instances)
-        all_instances = [inst for result in instances_results for inst in result]
+        all_instances, failed_regions = collect_verified_access_instances_all_regions(regions)
         utils.log_success(f"Total instances collected: {len(all_instances)}")
 
         print("Collecting Trust Providers...")
@@ -562,7 +606,7 @@ def main():
         print("Collecting Access Logs Configurations...")
         all_logs_configs = []
         for region in regions:
-            region_instances = [inst for inst in all_instances if inst['Region'] == region]
+            region_instances = [inst for inst in all_instances if inst.get('Region') == region]
             if region_instances:
                 logs_configs = collect_access_logs_config(region, region_instances)
                 all_logs_configs.extend(logs_configs)
@@ -581,7 +625,11 @@ def main():
             'logs_configs': all_logs_configs
         }
 
-        # Export even if empty (with helpful messaging)
+        # Export even if empty (with helpful messaging) — the Summary sheet is
+        # ALWAYS written by export_to_excel, regardless of failed_regions below.
+        # That forced-export behavior must be preserved: a workbook always
+        # lands, but a failed primary scope still gets flagged loudly (see
+        # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
         filename = export_to_excel(all_data, account_id, account_name)
 
         if filename:
@@ -601,6 +649,20 @@ def main():
             print("\nScript execution completed successfully.")
         else:
             utils.log_error("Export failed. Please check the logs.")
+
+        # If ANY region failed the primary Instances scope collection, make it
+        # loud: write a marker and exit non-zero — even though the Summary
+        # sheet (and any collected enrichment data) was always exported. A
+        # partial export that looks complete is exactly the failure mode this
+        # guards against. Genuinely-empty (every region succeeded, nothing
+        # found) stays exit 0, no marker.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'verifiedaccess', failed_regions)
+            print(
+                "\nERROR: Verified Access export completed with failures — data is incomplete. "
+                "See the *-verifiedaccess-FAILED-*.txt marker in the output directory."
+            )
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.")

--- a/scripts/verifiedpermissions_export.py
+++ b/scripts/verifiedpermissions_export.py
@@ -41,48 +41,92 @@ args = utils.parse_script_args("Export Amazon Verified Permissions policy stores
 utils.setup_logging('verifiedpermissions-export')
 
 
-@utils.aws_error_handler("Collecting policy stores", default_return=[])
-def collect_policy_stores(region: str) -> list[dict[str, Any]]:
-    """Collect all Verified Permissions policy stores in a region."""
-    vp = utils.get_boto3_client('verifiedpermissions', region_name=region)
-    stores = []
+def _build_policy_store_row(store: dict[str, Any], region: str, vp: Any) -> dict[str, Any]:
+    """
+    Build a single policy store export row, enriched with store detail.
 
+    Every field is read with ``.get()`` and a safe default so a divergent
+    resource shape cannot raise a ``KeyError`` here; the detail-fetch enrichment
+    stays graceful (falls back to 'N/A') rather than failing the whole store.
+    """
+    policy_store_id = store.get('policyStoreId', 'N/A')
+
+    validation_mode = 'N/A'
     try:
-        paginator = vp.get_paginator('list_policy_stores')
-        for page in paginator.paginate():
-            for store in page.get('policyStores', []):
-                policy_store_id = store.get('policyStoreId', 'N/A')
-
-                # Get detailed store information
-                try:
-                    detail = vp.get_policy_store(policyStoreId=policy_store_id)
-                    store_detail = detail
-
-                    validation_settings = store_detail.get('validationSettings', {})
-
-                    stores.append({
-                        'Region': region,
-                        'PolicyStoreId': policy_store_id,
-                        'PolicyStoreArn': store.get('arn', 'N/A'),
-                        'Description': store.get('description', 'N/A'),
-                        'CreatedDate': store.get('createdDate'),
-                        'LastUpdatedDate': store.get('lastUpdatedDate'),
-                        'ValidationMode': validation_settings.get('mode', 'N/A'),
-                    })
-                except Exception:
-                    stores.append({
-                        'Region': region,
-                        'PolicyStoreId': policy_store_id,
-                        'PolicyStoreArn': store.get('arn', 'N/A'),
-                        'Description': store.get('description', 'N/A'),
-                        'CreatedDate': store.get('createdDate'),
-                        'LastUpdatedDate': store.get('lastUpdatedDate'),
-                        'ValidationMode': 'N/A',
-                    })
+        detail = vp.get_policy_store(policyStoreId=policy_store_id)
+        validation_settings = detail.get('validationSettings', {})
+        validation_mode = validation_settings.get('mode', 'N/A')
     except Exception:
         pass
 
+    return {
+        'Region': region,
+        'PolicyStoreId': policy_store_id,
+        'PolicyStoreArn': store.get('arn', 'N/A'),
+        'Description': store.get('description', 'N/A'),
+        'CreatedDate': store.get('createdDate'),
+        'LastUpdatedDate': store.get('lastUpdatedDate'),
+        'ValidationMode': validation_mode,
+    }
+
+
+def _scan_policy_stores_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Verified Permissions policy stores from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no policy stores" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed policy stores are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    vp = utils.get_boto3_client('verifiedpermissions', region_name=region)
+    stores = []
+
+    paginator = vp.get_paginator('list_policy_stores')
+    for page in paginator.paginate():
+        for store in page.get('policyStores', []):
+            try:
+                stores.append(_build_policy_store_row(store, region, vp))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed policy store in {region}: "
+                    f"{store.get('policyStoreId', '<unknown>')}",
+                    e,
+                )
+                continue
+
     return stores
+
+
+def collect_policy_stores(regions: list[str]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    """
+    Collect Verified Permissions policy stores across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(stores, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_policy_stores_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_stores = [store for result in region_results for store in result]
+    return all_stores, failed_regions
 
 
 @utils.aws_error_handler("Collecting policies", default_return=[])
@@ -218,44 +262,44 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Verified Permissions data and write the Excel export."""
     utils.log_info(f"Exporting Verified Permissions for account: {account_name} ({utils.mask_account_id(account_id)})")
 
-    # Collect all resources
-    all_stores = []
+    # STEP 1: Collect policy stores (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    all_stores, failed_regions = collect_policy_stores(regions)
+
     all_policies = []
     all_templates = []
     all_identity_sources = []
 
-    for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
+    if all_stores:
+        utils.log_info(f"Found {len(all_stores)} policy store(s) across {len(regions)} region(s)")
 
-        # Collect policy stores
-        stores = collect_policy_stores(region)
-        if stores:
-            utils.log_info(f"  Found {len(stores)} policy store(s)")
-            all_stores.extend(stores)
+        # Collect resources for each policy store (enrichment — degrades
+        # gracefully; a failure here does not fail the whole export).
+        for store in all_stores:
+            region = store.get('Region')
+            policy_store_id = store.get('PolicyStoreId', 'N/A')
+            if not region or policy_store_id == 'N/A':
+                continue
 
-            # Collect resources for each policy store
-            for store in stores:
-                policy_store_id = store['PolicyStoreId']
+            # Collect policies
+            policies = collect_policies(region, policy_store_id)
+            if policies:
+                utils.log_info(f"    Found {len(policies)} policy(ies) in store {policy_store_id}")
+                all_policies.extend(policies)
 
-                # Collect policies
-                policies = collect_policies(region, policy_store_id)
-                if policies:
-                    utils.log_info(f"    Found {len(policies)} policy(ies) in store {policy_store_id}")
-                    all_policies.extend(policies)
+            # Collect policy templates
+            templates = collect_policy_templates(region, policy_store_id)
+            if templates:
+                utils.log_info(f"    Found {len(templates)} policy template(s) in store {policy_store_id}")
+                all_templates.extend(templates)
 
-                # Collect policy templates
-                templates = collect_policy_templates(region, policy_store_id)
-                if templates:
-                    utils.log_info(f"    Found {len(templates)} policy template(s) in store {policy_store_id}")
-                    all_templates.extend(templates)
-
-                # Collect identity sources
-                identity_sources = collect_identity_sources(region, policy_store_id)
-                if identity_sources:
-                    utils.log_info(f"    Found {len(identity_sources)} identity source(s) in store {policy_store_id}")
-                    all_identity_sources.extend(identity_sources)
-
-    if not all_stores:
+            # Collect identity sources
+            identity_sources = collect_identity_sources(region, policy_store_id)
+            if identity_sources:
+                utils.log_info(f"    Found {len(identity_sources)} identity source(s) in store {policy_store_id}")
+                all_identity_sources.extend(identity_sources)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No Verified Permissions policy stores found in any selected region.")
         utils.log_info("Creating empty export file...")
 
@@ -317,6 +361,18 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.log_info(f"  Identity Sources: {len(all_identity_sources)}")
 
     utils.log_success("Verified Permissions export completed successfully!")
+
+    # If ANY region failed the policy-stores scope collection, make it loud:
+    # write a marker and exit non-zero, even though the Summary sheet (and any
+    # partial data) was still exported. A workbook that looks complete is
+    # exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'verifiedpermissions', failed_regions)
+        print(
+            "\nERROR: Verified Permissions export completed with failures — data is incomplete. "
+            "See the *-verifiedpermissions-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/tests/test_exporters/test_acm_export.py
+++ b/tests/test_exporters/test_acm_export.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for acm_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import acm_export  # noqa: E402
+from acm_export import scan_acm_certificates_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_certificate(client, domain_name):
+    """Request a certificate for ``domain_name`` and return its ARN."""
+    response = client.request_certificate(
+        DomainName=domain_name,
+        ValidationMethod="DNS",
+    )
+    return response["CertificateArn"]
+
+
+class TestScanAcmCertificatesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_certificates(self):
+        client = boto3.client("acm", region_name=REGION)
+        _create_certificate(client, "web.example.com")
+
+        rows = scan_acm_certificates_in_region(REGION)
+
+        domains = {row["Domain Name"] for row in rows}
+        assert "web.example.com" in domains
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("acm", region_name=REGION)  # region exists, no certificates
+
+        rows = scan_acm_certificates_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One certificate that fails to process must not discard the whole region."""
+        client = boto3.client("acm", region_name=REGION)
+        good_arn = _create_certificate(client, "good.example.com")
+        bad_arn = _create_certificate(client, "bad.example.com")
+
+        original = acm_export._build_certificate_row
+
+        def raise_for_bad(cert_summary, region, acm_client):
+            if cert_summary.get("CertificateArn") == bad_arn:
+                raise KeyError("SomeUnexpectedField")
+            return original(cert_summary, region, acm_client)
+
+        monkeypatch.setattr(acm_export, "_build_certificate_row", raise_for_bad)
+
+        rows = scan_acm_certificates_in_region(REGION)
+
+        arns = {row["Certificate ARN"] for row in rows}
+        assert good_arn in arns, "healthy certificate was lost when a sibling failed"
+        assert bad_arn not in arns, "malformed certificate should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListCertificates",
+            )
+
+        monkeypatch.setattr(acm_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_acm_certificates_in_region(REGION)
+
+    @mock_aws
+    def test_collect_acm_certificates_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListCertificates",
+            )
+
+        monkeypatch.setattr(acm_export, "scan_acm_certificates_in_region", boom)
+
+        certificates, failed_regions = acm_export.collect_acm_certificates([REGION])
+
+        assert certificates == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_acm_privateca_export.py
+++ b/tests/test_exporters/test_acm_privateca_export.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for acm_privateca_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto coverage: moto's ``acm-pca`` backend supports
+``create_certificate_authority``, ``list_certificate_authorities``,
+``describe_certificate_authority``, and ``list_tags``, which is enough to
+exercise the primary CA-listing scope directly. It does not model the
+region-level ``Throttling``/``AccessDenied`` failures we need to test, so
+those cases monkeypatch ``utils.get_boto3_client`` (region-failure tests) or
+the module's ``_scan_private_cas_region``/``collect_private_cas`` functions
+(scope-wrapper tests) to raise instead of hitting a real botocore call.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import acm_privateca_export  # noqa: E402
+from acm_privateca_export import _build_ca_row, _scan_private_cas_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_ca(client, common_name="example.com"):
+    """Create a root Private CA and return its ARN."""
+    resp = client.create_certificate_authority(
+        CertificateAuthorityConfiguration={
+            "KeyAlgorithm": "RSA_2048",
+            "SigningAlgorithm": "SHA256WITHRSA",
+            "Subject": {"CommonName": common_name},
+        },
+        CertificateAuthorityType="ROOT",
+    )
+    return resp["CertificateAuthorityArn"]
+
+
+class TestScanPrivateCasRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_cas(self):
+        client = boto3.client("acm-pca", region_name=REGION)
+        _create_ca(client, "web.example.com")
+
+        rows = _scan_private_cas_region(REGION)
+
+        common_names = {row["Common Name"] for row in rows}
+        assert "web.example.com" in common_names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("acm-pca", region_name=REGION)  # region exists, no CAs
+
+        rows = _scan_private_cas_region(REGION)
+
+        assert rows == []
+
+    def test_build_ca_row_from_list_response_shape(self):
+        """
+        ListCertificateAuthorities already returns the full CertificateAuthority
+        shape (same fields as DescribeCertificateAuthority) — _build_ca_row must
+        work directly off that item with no secondary API call.
+        """
+        item = {
+            "Arn": "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/abc",
+            "OwnerAccount": "123456789012",
+            "Type": "ROOT",
+            "Status": "ACTIVE",
+            "CertificateAuthorityConfiguration": {
+                "KeyAlgorithm": "RSA_2048",
+                "SigningAlgorithm": "SHA256WITHRSA",
+                "Subject": {"CommonName": "example.com"},
+            },
+            "RevocationConfiguration": {"CrlConfiguration": {"Enabled": False}},
+            "KeyStorageSecurityStandard": "FIPS_140_2_LEVEL_3_OR_HIGHER",
+            "UsageMode": "SHORT_LIVED_CERTIFICATE",
+        }
+
+        row = _build_ca_row(item, REGION)
+
+        assert row["CA ARN"] == item["Arn"]
+        assert row["Common Name"] == "example.com"
+        assert row["Status"] == "ACTIVE"
+        assert row["Tags"] == "N/A"
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed into an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One CA that fails to process must not discard the whole region."""
+        client = boto3.client("acm-pca", region_name=REGION)
+        _create_ca(client, "good-ca.example.com")
+        _create_ca(client, "bad-ca.example.com")
+
+        original = acm_privateca_export._build_ca_row
+
+        def raise_for_bad(item, region):
+            config = item.get("CertificateAuthorityConfiguration", {}) or {}
+            subject = config.get("Subject", {}) or {}
+            if subject.get("CommonName") == "bad-ca.example.com":
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(acm_privateca_export, "_build_ca_row", raise_for_bad)
+
+        rows = _scan_private_cas_region(REGION)
+
+        common_names = {row["Common Name"] for row in rows}
+        assert "good-ca.example.com" in common_names, "healthy CA was lost when a sibling failed"
+        assert "bad-ca.example.com" not in common_names, "malformed CA should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+
+        moto does not simulate Throttling/AccessDenied for acm-pca, so the
+        boto3 client factory itself is monkeypatched to raise — this still
+        exercises the real code path in _scan_private_cas_region, which no
+        longer wraps the listing call in a broad try/except.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListCertificateAuthorities",
+            )
+
+        monkeypatch.setattr(acm_privateca_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_private_cas_region(REGION)
+
+    def test_collect_private_cas_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets main() write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListCertificateAuthorities",
+            )
+
+        monkeypatch.setattr(acm_privateca_export, "_scan_private_cas_region", boom)
+
+        cas, failed_regions = acm_privateca_export.collect_private_cas([REGION])
+
+        assert cas == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_iam_identity_providers_export.py
+++ b/tests/test_exporters/test_iam_identity_providers_export.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Tests for iam_identity_providers_export.py.
+
+Covers:
+- collect_saml_providers() / collect_oidc_providers() per-item guarding and
+  account-scope failure propagation
+- main()'s failed-scope tracking, finalize, and exit-code behavior
+
+IAM identity providers are a global/account-scope resource (not
+multi-region), so both collect_saml_providers() and collect_oidc_providers()
+are PRIMARY account-scope collectors -- mirrors the scripts/shield_export.py
+account-scope pattern (see scripts/lambda_export.py for the finalize shape).
+moto supports create_saml_provider/list_saml_providers and
+create_open_id_connect_provider/list_open_id_connect_providers, so the
+per-item ("malformed provider") tests build real providers via @mock_aws and
+monkeypatch the extracted _build_*_row() helper to simulate the one bad item
+(moto cannot itself produce a malformed API response). The API-error tests
+monkeypatch the boto3 client directly, since moto has no way to force a
+ListSAMLProviders/ListOpenIDConnectProviders failure.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import boto3
+import botocore.exceptions
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import iam_identity_providers_export  # noqa: E402
+from iam_identity_providers_export import (  # noqa: E402
+    collect_oidc_providers,
+    collect_saml_providers,
+)
+
+REGION = "us-east-1"
+SAML_METADATA = '<xml>entityID="https://example.com/saml"</xml>' + ("x" * 1000)
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(iam_identity_providers_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to IAM identity providers: collect_saml_providers() and
+    collect_oidc_providers() -- the two PRIMARY, global/account-scope
+    collectors -- used to swallow a real API error into an empty list,
+    indistinguishable from an account with no providers configured. main()
+    also used to have no way to signal that failure downstream. These tests
+    cover: (a) a malformed provider is skipped, not fatal, for both scopes;
+    (b) both collectors raise rather than swallowing a real API error; (c) a
+    primary-scope failure surfaces through main() as a non-zero exit plus a
+    utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------------
+
+    @mock_aws
+    def test_malformed_saml_provider_is_skipped_not_fatal(self, monkeypatch):
+        """One SAML provider that fails to process must not discard the others."""
+        iam = boto3.client("iam", region_name=REGION)
+        good = iam.create_saml_provider(Name="good-saml", SAMLMetadataDocument=SAML_METADATA)
+        bad = iam.create_saml_provider(Name="bad-saml", SAMLMetadataDocument=SAML_METADATA)
+
+        original = iam_identity_providers_export._build_saml_row
+
+        def raise_for_bad(client_arg, provider):
+            if provider.get("Arn") == bad["SAMLProviderArn"]:
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, provider)
+
+        monkeypatch.setattr(iam_identity_providers_export, "_build_saml_row", raise_for_bad)
+
+        result = collect_saml_providers()
+
+        arns = {row["ARN"] for row in result}
+        assert good["SAMLProviderArn"] in arns, "healthy SAML provider was lost when a sibling failed"
+        assert bad["SAMLProviderArn"] not in arns, "malformed SAML provider should have been skipped"
+
+    @mock_aws
+    def test_malformed_oidc_provider_is_skipped_not_fatal(self, monkeypatch):
+        """One OIDC provider that fails to process must not discard the others."""
+        iam = boto3.client("iam", region_name=REGION)
+        good = iam.create_open_id_connect_provider(
+            Url="https://good.example.com/oidc",
+            ClientIDList=["sts.amazonaws.com"],
+            ThumbprintList=["a" * 40],
+        )
+        bad = iam.create_open_id_connect_provider(
+            Url="https://bad.example.com/oidc",
+            ClientIDList=["sts.amazonaws.com"],
+            ThumbprintList=["b" * 40],
+        )
+
+        original = iam_identity_providers_export._build_oidc_row
+
+        def raise_for_bad(client_arg, provider):
+            if provider.get("Arn") == bad["OpenIDConnectProviderArn"]:
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, provider)
+
+        monkeypatch.setattr(iam_identity_providers_export, "_build_oidc_row", raise_for_bad)
+
+        result = collect_oidc_providers()
+
+        arns = {row["ARN"] for row in result}
+        assert good["OpenIDConnectProviderArn"] in arns, "healthy OIDC provider was lost when a sibling failed"
+        assert bad["OpenIDConnectProviderArn"] not in arns, "malformed OIDC provider should have been skipped"
+
+    # -- (b) Account-scope failure propagation -------------------------------
+
+    def test_collect_saml_providers_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real ListSAMLProviders error must propagate, not collapse to an
+        empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ServiceFailureException", "Message": "Something broke"}},
+                "ListSAMLProviders",
+            )
+
+        client = MagicMock()
+        client.list_saml_providers.side_effect = boom
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "get_boto3_client", lambda *a, **kw: client
+        )
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_saml_providers()
+
+    def test_collect_oidc_providers_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real ListOpenIDConnectProviders error must propagate, not
+        collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ServiceFailureException", "Message": "Something broke"}},
+                "ListOpenIDConnectProviders",
+            )
+
+        client = MagicMock()
+        client.list_open_id_connect_providers.side_effect = boom
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "get_boto3_client", lambda *a, **kw: client
+        )
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_oidc_providers()
+
+    # -- (c) main(): failure surfaced, non-zero exit -------------------------
+
+    def test_main_saml_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A SAML providers API failure in main() must exit non-zero and
+        call utils.report_collection_failures -- never silently collapse
+        into an empty export."""
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "ensure_dependencies", lambda *a, **kw: True
+        )
+        # setup_logging()/log_script_start() are left un-patched (run for
+        # real, writing to the redirected tmp_path output dir) because
+        # utils.save_multiple_dataframes_to_excel() logs via the raw module
+        # -level ``logger`` global, not get_logger() -- a no-op'd
+        # setup_logging() leaves that global None and crashes the export.
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ServiceFailureException", "Message": "Something broke"}},
+                "ListSAMLProviders",
+            )
+
+        monkeypatch.setattr(iam_identity_providers_export, "collect_saml_providers", boom)
+        monkeypatch.setattr(iam_identity_providers_export, "collect_oidc_providers", lambda: [])
+        monkeypatch.setattr(
+            iam_identity_providers_export, "collect_roles_using_providers", lambda *a, **kw: []
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "report_collection_failures", fake_report
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            iam_identity_providers_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "iam-identity-providers"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "saml_providers"
+
+    def test_main_oidc_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An OIDC providers API failure in main() must exit non-zero and
+        call utils.report_collection_failures -- never silently collapse
+        into an empty export."""
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "ensure_dependencies", lambda *a, **kw: True
+        )
+        # setup_logging()/log_script_start() are left un-patched (run for
+        # real, writing to the redirected tmp_path output dir) because
+        # utils.save_multiple_dataframes_to_excel() logs via the raw module
+        # -level ``logger`` global, not get_logger() -- a no-op'd
+        # setup_logging() leaves that global None and crashes the export.
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+
+        monkeypatch.setattr(iam_identity_providers_export, "collect_saml_providers", lambda: [])
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ServiceFailureException", "Message": "Something broke"}},
+                "ListOpenIDConnectProviders",
+            )
+
+        monkeypatch.setattr(iam_identity_providers_export, "collect_oidc_providers", boom)
+        monkeypatch.setattr(
+            iam_identity_providers_export, "collect_roles_using_providers", lambda *a, **kw: []
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(
+            iam_identity_providers_export.utils, "report_collection_failures", fake_report
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            iam_identity_providers_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "iam-identity-providers"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "oidc_providers"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_iam_rolesanywhere_export.py
+++ b/tests/test_exporters/test_iam_rolesanywhere_export.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Tests for iam_rolesanywhere_export.py.
+
+Covers:
+- collect_trust_anchors() / collect_profiles() per-item guarding and
+  account-scope failure propagation
+- main()'s failed-scope tracking, finalize, and exit-code behavior
+
+IAM Roles Anywhere is a global/account-scope service (not multi-region), so
+collect_trust_anchors() and collect_profiles() are the two PRIMARY
+account-scope collectors -- mirrors the scripts/iam_export.py account-scope
+pattern (see scripts/shield_export.py for the same fix applied to a single
+account-scope collector, and scripts/lambda_export.py for the finalize
+shape). moto's Roles Anywhere support is limited (``list_trust_anchors`` /
+``list_profiles`` raise "Not yet implemented" -- see moto 5.1.21), so these
+tests drive the module through monkeypatched boto3 clients / module
+functions rather than real moto-backed Roles Anywhere state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import iam_rolesanywhere_export  # noqa: E402
+from iam_rolesanywhere_export import collect_profiles, collect_trust_anchors  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(iam_rolesanywhere_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_rolesanywhere_client(trust_anchors=None, profiles=None):
+    """Build a MagicMock standing in for a boto3 Roles Anywhere client."""
+    client = MagicMock()
+
+    def get_paginator(operation):
+        paginator = MagicMock()
+        if operation == "list_trust_anchors":
+            paginator.paginate.return_value = [{"trustAnchors": trust_anchors or []}]
+        elif operation == "list_profiles":
+            paginator.paginate.return_value = [{"profiles": profiles or []}]
+        else:
+            paginator.paginate.return_value = [{}]
+        return paginator
+
+    client.get_paginator.side_effect = get_paginator
+    client.get_trust_anchor.return_value = {"trustAnchor": {}}
+    client.get_profile.return_value = {"profile": {}}
+    return client
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to IAM Roles Anywhere: collect_trust_anchors() and
+    collect_profiles() -- the two PRIMARY, global/account-scope collectors --
+    used to swallow a real API error into an empty list, indistinguishable
+    from an account with no trust anchors/profiles configured. main() also
+    had no way to signal that failure downstream. These tests cover: (a) a
+    malformed trust anchor / profile is skipped, not fatal; (b)
+    collect_trust_anchors() and collect_profiles() raise rather than
+    swallowing a real API error; (c) that a failure in either primary scope
+    surfaces through main() as a non-zero exit plus a
+    utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard: trust anchors ----------------------------------
+
+    def test_malformed_trust_anchor_is_skipped_not_fatal(self, monkeypatch):
+        """One trust anchor that fails to process must not discard the others."""
+        good = {"trustAnchorId": "good-id", "name": "good-anchor"}
+        bad = {"trustAnchorId": "bad-id", "name": "bad-anchor"}
+
+        client = _fake_rolesanywhere_client(trust_anchors=[good, bad])
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = iam_rolesanywhere_export._build_trust_anchor_row
+
+        def raise_for_bad(client_arg, anchor):
+            if anchor.get("trustAnchorId") == "bad-id":
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, anchor)
+
+        monkeypatch.setattr(iam_rolesanywhere_export, "_build_trust_anchor_row", raise_for_bad)
+
+        result = collect_trust_anchors()
+
+        ids = {row["Trust Anchor ID"] for row in result}
+        assert "good-id" in ids, "healthy trust anchor was lost when a sibling failed"
+        assert "bad-id" not in ids, "malformed trust anchor should have been skipped"
+
+    # -- (a) Per-item guard: profiles ----------------------------------------
+
+    def test_malformed_profile_is_skipped_not_fatal(self, monkeypatch):
+        """One profile that fails to process must not discard the others."""
+        good = {"profileId": "good-id", "name": "good-profile"}
+        bad = {"profileId": "bad-id", "name": "bad-profile"}
+
+        client = _fake_rolesanywhere_client(profiles=[good, bad])
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = iam_rolesanywhere_export._build_profile_row
+
+        def raise_for_bad(client_arg, profile):
+            if profile.get("profileId") == "bad-id":
+                raise KeyError("SomeUnexpectedField")
+            return original(client_arg, profile)
+
+        monkeypatch.setattr(iam_rolesanywhere_export, "_build_profile_row", raise_for_bad)
+
+        result = collect_profiles()
+
+        ids = {row["Profile ID"] for row in result}
+        assert "good-id" in ids, "healthy profile was lost when a sibling failed"
+        assert "bad-id" not in ids, "malformed profile should have been skipped"
+
+    # -- (b) Account-scope failure propagation: trust anchors ---------------
+
+    def test_collect_trust_anchors_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Roles Anywhere API error during trust anchor collection must
+        propagate, not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "ListTrustAnchors",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_trust_anchors()
+
+    # -- (b) Account-scope failure propagation: profiles ---------------------
+
+    def test_collect_profiles_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Roles Anywhere API error during profile collection must
+        propagate, not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "ListProfiles",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_profiles()
+
+    # -- (c) main(): failure surfaced, non-zero exit -------------------------
+
+    def _patch_common_main(self, monkeypatch):
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            iam_rolesanywhere_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(
+            iam_rolesanywhere_export.utils,
+            "validate_aws_credentials",
+            lambda *a, **kw: (True, "123456789012", None),
+        )
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_crls", lambda: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(iam_rolesanywhere_export.utils, "report_collection_failures", fake_report)
+        return calls
+
+    def test_main_trust_anchors_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A trust-anchor API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+        calls = self._patch_common_main(monkeypatch)
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "ListTrustAnchors",
+            )
+
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_trust_anchors", boom)
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_profiles", lambda: [])
+
+        with pytest.raises(SystemExit) as exc_info:
+            iam_rolesanywhere_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "iam-rolesanywhere"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "trust_anchors"
+
+    def test_main_profiles_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A profiles API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty export."""
+        calls = self._patch_common_main(monkeypatch)
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "ListProfiles",
+            )
+
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_trust_anchors", lambda: [])
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_profiles", boom)
+
+        with pytest.raises(SystemExit) as exc_info:
+            iam_rolesanywhere_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "iam-rolesanywhere"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "profiles"
+
+    def test_main_genuinely_empty_exits_zero_no_marker(self, monkeypatch):
+        """Both primary scopes succeeding with no data is a legitimate,
+        genuinely-empty state -- exit 0 (implicit), and
+        utils.report_collection_failures is never called (no
+        *-FAILED-*.txt marker is written)."""
+        calls = self._patch_common_main(monkeypatch)
+
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_trust_anchors", lambda: [])
+        monkeypatch.setattr(iam_rolesanywhere_export, "collect_profiles", lambda: [])
+
+        # main() does not sys.exit() on the success path; it simply returns.
+        iam_rolesanywhere_export.main()
+
+        assert "failed_scopes" not in calls
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_macie_export.py
+++ b/tests/test_exporters/test_macie_export.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for macie_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's ``macie2`` mock has limited fidelity — ``get_macie_session``
+always succeeds as if Macie is already enabled and does not model the
+account-not-enabled ``ResourceNotFoundException`` or throttling/access-denied
+errors. Those behaviors are exercised here via monkeypatching the boto3
+client (or ``utils.get_boto3_client``) rather than via moto's own state.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import macie_export  # noqa: E402
+from macie_export import collect_macie_status_from_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _resource_not_found_error(op_name="GetMacieSession"):
+    return botocore.exceptions.ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "The request failed because the specified account isn't associated with Amazon Macie.",
+            }
+        },
+        op_name,
+    )
+
+
+class TestCollectMacieStatusFromRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_status(self):
+        rows = collect_macie_status_from_region(REGION)
+
+        assert len(rows) == 1
+        assert rows[0]["Region"] == REGION
+        assert rows[0]["Status"] == "ENABLED"
+
+    def test_invalid_region_returns_empty(self):
+        rows = collect_macie_status_from_region("not-a-real-region")
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty/default
+    result, indistinguishable from a genuinely empty or disabled region.
+    """
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A real region-level API failure (e.g. throttling) must propagate (so
+        the caller can record a FAILED region) rather than being swallowed
+        into an empty/"Not Enabled" result.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+                "GetMacieSession",
+            )
+
+        monkeypatch.setattr(macie_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_macie_status_from_region(REGION)
+
+    @mock_aws
+    def test_access_denied_raises_not_empty(self, monkeypatch):
+        """An AccessDenied error must also propagate as a real failure."""
+        client = boto3.client("macie2", region_name=REGION)
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "nope"}},
+                "GetMacieSession",
+            )
+
+        monkeypatch.setattr(client, "get_macie_session", boom)
+        monkeypatch.setattr(macie_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_macie_status_from_region(REGION)
+
+    @mock_aws
+    def test_collect_macie_status_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker +
+        exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "nope"}},
+                "GetMacieSession",
+            )
+
+        monkeypatch.setattr(macie_export, "collect_macie_status_from_region", boom)
+
+        status, failed_regions = macie_export.collect_macie_status([REGION])
+
+        assert status == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_macie_not_enabled_is_not_a_failed_region(self, monkeypatch):
+        """
+        A region where Macie is simply not enabled (ResourceNotFoundException
+        from GetMacieSession) is a legitimate, non-failure, disabled state.
+        It must come back as a normal 'Not Enabled' row and must NOT be
+        counted as a failed region.
+        """
+        client = boto3.client("macie2", region_name=REGION)
+        monkeypatch.setattr(
+            client, "get_macie_session", lambda: (_ for _ in ()).throw(_resource_not_found_error())
+        )
+        monkeypatch.setattr(macie_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = collect_macie_status_from_region(REGION)
+
+        assert len(rows) == 1
+        assert rows[0]["Region"] == REGION
+        assert rows[0]["Status"] == "Not Enabled"
+
+        # And at the collect_macie_status() wrapper level, this must not be
+        # reported as a failed region.
+        monkeypatch.setattr(
+            macie_export, "collect_macie_status_from_region", lambda region: rows
+        )
+        status, failed_regions = macie_export.collect_macie_status([REGION])
+
+        assert status == rows
+        assert failed_regions == []

--- a/tests/test_exporters/test_security_hub_export.py
+++ b/tests/test_exporters/test_security_hub_export.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for security_hub_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's securityhub support covers ``enable_security_hub``,
+``describe_hub``, ``batch_import_findings``, and ``get_findings`` (including
+the Filters used by this exporter), so the happy-path / malformed-item /
+region-failure tests below run against real moto behavior. Where moto does
+not model a specific AWS error condition (e.g. a mid-scan throttling error),
+the test monkeypatches the boto3 client call directly instead of working
+around moto with a hand-rolled fake.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import security_hub_export  # noqa: E402
+from security_hub_export import collect_security_hub_findings  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _import_finding(client, finding_id, severity="HIGH"):
+    """Enable Security Hub (if needed) and import a single active/new finding."""
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    finding = {
+        "SchemaVersion": "2018-10-08",
+        "Id": finding_id,
+        "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+        "GeneratorId": "gen-1",
+        "AwsAccountId": "123456789012",
+        "Types": ["Software and Configuration Checks"],
+        "CreatedAt": now,
+        "UpdatedAt": now,
+        "Severity": {"Label": severity, "Normalized": 70},
+        "Title": f"Test finding {finding_id}",
+        "Description": "desc",
+        "Resources": [{"Type": "AwsEc2Instance", "Id": "i-1234"}],
+        "Workflow": {"Status": "NEW"},
+        "RecordState": "ACTIVE",
+    }
+    client.batch_import_findings(Findings=[finding])
+
+
+class TestCollectSecurityHubFindings:
+    """Happy-path collection and the not-enabled skip."""
+
+    @mock_aws
+    def test_collects_findings(self):
+        client = boto3.client("securityhub", region_name=REGION)
+        client.enable_security_hub()
+        _import_finding(client, "finding-1")
+
+        findings, cap_reached = collect_security_hub_findings(REGION)
+
+        ids = {f["Finding ID"] for f in findings}
+        assert "finding-1" in ids
+        assert cap_reached is False
+
+    @mock_aws
+    def test_hub_not_enabled_returns_empty_not_error(self):
+        # No enable_security_hub() call — describe_hub() raises
+        # InvalidAccessException, which is a legitimate disabled state.
+        boto3.client("securityhub", region_name=REGION)
+
+        findings, cap_reached = collect_security_hub_findings(REGION)
+
+        assert findings == []
+        assert cap_reached is False
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty/disabled region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One finding that fails to process must not discard the whole region."""
+        client = boto3.client("securityhub", region_name=REGION)
+        client.enable_security_hub()
+        _import_finding(client, "good-finding")
+        _import_finding(client, "bad-finding")
+
+        original = security_hub_export._build_finding_row
+
+        def raise_for_bad(finding, region):
+            if finding.get("Id") == "bad-finding":
+                raise KeyError("SomeUnexpectedField")
+            return original(finding, region)
+
+        monkeypatch.setattr(security_hub_export, "_build_finding_row", raise_for_bad)
+
+        findings, cap_reached = collect_security_hub_findings(REGION)
+
+        ids = {f["Finding ID"] for f in findings}
+        assert "good-finding" in ids, "healthy finding was lost when a sibling failed"
+        assert "bad-finding" not in ids, "malformed finding should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A real Security Hub API failure (not "hub not enabled") must propagate
+        (so the caller can record a FAILED region) rather than being swallowed
+        into an empty list.
+        """
+        client = boto3.client("securityhub", region_name=REGION)
+        client.enable_security_hub()
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "GetFindings",
+            )
+
+        monkeypatch.setattr(client, "get_paginator", boom)
+        monkeypatch.setattr(security_hub_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_security_hub_findings(REGION)
+
+    @mock_aws
+    def test_hub_not_enabled_is_not_a_failed_region(self, monkeypatch):
+        """
+        Security Hub not being enabled in a region is a legitimate disabled
+        state, not a collection failure — it must NOT be reported as a failed
+        region via scan_regions_concurrent(collect_failures=True).
+        """
+        boto3.client("securityhub", region_name=REGION)  # not enabled
+
+        results, failed_regions = security_hub_export.utils.scan_regions_concurrent(
+            [REGION],
+            collect_security_hub_findings,
+            collect_failures=True,
+        )
+
+        assert failed_regions == []
+        assert results == [([], False)]
+
+    @mock_aws
+    def test_collection_surfaces_failed_regions_via_scanner(self, monkeypatch):
+        """
+        The scope collector must surface failures through
+        scan_regions_concurrent(collect_failures=True), not drop them — this
+        is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "GetFindings",
+            )
+
+        monkeypatch.setattr(security_hub_export, "collect_security_hub_findings", boom)
+
+        results, failed_regions = security_hub_export.utils.scan_regions_concurrent(
+            [REGION],
+            security_hub_export.collect_security_hub_findings,
+            collect_failures=True,
+        )
+
+        assert results == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_verifiedaccess_export.py
+++ b/tests/test_exporters/test_verifiedaccess_export.py
@@ -8,12 +8,23 @@ under 'ec2'. Because every collector is wrapped in @aws_error_handler, the
 invalid client surfaced as a silently empty export rather than a crash — so the
 import-only smoke test never caught it. These tests assert every collector
 creates its client with a *real* boto3 service.
+
+Also covers the Tier-3 silent-collection-failure fix (07.16.2026 audit): the
+primary scope (Verified Access Instances) must raise on a region-level API
+error rather than swallow it, so ``collect_verified_access_instances_all_regions``
+can surface a failed region instead of reporting "no instances". See
+TestSilentCollectionFailureRegression below.
+
+Note: moto (as of this test's authoring) does not implement any of the
+describe_verified_access_* EC2 actions, so these tests monkeypatch
+``utils.get_boto3_client`` with a MagicMock instead of using ``@mock_aws``.
 """
 
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import botocore.exceptions
 import botocore.session
 import pytest
 
@@ -25,7 +36,7 @@ REGION = "us-east-1"
 # Every collector and how to invoke it (collect_access_logs_config needs the
 # already-collected instances list).
 COLLECTORS = [
-    ("collect_verified_access_instances", lambda f: f(REGION)),
+    ("_scan_verified_access_instances_region", lambda f: f(REGION)),
     ("collect_trust_providers", lambda f: f(REGION)),
     ("collect_verified_access_groups", lambda f: f(REGION)),
     ("collect_verified_access_endpoints", lambda f: f(REGION)),
@@ -90,13 +101,91 @@ def test_collect_instances_parses_data(monkeypatch):
 
     monkeypatch.setattr(va.utils, "get_boto3_client", spy)
 
-    rows = va.collect_verified_access_instances(REGION)
+    rows = va._scan_verified_access_instances_region(REGION)
 
     assert captured["service"] == "ec2"
     assert len(rows) == 1
     assert rows[0]["Instance ID"] == "vai-0123456789abcdef0"
     assert rows[0]["Trust Provider Count"] == 1
     assert rows[0]["Tags"] == "env=prod"
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+
+    Tier-3 nuance: verifiedaccess_export.py always writes a forced Summary
+    sheet (a workbook always lands), so these tests only cover the primary
+    scope's failure-propagation contract — not the always-on export itself.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One instance that fails to process must not discard the whole region."""
+        page = {
+            "VerifiedAccessInstances": [
+                {"VerifiedAccessInstanceId": "vai-good", "Tags": []},
+                {"VerifiedAccessInstanceId": "vai-bad", "Tags": []},
+            ]
+        }
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = [page]
+        monkeypatch.setattr(
+            va.utils, "get_boto3_client", lambda service, region_name=None, **kw: client
+        )
+
+        original = va._build_instance_row
+
+        def raise_for_bad(instance, region):
+            if instance.get("VerifiedAccessInstanceId") == "vai-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(instance, region)
+
+        monkeypatch.setattr(va, "_build_instance_row", raise_for_bad)
+
+        rows = va._scan_verified_access_instances_region(REGION)
+
+        ids = {row["Instance ID"] for row in rows}
+        assert "vai-good" in ids, "healthy instance was lost when a sibling failed"
+        assert "vai-bad" not in ids, "malformed instance should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(service, region_name=None, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeVerifiedAccessInstances",
+            )
+
+        monkeypatch.setattr(va.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            va._scan_verified_access_instances_region(REGION)
+
+    def test_collect_instances_all_regions_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker +
+        exit 1 while the forced Summary sheet still lands.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeVerifiedAccessInstances",
+            )
+
+        monkeypatch.setattr(va, "_scan_verified_access_instances_region", boom)
+
+        instances, failed_regions = va.collect_verified_access_instances_all_regions([REGION])
+
+        assert instances == []
+        assert [r for r, _ in failed_regions] == [REGION]
 
 
 if __name__ == "__main__":

--- a/tests/test_exporters/test_verifiedpermissions_export.py
+++ b/tests/test_exporters/test_verifiedpermissions_export.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Tests for verifiedpermissions_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto coverage: as of moto 5.1.21 there is no AWS Verified Permissions
+backend implemented — even ``list_policy_stores`` under ``@mock_aws`` raises a
+botocore ClientError with message "Not yet implemented". These tests therefore
+monkeypatch ``utils.get_boto3_client`` with a small fake client instead of
+using moto to back the API calls (see ``_FakeVPClient`` below).
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import verifiedpermissions_export  # noqa: E402
+from verifiedpermissions_export import _scan_policy_stores_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakePaginator:
+    """Minimal paginator stand-in that yields exactly one page."""
+
+    def __init__(self, page):
+        self._page = page
+
+    def paginate(self, **kwargs):
+        return iter([self._page])
+
+
+class _FakeVPClient:
+    """Minimal Verified Permissions client stand-in (moto has no backend)."""
+
+    def __init__(self, stores):
+        self._stores = stores
+
+    def get_paginator(self, operation_name):
+        assert operation_name == "list_policy_stores"
+        return _FakePaginator({"policyStores": self._stores})
+
+    def get_policy_store(self, **kwargs):
+        return {"validationSettings": {"mode": "OFF"}}
+
+
+def _store(policy_store_id):
+    return {
+        "policyStoreId": policy_store_id,
+        "arn": f"arn:aws:verifiedpermissions::123456789012:policy-store/{policy_store_id}",
+        "description": "N/A",
+        "createdDate": None,
+        "lastUpdatedDate": None,
+    }
+
+
+class TestScanPolicyStoresRegion:
+    """Happy-path collection."""
+
+    def test_collects_policy_stores(self, monkeypatch):
+        client = _FakeVPClient([_store("PS-good")])
+        monkeypatch.setattr(verifiedpermissions_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = _scan_policy_stores_region(REGION)
+
+        ids = {row["PolicyStoreId"] for row in rows}
+        assert "PS-good" in ids
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _FakeVPClient([])
+        monkeypatch.setattr(verifiedpermissions_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        rows = _scan_policy_stores_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit. This exporter already writes a
+    forced Summary sheet on every run (a workbook always lands — Tier-3
+    PARTIAL) but previously could not distinguish a genuinely-empty account
+    from a failed collection scope. These tests lock in the fix: a real
+    collection failure must propagate/surface, never collapse into "empty".
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One policy store that fails to process must not discard the whole region."""
+        client = _FakeVPClient([_store("good-store"), _store("bad-store")])
+        monkeypatch.setattr(verifiedpermissions_export.utils, "get_boto3_client", lambda *a, **k: client)
+
+        original = verifiedpermissions_export._build_policy_store_row
+
+        def raise_for_bad(store, region, vp):
+            if store.get("policyStoreId") == "bad-store":
+                raise KeyError("PolicyStoreId")
+            return original(store, region, vp)
+
+        monkeypatch.setattr(verifiedpermissions_export, "_build_policy_store_row", raise_for_bad)
+
+        rows = _scan_policy_stores_region(REGION)
+
+        ids = {row["PolicyStoreId"] for row in rows}
+        assert "good-store" in ids, "healthy policy store was lost when a sibling failed"
+        assert "bad-store" not in ids, "malformed policy store should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "not authorized"}},
+                "ListPolicyStores",
+            )
+
+        monkeypatch.setattr(verifiedpermissions_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_policy_stores_region(REGION)
+
+    def test_collect_policy_stores_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets ``_run_export`` write a FAILED marker
+        and exit non-zero.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListPolicyStores",
+            )
+
+        monkeypatch.setattr(verifiedpermissions_export, "_scan_policy_stores_region", boom)
+
+        stores, failed_regions = verifiedpermissions_export.collect_policy_stores([REGION])
+
+        assert stores == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -74,6 +74,9 @@ _EXCLUDED = {
     #   savingsplans:DescribeSavingsPlans   -> 404 "Not yet implemented"
     #   transfer:ListServers                -> NotImplementedError
     #   apprunner:ListServices              -> 404 "Not yet implemented"
+    #   rolesanywhere:ListTrustAnchors      -> 404 "Not yet implemented"
+    #   ec2:DescribeVerifiedAccessInstances -> NotImplementedError
+    #   verifiedpermissions:ListPolicyStores-> 404 "Not yet implemented"
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -85,6 +88,9 @@ _EXCLUDED = {
     "savings_plans_export.py",
     "transfer_family_export.py",
     "apprunner_export.py",
+    "iam_rolesanywhere_export.py",
+    "verifiedaccess_export.py",
+    "verifiedpermissions_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **Third Tier-3 (PARTIAL) phase — Batch H: security & identity (8 exporters).**

| Exporter | Type | Slug |
|---|---|---|
| acm | multi-region | `acm` |
| acm_privateca | multi-region | `acm-privateca` |
| macie | multi-region | `macie` |
| security_hub | multi-region | `security-hub` |
| verifiedaccess | multi-region | `verifiedaccess` |
| verifiedpermissions | multi-region | `verifiedpermissions` |
| iam_identity_providers | account-scope (SAML+OIDC) | `iam-identity-providers` |
| iam_rolesanywhere | account-scope | `iam-rolesanywhere` |

Primary scope collector RAISES on error → surfaced failures → per-item `_build_*_row` guard → marker + `sys.exit(1)`; genuine-empty stays exit 0. KeyError sites guarded (`inst['Region']`, `store['PolicyStoreId']`, tag subscripts).

**Correctness nuances:** `macie` and `security_hub` distinguish *service-not-enabled* (a legitimate disabled state → normal skip, not a failure) from a real API error (→ failed scope). `acm_privateca` preserves the #224 dead issued-cert-scanner limitation.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite (macie/security_hub add a not-enabled-is-not-a-failure case). **Batch-H suites: 50 passed. Full suite: 1067 passed, 2 skipped.** `ruff check .` clean (py39 floor).

## test_smoke.py exclusions
`iam_rolesanywhere`, `verifiedaccess`, `verifiedpermissions` added to `_EXCLUDED` — moto has no backend for their primary APIs. The other 5 pass smoke.

## Remaining
Tier-3 batches **I** devops/governance, **J** cost/compute, **K** networking/misc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)