### PR TITLE
Silent collection failure: Tier-3i (devops & governance exporters)

### DIFF
--- a/scripts/backup_export.py
+++ b/scripts/backup_export.py
@@ -45,76 +45,109 @@ except ImportError:
 args = utils.parse_script_args("Export AWS Backup plans, vaults, and jobs to Excel")
 
 
+def _build_vault_row(vault: dict, region: str) -> dict[str, Any]:
+    """Build a single Backup vault export row from a list_backup_vaults response."""
+    vault_name = vault.get('BackupVaultName', '')
+    vault_arn = vault.get('BackupVaultArn', '')
+    creation_date = vault.get('CreationDate', '')
+    if creation_date:
+        creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+
+    encryption_key_arn = vault.get('EncryptionKeyArn', 'N/A')
+    creator_request_id = vault.get('CreatorRequestId', 'N/A')
+    number_of_recovery_points = vault.get('NumberOfRecoveryPoints', 0)
+    locked = vault.get('Locked', False)
+    min_retention_days = vault.get('MinRetentionDays', 'N/A')
+    max_retention_days = vault.get('MaxRetentionDays', 'N/A')
+
+    lock_date = vault.get('LockDate', '')
+    if lock_date:
+        lock_date = lock_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(lock_date, datetime.datetime) else str(lock_date)
+
+    return {
+        'Region': region,
+        'Vault Name': vault_name,
+        'Recovery Point Count': number_of_recovery_points,
+        'Locked': locked,
+        'Min Retention (days)': min_retention_days,
+        'Max Retention (days)': max_retention_days,
+        'Lock Date': lock_date if lock_date else 'N/A',
+        'Encryption Key ARN': encryption_key_arn,
+        'Creation Date': creation_date,
+        'Creator Request ID': creator_request_id,
+        'Vault ARN': vault_arn
+    }
+
+
 def _scan_backup_vaults_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for backup vaults."""
-    vaults_data = []
+    """
+    Collect backup vaults from a single region.
 
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no backup vaults" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed vaults are skipped (logged) rather than aborting the
+    whole region.
+    """
     if not utils.is_aws_region(region):
-        return vaults_data
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-    try:
-        backup_client = utils.get_boto3_client('backup', region_name=region)
-        paginator = backup_client.get_paginator('list_backup_vaults')
+    print(f"\nProcessing region: {region}")
 
-        for page in paginator.paginate():
-            vaults = page.get('BackupVaultList', [])
+    backup_client = utils.get_boto3_client('backup', region_name=region)
+    paginator = backup_client.get_paginator('list_backup_vaults')
+    vaults_data = []
+    vault_count = 0
 
-            for vault in vaults:
-                vault_name = vault.get('BackupVaultName', '')
-                vault_arn = vault.get('BackupVaultArn', '')
-                creation_date = vault.get('CreationDate', '')
-                if creation_date:
-                    creation_date = creation_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(creation_date, datetime.datetime) else str(creation_date)
+    for page in paginator.paginate():
+        vaults = page.get('BackupVaultList', [])
+        vault_count += len(vaults)
 
-                encryption_key_arn = vault.get('EncryptionKeyArn', 'N/A')
-                creator_request_id = vault.get('CreatorRequestId', 'N/A')
-                number_of_recovery_points = vault.get('NumberOfRecoveryPoints', 0)
-                locked = vault.get('Locked', False)
-                min_retention_days = vault.get('MinRetentionDays', 'N/A')
-                max_retention_days = vault.get('MaxRetentionDays', 'N/A')
+        for vault in vaults:
+            try:
+                vaults_data.append(_build_vault_row(vault, region))
+            except Exception as e:
+                # One malformed vault is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed backup vault in {region}: "
+                    f"{vault.get('BackupVaultName', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                lock_date = vault.get('LockDate', '')
-                if lock_date:
-                    lock_date = lock_date.strftime('%Y-%m-%d %H:%M:%S') if isinstance(lock_date, datetime.datetime) else str(lock_date)
-
-                vaults_data.append({
-                    'Region': region,
-                    'Vault Name': vault_name,
-                    'Recovery Point Count': number_of_recovery_points,
-                    'Locked': locked,
-                    'Min Retention (days)': min_retention_days,
-                    'Max Retention (days)': max_retention_days,
-                    'Lock Date': lock_date if lock_date else 'N/A',
-                    'Encryption Key ARN': encryption_key_arn,
-                    'Creation Date': creation_date,
-                    'Creator Request ID': creator_request_id,
-                    'Vault ARN': vault_arn
-                })
-    except Exception as e:
-        utils.log_error(f"Error scanning backup vaults in {region}", e)
-
+    print(f"  Found {vault_count} backup vaults")
     return vaults_data
 
 
-@utils.aws_error_handler("Collecting backup vaults", default_return=[])
-def collect_backup_vaults(regions: list[str]) -> list[dict[str, Any]]:
+def collect_backup_vaults(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect AWS Backup vault information from AWS regions.
+    Collect AWS Backup vault information across regions, surfacing failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with backup vault information
+        tuple: ``(vaults, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING BACKUP VAULTS ===")
 
-    # Use concurrent scanning for better performance
-    results = utils.scan_regions_concurrent(regions, _scan_backup_vaults_region)
-    all_vaults = [vault for result in results for vault in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_backup_vaults_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_vaults = [vault for result in region_results for vault in result]
 
     utils.log_success(f"Total backup vaults collected: {len(all_vaults)}")
-    return all_vaults
+    return all_vaults, failed_regions
 
 
 def _scan_backup_plans_region(region: str) -> list[dict[str, Any]]:
@@ -357,63 +390,78 @@ def export_backup_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect backup vaults
-    vaults = collect_backup_vaults(regions)
+    # STEP 1: Collect backup vaults (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    vaults, failed_regions = collect_backup_vaults(regions)
     if vaults:
         data_frames['Backup Vaults'] = pd.DataFrame(vaults)
 
-    # STEP 2: Collect backup plans
+    # STEP 2: Collect backup plans (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     plans = collect_backup_plans(regions)
     if plans:
         data_frames['Backup Plans'] = pd.DataFrame(plans)
 
-    # STEP 3: Collect backup selections
+    # STEP 3: Collect backup selections (enrichment — degrades gracefully).
     selections = collect_backup_selections(regions)
     if selections:
         data_frames['Backup Selections'] = pd.DataFrame(selections)
 
-    # STEP 4: Collect backup jobs (Phase F: API coverage fix)
+    # STEP 4: Collect backup jobs (enrichment — degrades gracefully;
+    # Phase F: API coverage fix).
     jobs = collect_backup_jobs(regions)
     if jobs:
         data_frames['Backup Jobs'] = pd.DataFrame(jobs)
 
-    # Check if we have any data
-    if not data_frames:
+    # Export whatever succeeded first — a partial export is required even
+    # when some regions failed (see the silent-collection-failure blast-radius audit).
+    if data_frames:
+        # STEP 4: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+
+        # STEP 5: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'aws-backup',
+            region_suffix,
+            current_date
+        )
+
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+
+            if output_path:
+                utils.log_success("AWS Backup data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
+                utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
+
+                # Summary of exported data
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
+
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
+    elif not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No AWS Backup data was collected. Nothing to export.")
         print("\nNo AWS Backup resources found in the selected region(s).")
-        return
 
-    # STEP 4: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
-
-    # STEP 5: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'aws-backup',
-        region_suffix,
-        current_date
-    )
-
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
-
-        if output_path:
-            utils.log_success("AWS Backup data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
-            utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
-
-            # Summary of exported data
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
-
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary backup vault scope collection, make it
+    # loud: write a marker and exit non-zero, even if some data was exported. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'aws-backup', failed_regions)
+        print(
+            "\nERROR: AWS Backup export completed with failures — data is incomplete. "
+            "See the *-aws-backup-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/cloudformation_export.py
+++ b/scripts/cloudformation_export.py
@@ -40,58 +40,108 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export CloudFormation stacks and resources to Excel")
 
-@utils.aws_error_handler("Collecting CloudFormation stacks", default_return=[])
-def collect_stacks(region: str) -> list[dict[str, Any]]:
-    """Collect all CloudFormation stacks in a region."""
+def _build_stack_row(stack: dict, region: str) -> dict[str, Any]:
+    """Build a single CloudFormation stack export row from a describe_stacks entry."""
+    # Extract parameters
+    parameters = []
+    for param in stack.get('Parameters', []):
+        parameters.append(f"{param.get('ParameterKey')}={param.get('ParameterValue')}")
+
+    # Extract outputs
+    outputs = []
+    for output in stack.get('Outputs', []):
+        outputs.append(f"{output.get('OutputKey')}={output.get('OutputValue')}")
+
+    # Extract tags
+    tags = []
+    for tag in stack.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    # Extract capabilities
+    capabilities = ', '.join(stack.get('Capabilities', []))
+
+    return {
+        'Region': region,
+        'StackName': stack.get('StackName', 'N/A'),
+        'StackId': stack.get('StackId', 'N/A'),
+        'Status': stack.get('StackStatus', 'N/A'),
+        'StatusReason': stack.get('StackStatusReason', 'N/A'),
+        'CreationTime': stack.get('CreationTime'),
+        'LastUpdatedTime': stack.get('LastUpdatedTime', 'N/A'),
+        'DriftStatus': stack.get('DriftInformation', {}).get('StackDriftStatus', 'NOT_CHECKED'),
+        'LastDriftCheckTime': stack.get('DriftInformation', {}).get('LastCheckTimestamp', 'N/A'),
+        'TerminationProtection': stack.get('EnableTerminationProtection', False),
+        'RoleARN': stack.get('RoleARN', 'N/A'),
+        'TemplateDescription': stack.get('Description', 'N/A'),
+        'Capabilities': capabilities if capabilities else 'N/A',
+        'Parameters': ', '.join(parameters) if parameters else 'N/A',
+        'Outputs': ', '.join(outputs) if outputs else 'N/A',
+        'Tags': ', '.join(tags) if tags else 'N/A',
+        'DisableRollback': stack.get('DisableRollback', False),
+        'NotificationARNs': ', '.join(stack.get('NotificationARNs', [])) if stack.get('NotificationARNs') else 'N/A',
+        'TimeoutInMinutes': stack.get('TimeoutInMinutes', 'N/A'),
+        'ParentId': stack.get('ParentId', 'N/A'),
+        'RootId': stack.get('RootId', 'N/A'),
+    }
+
+
+def _scan_stacks_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect CloudFormation stacks from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no stacks" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed stacks are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     cfn = utils.get_boto3_client('cloudformation', region_name=region)
     stacks = []
 
     paginator = cfn.get_paginator('describe_stacks')
     for page in paginator.paginate():
         for stack in page.get('Stacks', []):
-            # Extract parameters
-            parameters = []
-            for param in stack.get('Parameters', []):
-                parameters.append(f"{param.get('ParameterKey')}={param.get('ParameterValue')}")
-
-            # Extract outputs
-            outputs = []
-            for output in stack.get('Outputs', []):
-                outputs.append(f"{output.get('OutputKey')}={output.get('OutputValue')}")
-
-            # Extract tags
-            tags = []
-            for tag in stack.get('Tags', []):
-                tags.append(f"{tag.get('Key')}={tag.get('Value')}")
-
-            # Extract capabilities
-            capabilities = ', '.join(stack.get('Capabilities', []))
-
-            stacks.append({
-                'Region': region,
-                'StackName': stack.get('StackName', 'N/A'),
-                'StackId': stack.get('StackId', 'N/A'),
-                'Status': stack.get('StackStatus', 'N/A'),
-                'StatusReason': stack.get('StackStatusReason', 'N/A'),
-                'CreationTime': stack.get('CreationTime'),
-                'LastUpdatedTime': stack.get('LastUpdatedTime', 'N/A'),
-                'DriftStatus': stack.get('DriftInformation', {}).get('StackDriftStatus', 'NOT_CHECKED'),
-                'LastDriftCheckTime': stack.get('DriftInformation', {}).get('LastCheckTimestamp', 'N/A'),
-                'TerminationProtection': stack.get('EnableTerminationProtection', False),
-                'RoleARN': stack.get('RoleARN', 'N/A'),
-                'TemplateDescription': stack.get('Description', 'N/A'),
-                'Capabilities': capabilities if capabilities else 'N/A',
-                'Parameters': ', '.join(parameters) if parameters else 'N/A',
-                'Outputs': ', '.join(outputs) if outputs else 'N/A',
-                'Tags': ', '.join(tags) if tags else 'N/A',
-                'DisableRollback': stack.get('DisableRollback', False),
-                'NotificationARNs': ', '.join(stack.get('NotificationARNs', [])) if stack.get('NotificationARNs') else 'N/A',
-                'TimeoutInMinutes': stack.get('TimeoutInMinutes', 'N/A'),
-                'ParentId': stack.get('ParentId', 'N/A'),
-                'RootId': stack.get('RootId', 'N/A'),
-            })
+            try:
+                stacks.append(_build_stack_row(stack, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed CloudFormation stack in {region}: "
+                    f"{stack.get('StackName', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return stacks
+
+
+def collect_stacks(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect CloudFormation stacks across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(stacks, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_stacks_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_stacks = [stack for result in region_results for stack in result]
+    return all_stacks, failed_regions
 
 
 @utils.aws_error_handler("Collecting stack resources", default_return=[])
@@ -194,27 +244,29 @@ def collect_stackset_instances(region: str, stackset_name: str) -> list[dict[str
 
 def _run_export(account_id: str, account_name: str, regions: list) -> None:
     """Collect CloudFormation data and write the Excel export."""
-    all_stacks = []
     all_resources = []
     all_stacksets = []
     all_stackset_instances = []
 
+    # PRIMARY scope: CloudFormation stacks (concurrent, failure-tracking — a
+    # region whose collection errors must never be reported as "no stacks").
+    utils.log_info(f"Collecting CloudFormation stacks across {len(regions)} region(s)...")
+    all_stacks, failed_regions = collect_stacks(regions)
+    utils.log_info(f"  Found {len(all_stacks)} stack(s) total")
+
+    # Enrichment: resources for each stack (graceful — a stack that can't be
+    # enumerated for resources does not invalidate the stack itself).
+    for stack in all_stacks:
+        region = stack['Region']
+        stack_name = stack['StackName']
+        resources = collect_stack_resources(region, stack_name)
+        all_resources.extend(resources)
+
+    # Collect StackSets and their instances (unaffected by this fix — kept as
+    # a graceful, per-region best-effort scan).
     for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
+        utils.log_info(f"[{idx}/{len(regions)}] Processing region for StackSets: {region}")
 
-        # Collect stacks
-        stacks = collect_stacks(region)
-        if stacks:
-            utils.log_info(f"  Found {len(stacks)} stack(s)")
-            all_stacks.extend(stacks)
-
-            # Collect resources for each stack
-            for stack in stacks:
-                stack_name = stack['StackName']
-                resources = collect_stack_resources(region, stack_name)
-                all_resources.extend(resources)
-
-        # Collect StackSets
         stacksets = collect_stacksets(region)
         if stacksets:
             utils.log_info(f"  Found {len(stacksets)} StackSet(s)")
@@ -282,6 +334,18 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     utils.log_info(f"  StackSet Instances: {len(all_stackset_instances)}")
 
     utils.log_success("CloudFormation export completed successfully!")
+
+    # If ANY region failed the primary stacks scope collection, make it loud:
+    # write a marker and exit non-zero, even though the forced Summary sheet
+    # means a workbook always lands. A complete-looking file that silently
+    # hides missing regions is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'cloudformation', failed_regions)
+        print(
+            "\nERROR: CloudFormation export completed with failures — data is incomplete. "
+            "See the *-cloudformation-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/cloudwatch_export.py
+++ b/scripts/cloudwatch_export.py
@@ -43,105 +43,152 @@ except ImportError:
 args = utils.parse_script_args("Export CloudWatch alarms and dashboards to Excel")
 
 
+def _build_alarm_row(alarm: dict[str, Any], region: str) -> dict[str, Any]:
+    """
+    Build the export row for a single CloudWatch alarm (metric or composite).
+
+    Extracted so the per-alarm processing can be wrapped in try/except by the
+    caller: a malformed alarm entry is logged and skipped rather than
+    discarding the whole region's results. Every field is read with ``.get()``
+    and a safe default for the same reason (including the ``Dimensions``
+    list, which previously used hard subscripts ``d['Name']``/``d['Value']``
+    — a confirmed KeyError candidate per the silent-collection-failure audit).
+
+    Args:
+        alarm: A single alarm entry from describe_alarms (Metric or Composite).
+        region: AWS region name.
+
+    Returns:
+        dict: The assembled alarm row.
+    """
+    alarm_name = alarm.get('AlarmName', 'N/A')
+    alarm_type = 'Composite' if 'AlarmRule' in alarm else 'Metric'
+    alarm_arn = alarm.get('AlarmArn', 'N/A')
+    description = alarm.get('AlarmDescription', 'N/A')
+    state = alarm.get('StateValue', 'UNKNOWN')
+    state_reason = alarm.get('StateReason', 'N/A')
+
+    state_updated = alarm.get('StateUpdatedTimestamp', '')
+    if state_updated:
+        state_updated = state_updated.strftime('%Y-%m-%d %H:%M:%S') if isinstance(state_updated, datetime.datetime) else str(state_updated)
+
+    actions_enabled = alarm.get('ActionsEnabled', False)
+
+    if alarm_type == 'Metric':
+        metric_name = alarm.get('MetricName', 'N/A')
+        namespace = alarm.get('Namespace', 'N/A')
+        statistic = alarm.get('Statistic', alarm.get('ExtendedStatistic', 'N/A'))
+        comparison_operator = alarm.get('ComparisonOperator', 'N/A')
+        threshold = alarm.get('Threshold', 'N/A')
+        evaluation_periods = alarm.get('EvaluationPeriods', 'N/A')
+        period = alarm.get('Period', 'N/A')
+        treat_missing_data = alarm.get('TreatMissingData', 'notBreaching')
+        dimensions = alarm.get('Dimensions', [])
+        dimensions_str = ', '.join(
+            [f"{d.get('Name', 'N/A')}={d.get('Value', 'N/A')}" for d in dimensions]
+        ) if dimensions else 'None'
+
+        return {
+            'Region': region,
+            'Alarm Name': alarm_name,
+            'Alarm Type': alarm_type,
+            'State': state,
+            'State Reason': state_reason,
+            'State Updated': state_updated if state_updated else 'N/A',
+            'Actions Enabled': actions_enabled,
+            'Metric Name': metric_name,
+            'Namespace': namespace,
+            'Statistic': statistic,
+            'Comparison': comparison_operator,
+            'Threshold': threshold,
+            'Evaluation Periods': evaluation_periods,
+            'Period (sec)': period,
+            'Treat Missing Data': treat_missing_data,
+            'Dimensions': dimensions_str,
+            'Description': description,
+            'Alarm ARN': alarm_arn
+        }
+    else:
+        alarm_rule = alarm.get('AlarmRule', 'N/A')
+        return {
+            'Region': region,
+            'Alarm Name': alarm_name,
+            'Alarm Type': alarm_type,
+            'State': state,
+            'State Reason': state_reason,
+            'State Updated': state_updated if state_updated else 'N/A',
+            'Actions Enabled': actions_enabled,
+            'Alarm Rule': alarm_rule,
+            'Description': description,
+            'Alarm ARN': alarm_arn
+        }
+
+
 def _scan_cloudwatch_alarms_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for CloudWatch alarms."""
+    """
+    Collect CloudWatch alarms from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no alarms" (the silent-
+    collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed alarms are skipped (logged) rather than aborting the
+    whole region.
+    """
     alarms_data = []
 
     if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
         return alarms_data
 
-    try:
-        cw_client = utils.get_boto3_client('cloudwatch', region_name=region)
-        paginator = cw_client.get_paginator('describe_alarms')
+    cw_client = utils.get_boto3_client('cloudwatch', region_name=region)
+    paginator = cw_client.get_paginator('describe_alarms')
 
-        for page in paginator.paginate():
-            alarms = page.get('MetricAlarms', []) + page.get('CompositeAlarms', [])
+    for page in paginator.paginate():
+        alarms = page.get('MetricAlarms', []) + page.get('CompositeAlarms', [])
 
-            for alarm in alarms:
-                alarm_name = alarm.get('AlarmName', 'N/A')
-                alarm_type = 'Composite' if 'AlarmRule' in alarm else 'Metric'
-                alarm_arn = alarm.get('AlarmArn', 'N/A')
-                description = alarm.get('AlarmDescription', 'N/A')
-                state = alarm.get('StateValue', 'UNKNOWN')
-                state_reason = alarm.get('StateReason', 'N/A')
-
-                state_updated = alarm.get('StateUpdatedTimestamp', '')
-                if state_updated:
-                    state_updated = state_updated.strftime('%Y-%m-%d %H:%M:%S') if isinstance(state_updated, datetime.datetime) else str(state_updated)
-
-                actions_enabled = alarm.get('ActionsEnabled', False)
-
-                if alarm_type == 'Metric':
-                    metric_name = alarm.get('MetricName', 'N/A')
-                    namespace = alarm.get('Namespace', 'N/A')
-                    statistic = alarm.get('Statistic', alarm.get('ExtendedStatistic', 'N/A'))
-                    comparison_operator = alarm.get('ComparisonOperator', 'N/A')
-                    threshold = alarm.get('Threshold', 'N/A')
-                    evaluation_periods = alarm.get('EvaluationPeriods', 'N/A')
-                    period = alarm.get('Period', 'N/A')
-                    treat_missing_data = alarm.get('TreatMissingData', 'notBreaching')
-                    dimensions = alarm.get('Dimensions', [])
-                    dimensions_str = ', '.join([f"{d['Name']}={d['Value']}" for d in dimensions]) if dimensions else 'None'
-
-                    alarms_data.append({
-                        'Region': region,
-                        'Alarm Name': alarm_name,
-                        'Alarm Type': alarm_type,
-                        'State': state,
-                        'State Reason': state_reason,
-                        'State Updated': state_updated if state_updated else 'N/A',
-                        'Actions Enabled': actions_enabled,
-                        'Metric Name': metric_name,
-                        'Namespace': namespace,
-                        'Statistic': statistic,
-                        'Comparison': comparison_operator,
-                        'Threshold': threshold,
-                        'Evaluation Periods': evaluation_periods,
-                        'Period (sec)': period,
-                        'Treat Missing Data': treat_missing_data,
-                        'Dimensions': dimensions_str,
-                        'Description': description,
-                        'Alarm ARN': alarm_arn
-                    })
-                else:
-                    alarm_rule = alarm.get('AlarmRule', 'N/A')
-                    alarms_data.append({
-                        'Region': region,
-                        'Alarm Name': alarm_name,
-                        'Alarm Type': alarm_type,
-                        'State': state,
-                        'State Reason': state_reason,
-                        'State Updated': state_updated if state_updated else 'N/A',
-                        'Actions Enabled': actions_enabled,
-                        'Alarm Rule': alarm_rule,
-                        'Description': description,
-                        'Alarm ARN': alarm_arn
-                    })
-    except Exception as e:
-        utils.log_error(f"Error scanning CloudWatch alarms in {region}", e)
+        for alarm in alarms:
+            try:
+                alarms_data.append(_build_alarm_row(alarm, region))
+            except Exception as e:
+                # One malformed alarm is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed CloudWatch alarm in {region}: "
+                    f"{alarm.get('AlarmName', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return alarms_data
 
 
-@utils.aws_error_handler("Collecting CloudWatch alarms", default_return=[])
-def collect_cloudwatch_alarms(regions: list[str]) -> list[dict[str, Any]]:
+def collect_cloudwatch_alarms(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect CloudWatch alarm information from AWS regions.
+    Collect CloudWatch alarm information across regions, surfacing failures.
 
-    Args:
-        regions: List of AWS regions to scan
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Returns:
-        list: List of dictionaries with alarm information
+        tuple: ``(alarms, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING CLOUDWATCH ALARMS ===")
 
-    # Use concurrent scanning for better performance
-    results = utils.scan_regions_concurrent(regions, _scan_cloudwatch_alarms_region)
-    all_alarms = [alarm for result in results for alarm in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_cloudwatch_alarms_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_alarms = [alarm for result in region_results for alarm in result]
 
     utils.log_success(f"Total CloudWatch alarms collected: {len(all_alarms)}")
-    return all_alarms
+    return all_alarms, failed_regions
 
 
 def _scan_log_groups_region(region: str) -> list[dict[str, Any]]:
@@ -331,63 +378,60 @@ def export_cloudwatch_data(account_id: str, account_name: str):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect alarms
-    alarms = collect_cloudwatch_alarms(regions)
+    # STEP 1: Collect alarms (primary scope — region failures must propagate
+    # as failed_regions, never collapse into "empty").
+    alarms, failed_regions = collect_cloudwatch_alarms(regions)
     if alarms:
         data_frames['CloudWatch Alarms'] = pd.DataFrame(alarms)
 
-    # STEP 2: Collect log groups
+    # STEP 2: Collect log groups (enrichment — degrades gracefully).
     log_groups = collect_log_groups(regions)
     if log_groups:
         data_frames['Log Groups'] = pd.DataFrame(log_groups)
 
-    # STEP 3: Collect dashboards
+    # STEP 3: Collect dashboards (enrichment — degrades gracefully).
     dashboards = collect_dashboards(regions)
     if dashboards:
         data_frames['Dashboards'] = pd.DataFrame(dashboards)
 
-    # STEP 4: Collect metric filters
+    # STEP 4: Collect metric filters (enrichment — degrades gracefully).
     metric_filters = collect_metric_filters(regions)
     if metric_filters:
         data_frames['Metric Filters'] = pd.DataFrame(metric_filters)
 
-    # STEP 5: Create summary
-    if alarms or log_groups or dashboards or metric_filters:
-        summary_data = []
+    # STEP 5: Create summary. Always written (even when every scope came back
+    # empty) so the workbook always lands — this is the Tier-3 forced-Summary
+    # behavior that must be preserved. A zero-row/zero-count Summary is not
+    # itself a failure signal; the failed_regions check below is.
+    summary_data = []
 
-        total_alarms = len(alarms)
-        total_log_groups = len(log_groups)
+    total_alarms = len(alarms)
+    total_log_groups = len(log_groups)
 
-        # Alarm states
-        alarm_states = {}
-        for alarm in alarms:
-            state = alarm.get('State', 'UNKNOWN')
-            alarm_states[state] = alarm_states.get(state, 0) + 1
+    # Alarm states
+    alarm_states = {}
+    for alarm in alarms:
+        state = alarm.get('State', 'UNKNOWN')
+        alarm_states[state] = alarm_states.get(state, 0) + 1
 
-        # Alarm types
-        metric_alarms = sum(1 for a in alarms if a.get('Alarm Type') == 'Metric')
-        composite_alarms = sum(1 for a in alarms if a.get('Alarm Type') == 'Composite')
+    # Alarm types
+    metric_alarms = sum(1 for a in alarms if a.get('Alarm Type') == 'Metric')
+    composite_alarms = sum(1 for a in alarms if a.get('Alarm Type') == 'Composite')
 
-        # Log group storage
-        total_log_storage_mb = sum(float(lg.get('Stored Size (MB)', 0)) for lg in log_groups)
+    # Log group storage
+    total_log_storage_mb = sum(float(lg.get('Stored Size (MB)', 0)) for lg in log_groups)
 
-        summary_data.append({'Metric': 'Total CloudWatch Alarms', 'Value': total_alarms})
-        summary_data.append({'Metric': 'Metric Alarms', 'Value': metric_alarms})
-        summary_data.append({'Metric': 'Composite Alarms', 'Value': composite_alarms})
-        for state, count in alarm_states.items():
-            summary_data.append({'Metric': f'Alarms in {state} State', 'Value': count})
-        summary_data.append({'Metric': 'Total Log Groups', 'Value': total_log_groups})
-        summary_data.append({'Metric': 'Total Log Storage (MB)', 'Value': round(total_log_storage_mb, 2)})
-        summary_data.append({'Metric': 'Total Dashboards', 'Value': len(dashboards)})
-        summary_data.append({'Metric': 'Total Metric Filters', 'Value': len(metric_filters)})
+    summary_data.append({'Metric': 'Total CloudWatch Alarms', 'Value': total_alarms})
+    summary_data.append({'Metric': 'Metric Alarms', 'Value': metric_alarms})
+    summary_data.append({'Metric': 'Composite Alarms', 'Value': composite_alarms})
+    for state, count in alarm_states.items():
+        summary_data.append({'Metric': f'Alarms in {state} State', 'Value': count})
+    summary_data.append({'Metric': 'Total Log Groups', 'Value': total_log_groups})
+    summary_data.append({'Metric': 'Total Log Storage (MB)', 'Value': round(total_log_storage_mb, 2)})
+    summary_data.append({'Metric': 'Total Dashboards', 'Value': len(dashboards)})
+    summary_data.append({'Metric': 'Total Metric Filters', 'Value': len(metric_filters)})
 
-        data_frames['Summary'] = pd.DataFrame(summary_data)
-
-    # Check if we have any data
-    if not data_frames:
-        utils.log_warning("No CloudWatch data was collected. Nothing to export.")
-        print("\nNo CloudWatch resources found in the selected region(s).")
-        return
+    data_frames['Summary'] = pd.DataFrame(summary_data)
 
     # STEP 4: Prepare all DataFrames for export
     for sheet_name in data_frames:
@@ -420,6 +464,18 @@ def export_cloudwatch_data(account_id: str, account_name: str):
 
     except Exception as e:
         utils.log_error("Error creating Excel file", e)
+
+    # If ANY region failed the CloudWatch Alarms scope collection, make it
+    # loud: write a marker and exit non-zero, even though the Summary sheet
+    # (and possibly other data) was still exported. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'cloudwatch', failed_regions)
+        print(
+            "\nERROR: CloudWatch export completed with failures — data is incomplete. "
+            "See the *-cloudwatch-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/codebuild_export.py
+++ b/scripts/codebuild_export.py
@@ -27,82 +27,122 @@ except ImportError:
 args = utils.parse_script_args("Export CodeBuild projects and builds to Excel")
 
 def _scan_projects_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for CodeBuild projects."""
+    """
+    Collect CodeBuild projects from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no CodeBuild projects" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed projects are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     projects_data = []
+    codebuild_client = utils.get_boto3_client('codebuild', region_name=region)
 
-    try:
-        codebuild_client = utils.get_boto3_client('codebuild', region_name=region)
+    # List all projects
+    paginator = codebuild_client.get_paginator('list_projects')
+    project_names = []
+    for page in paginator.paginate():
+        project_names.extend(page.get('projects', []))
 
-        # List all projects
-        paginator = codebuild_client.get_paginator('list_projects')
-        project_names = []
-        for page in paginator.paginate():
-            project_names.extend(page.get('projects', []))
+    # Batch get project details (100 at a time)
+    for i in range(0, len(project_names), 100):
+        batch = project_names[i:i+100]
+        projects_response = codebuild_client.batch_get_projects(names=batch)
+        projects = projects_response.get('projects', [])
 
-        # Batch get project details (100 at a time)
-        for i in range(0, len(project_names), 100):
-            batch = project_names[i:i+100]
-            projects_response = codebuild_client.batch_get_projects(names=batch)
-            projects = projects_response.get('projects', [])
-
-            for project in projects:
-                created = project.get('created', 'N/A')
-                if created != 'N/A':
-                    created = created.strftime('%Y-%m-%d %H:%M:%S')
-                last_modified = project.get('lastModified', 'N/A')
-                if last_modified != 'N/A':
-                    last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
-
-                source = project.get('source', {})
-                environment = project.get('environment', {})
-                artifacts = project.get('artifacts', {})
-                cache = project.get('cache', {})
-                vpc_config = project.get('vpcConfig', {})
-                vpc_id = vpc_config.get('vpcId', 'N/A')
-                logs_config = project.get('logsConfig', {})
-
-                projects_data.append({
-                    'Region': region,
-                    'Project Name': project.get('name', 'N/A'),
-                    'ARN': project.get('arn', 'N/A'),
-                    'Description': project.get('description', 'N/A'),
-                    'Created': created,
-                    'Last Modified': last_modified,
-                    'Source Type': source.get('type', 'N/A'),
-                    'Source Location': source.get('location', 'N/A'),
-                    'Buildspec': source.get('buildspec', 'Inline/Default'),
-                    'Git Clone Depth': source.get('gitCloneDepth', 'N/A'),
-                    'Environment Type': environment.get('type', 'N/A'),
-                    'Compute Type': environment.get('computeType', 'N/A'),
-                    'Image': environment.get('image', 'N/A'),
-                    'Privileged Mode': environment.get('privilegedMode', False),
-                    'Service Role': project.get('serviceRole', 'N/A'),
-                    'Artifacts Type': artifacts.get('type', 'N/A'),
-                    'Artifacts Location': artifacts.get('location', 'N/A'),
-                    'Cache Type': cache.get('type', 'NO_CACHE'),
-                    'Cache Location': cache.get('location', 'N/A'),
-                    'VPC Enabled': 'Yes' if vpc_id != 'N/A' else 'No',
-                    'VPC ID': vpc_id,
-                    'Timeout (minutes)': project.get('timeoutInMinutes', 'N/A'),
-                    'Queued Timeout (minutes)': project.get('queuedTimeoutInMinutes', 'N/A'),
-                    'Badge Enabled': project.get('badge', {}).get('badgeEnabled', False),
-                    'CloudWatch Logs': logs_config.get('cloudWatchLogs', {}).get('status', 'DISABLED'),
-                    'S3 Logs': logs_config.get('s3Logs', {}).get('status', 'DISABLED'),
-                    'Webhook URL': project.get('webhook', {}).get('url', 'N/A')
-                })
-    except Exception as e:
-        utils.log_error(f"Error scanning CodeBuild projects in {region}", e)
+        for project in projects:
+            try:
+                projects_data.append(_build_project_row(project, region))
+            except Exception as e:
+                # One malformed project is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed CodeBuild project in {region}: "
+                    f"{project.get('name', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return projects_data
 
 
-@utils.aws_error_handler("Collecting CodeBuild projects", default_return=[])
-def collect_projects(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect CodeBuild project information from AWS regions."""
-    results = utils.scan_regions_concurrent(regions, _scan_projects_region)
-    all_projects = [p for result in results for p in result]
+def _build_project_row(project: dict, region: str) -> dict[str, Any]:
+    """Build a single CodeBuild project export row from a batch_get_projects response."""
+    created = project.get('created', 'N/A')
+    if created != 'N/A':
+        created = created.strftime('%Y-%m-%d %H:%M:%S')
+    last_modified = project.get('lastModified', 'N/A')
+    if last_modified != 'N/A':
+        last_modified = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    source = project.get('source', {})
+    environment = project.get('environment', {})
+    artifacts = project.get('artifacts', {})
+    cache = project.get('cache', {})
+    vpc_config = project.get('vpcConfig', {})
+    vpc_id = vpc_config.get('vpcId', 'N/A')
+    logs_config = project.get('logsConfig', {})
+
+    return {
+        'Region': region,
+        'Project Name': project.get('name', 'N/A'),
+        'ARN': project.get('arn', 'N/A'),
+        'Description': project.get('description', 'N/A'),
+        'Created': created,
+        'Last Modified': last_modified,
+        'Source Type': source.get('type', 'N/A'),
+        'Source Location': source.get('location', 'N/A'),
+        'Buildspec': source.get('buildspec', 'Inline/Default'),
+        'Git Clone Depth': source.get('gitCloneDepth', 'N/A'),
+        'Environment Type': environment.get('type', 'N/A'),
+        'Compute Type': environment.get('computeType', 'N/A'),
+        'Image': environment.get('image', 'N/A'),
+        'Privileged Mode': environment.get('privilegedMode', False),
+        'Service Role': project.get('serviceRole', 'N/A'),
+        'Artifacts Type': artifacts.get('type', 'N/A'),
+        'Artifacts Location': artifacts.get('location', 'N/A'),
+        'Cache Type': cache.get('type', 'NO_CACHE'),
+        'Cache Location': cache.get('location', 'N/A'),
+        'VPC Enabled': 'Yes' if vpc_id != 'N/A' else 'No',
+        'VPC ID': vpc_id,
+        'Timeout (minutes)': project.get('timeoutInMinutes', 'N/A'),
+        'Queued Timeout (minutes)': project.get('queuedTimeoutInMinutes', 'N/A'),
+        'Badge Enabled': project.get('badge', {}).get('badgeEnabled', False),
+        'CloudWatch Logs': logs_config.get('cloudWatchLogs', {}).get('status', 'DISABLED'),
+        'S3 Logs': logs_config.get('s3Logs', {}).get('status', 'DISABLED'),
+        'Webhook URL': project.get('webhook', {}).get('url', 'N/A')
+    }
+
+
+def collect_projects(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect CodeBuild project information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(projects, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_projects_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_projects = [p for result in region_results for p in result]
     utils.log_info(f"Collected {len(all_projects)} CodeBuild projects")
-    return all_projects
+    return all_projects, failed_regions
 
 
 def _scan_builds_region(region: str) -> list[dict[str, Any]]:
@@ -340,7 +380,9 @@ def main():
     # Collect data
     print("\nCollecting AWS CodeBuild data...")
 
-    projects = collect_projects(regions)
+    # STEP 1: Collect CodeBuild projects (primary scope — region failures
+    # must propagate as failed_regions, never collapse into "empty").
+    projects, failed_regions = collect_projects(regions)
     builds = collect_builds(regions)
     report_groups = collect_report_groups(regions)
     summary = generate_summary(projects, builds, report_groups)
@@ -381,6 +423,19 @@ def main():
         # Log summary
     else:
         utils.log_warning("No AWS CodeBuild data found to export")
+
+    # If ANY region failed the primary CodeBuild projects scope collection,
+    # make it loud: write a marker and exit non-zero, even though the
+    # always-written Summary sheet means a workbook still landed. A partial
+    # export that looks complete is exactly the failure mode this guards
+    # against (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'codebuild', failed_regions)
+        print(
+            "\nERROR: CodeBuild export completed with failures — data is incomplete. "
+            "See the *-codebuild-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("AWS CodeBuild export completed successfully")
 

--- a/scripts/codepipeline_export.py
+++ b/scripts/codepipeline_export.py
@@ -26,112 +26,157 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export CodePipeline pipelines to Excel")
 
-def _scan_pipelines_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for CodePipeline pipelines."""
-    pipelines_data = []
+def _build_pipeline_row(client, pipeline_summary: dict, region: str) -> dict[str, Any]:
+    """
+    Build a single CodePipeline pipeline export row, including detail lookups.
 
+    The pipeline-state lookup (latest execution status) is an enrichment
+    call and degrades gracefully to 'Unknown' on failure; a failure fetching
+    the pipeline itself (``get_pipeline``) propagates so the caller can skip
+    just this one malformed/inaccessible pipeline.
+    """
+    pipeline_name = pipeline_summary.get('name', 'N/A')
+    print(f"  Processing pipeline: {pipeline_name}")
+
+    pipeline_response = client.get_pipeline(name=pipeline_name)
+    pipeline = pipeline_response.get('pipeline', {})
+    metadata = pipeline_response.get('metadata', {})
+
+    # Basic info
+    arn = metadata.get('pipelineArn', 'N/A')
+
+    created = pipeline_summary.get('created', metadata.get('created', 'N/A'))
+    if created != 'N/A':
+        created = created.strftime('%Y-%m-%d %H:%M:%S')
+
+    updated = pipeline_summary.get('updated', metadata.get('updated', 'N/A'))
+    if updated != 'N/A':
+        updated = updated.strftime('%Y-%m-%d %H:%M:%S')
+
+    # Version
+    version = pipeline_summary.get('version', pipeline.get('version', 'N/A'))
+
+    # Role
+    role_arn = pipeline.get('roleArn', 'N/A')
+
+    # Artifact store
+    artifact_store = pipeline.get('artifactStore', {})
+    artifact_type = artifact_store.get('type', 'N/A')
+    artifact_location = artifact_store.get('location', 'N/A')
+
+    # Encryption key
+    encryption_key = artifact_store.get('encryptionKey', {})
+    kms_key_id = encryption_key.get('id', 'None')
+
+    # Stages
+    stages = pipeline.get('stages', [])
+    stage_count = len(stages)
+    stage_names = [s.get('name', 'N/A') for s in stages]
+    stages_str = ' → '.join(stage_names)
+
+    # Count actions across all stages
+    total_actions = sum(len(stage.get('actions', [])) for stage in stages)
+
+    # Get pipeline state for execution info (enrichment — degrades gracefully)
     try:
-        codepipeline_client = utils.get_boto3_client('codepipeline', region_name=region)
+        state_response = client.get_pipeline_state(name=pipeline_name)
 
-        # List all pipelines
-        paginator = codepipeline_client.get_paginator('list_pipelines')
-        for page in paginator.paginate():
-            pipeline_summaries = page.get('pipelines', [])
+        # Latest execution
+        stage_states = state_response.get('stageStates', [])
+        if stage_states:
+            latest_execution = stage_states[0].get('latestExecution', {})
+            latest_status = latest_execution.get('status', 'N/A')
+        else:
+            latest_status = 'No Executions'
 
-            for pipeline_summary in pipeline_summaries:
-                pipeline_name = pipeline_summary.get('name', 'N/A')
+    except Exception:
+        latest_status = 'Unknown'
 
-                # Get detailed pipeline information
-                try:
-                    pipeline_response = codepipeline_client.get_pipeline(name=pipeline_name)
-                    pipeline = pipeline_response.get('pipeline', {})
-                    metadata = pipeline_response.get('metadata', {})
+    return {
+        'Region': region,
+        'Pipeline Name': pipeline_name,
+        'ARN': arn,
+        'Version': version,
+        'Created': created,
+        'Updated': updated,
+        'Latest Status': latest_status,
+        'Stage Count': stage_count,
+        'Total Actions': total_actions,
+        'Stages': stages_str,
+        'Role ARN': role_arn,
+        'Artifact Store Type': artifact_type,
+        'Artifact Location': artifact_location,
+        'KMS Key ID': kms_key_id
+    }
 
-                    # Basic info
-                    arn = metadata.get('pipelineArn', 'N/A')
 
-                    created = pipeline_summary.get('created', metadata.get('created', 'N/A'))
-                    if created != 'N/A':
-                        created = created.strftime('%Y-%m-%d %H:%M:%S')
+def _scan_pipelines_region(region: str) -> list[dict[str, Any]]:
+    """
+    Scan a single region for CodePipeline pipelines.
 
-                    updated = pipeline_summary.get('updated', metadata.get('updated', 'N/A'))
-                    if updated != 'N/A':
-                        updated = updated.strftime('%Y-%m-%d %H:%M:%S')
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no pipelines" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
-                    # Version
-                    version = pipeline_summary.get('version', pipeline.get('version', 'N/A'))
+    Individual malformed/inaccessible pipelines are skipped (logged) rather
+    than aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
-                    # Role
-                    role_arn = pipeline.get('roleArn', 'N/A')
+    print(f"\nProcessing region: {region}")
 
-                    # Artifact store
-                    artifact_store = pipeline.get('artifactStore', {})
-                    artifact_type = artifact_store.get('type', 'N/A')
-                    artifact_location = artifact_store.get('location', 'N/A')
+    pipelines_data = []
+    codepipeline_client = utils.get_boto3_client('codepipeline', region_name=region)
 
-                    # Encryption key
-                    encryption_key = artifact_store.get('encryptionKey', {})
-                    kms_key_id = encryption_key.get('id', 'None')
+    # List all pipelines
+    paginator = codepipeline_client.get_paginator('list_pipelines')
+    for page in paginator.paginate():
+        pipeline_summaries = page.get('pipelines', [])
 
-                    # Stages
-                    stages = pipeline.get('stages', [])
-                    stage_count = len(stages)
-                    stage_names = [s.get('name', 'N/A') for s in stages]
-                    stages_str = ' → '.join(stage_names)
-
-                    # Count actions across all stages
-                    total_actions = sum(len(stage.get('actions', [])) for stage in stages)
-
-                    # Get pipeline state for execution info
-                    try:
-                        state_response = codepipeline_client.get_pipeline_state(name=pipeline_name)
-                        state = state_response
-
-                        # Latest execution
-                        stage_states = state.get('stageStates', [])
-                        if stage_states:
-                            latest_execution = stage_states[0].get('latestExecution', {})
-                            latest_status = latest_execution.get('status', 'N/A')
-                        else:
-                            latest_status = 'No Executions'
-
-                    except Exception:
-                        latest_status = 'Unknown'
-
-                    pipelines_data.append({
-                        'Region': region,
-                        'Pipeline Name': pipeline_name,
-                        'ARN': arn,
-                        'Version': version,
-                        'Created': created,
-                        'Updated': updated,
-                        'Latest Status': latest_status,
-                        'Stage Count': stage_count,
-                        'Total Actions': total_actions,
-                        'Stages': stages_str,
-                        'Role ARN': role_arn,
-                        'Artifact Store Type': artifact_type,
-                        'Artifact Location': artifact_location,
-                        'KMS Key ID': kms_key_id
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for pipeline {pipeline_name} in {region}: {str(e)}")
-                    continue
-
-    except Exception as e:
-        utils.log_error(f"Error scanning CodePipeline pipelines in {region}", e)
+        for pipeline_summary in pipeline_summaries:
+            pipeline_name = pipeline_summary.get('name', 'N/A')
+            try:
+                pipelines_data.append(
+                    _build_pipeline_row(codepipeline_client, pipeline_summary, region)
+                )
+            except Exception as e:
+                # One malformed/inaccessible pipeline is skipped, not fatal
+                # to the region.
+                utils.log_error(
+                    f"Skipping malformed CodePipeline pipeline in {region}: {pipeline_name}",
+                    e,
+                )
+                continue
 
     return pipelines_data
 
 
-@utils.aws_error_handler("Collecting CodePipeline pipelines", default_return=[])
-def collect_pipelines(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect CodePipeline pipeline information from AWS regions."""
-    results = utils.scan_regions_concurrent(regions, _scan_pipelines_region)
-    all_pipelines = [pipeline for result in results for pipeline in result]
+def collect_pipelines(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect CodePipeline pipeline information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(pipelines, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_pipelines_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_pipelines = [pipeline for result in region_results for pipeline in result]
     utils.log_success(f"Collected {len(all_pipelines)} CodePipeline pipelines")
-    return all_pipelines
+    return all_pipelines, failed_regions
 
 
 def _scan_executions_region(region: str) -> list[dict[str, Any]]:
@@ -388,7 +433,10 @@ def main():
     # Collect data
     print("\nCollecting AWS CodePipeline data...")
 
-    pipelines = collect_pipelines(regions)
+    # Pipelines are the primary scope: region failures must propagate as
+    # failed_regions, never collapse into "empty" (see the silent-collection
+    # -failure blast-radius audit).
+    pipelines, failed_regions = collect_pipelines(regions)
     executions = collect_executions(regions)
     webhooks = collect_webhooks(regions)
     summary = generate_summary(pipelines, executions, webhooks)
@@ -431,6 +479,19 @@ def main():
         utils.log_warning("No AWS CodePipeline data found to export")
 
     utils.log_success("AWS CodePipeline export completed successfully")
+
+    # If ANY region failed the primary Pipelines scope collection, make it
+    # loud: write a marker and exit non-zero, even though the Summary sheet
+    # always lands (this script forces a non-empty Summary regardless of
+    # data). A complete-looking workbook that silently hides a failed region
+    # is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'codepipeline', failed_regions)
+        print(
+            "\nERROR: CodePipeline export completed with failures — data is incomplete. "
+            "See the *-codepipeline-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/controltower_export.py
+++ b/scripts/controltower_export.py
@@ -23,6 +23,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from botocore.exceptions import ClientError
+
 try:
     import utils
 except ImportError:
@@ -34,9 +36,30 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Control Tower landing zone configuration to Excel")
 
-@utils.aws_error_handler("Collecting landing zone information", default_return={})
 def collect_landing_zone() -> dict[str, Any]:
-    """Collect AWS Control Tower landing zone information (global service)."""
+    """
+    Collect AWS Control Tower landing zone information (global service).
+
+    This is a PRIMARY, account-scope collector (see scripts/shield_export.py
+    / scripts/organizations_export.py for the account-scope reference
+    pattern). It does not swallow errors to an empty dict: a swallowed error
+    here would be indistinguishable from Control Tower simply not being set
+    up in this account, producing silent data loss (see the 07.15.2026 /
+    07.16.2026 silent-collection-failure audits). "No landing zone" /
+    AccessDenied on ListLandingZones is treated as the legitimate "Control
+    Tower not set up" state and returns ``{}`` gracefully. Any other
+    ClientError/exception is allowed to propagate so the caller (main) can
+    record this scope as *failed* rather than *empty*.
+
+    Returns:
+        dict: Landing zone information, or ``{}`` if Control Tower is not
+            set up in this account (a legitimate, non-failure state).
+
+    Raises:
+        Exception: Any real AWS/pagination error for the account scope
+            (caller records it as a failed scope; it is never masked as
+            empty).
+    """
     print("\n=== COLLECTING LANDING ZONE INFORMATION ===")
 
     # Control Tower is a global service - use partition-aware home region
@@ -44,62 +67,114 @@ def collect_landing_zone() -> dict[str, Any]:
     ct_client = utils.get_boto3_client('controltower', region_name=home_region)
 
     try:
-        # List landing zones
         landing_zones = ct_client.list_landing_zones()
-        lz_list = landing_zones.get('landingZones', [])
-
-        if not lz_list:
-            utils.log_warning("No landing zone found. Control Tower may not be set up.")
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code in ('AccessDeniedException', 'ResourceNotFoundException'):
+            utils.log_info(
+                f"Control Tower landing zone not accessible ({error_code}); "
+                "treating as 'not set up' in this account."
+            )
             return {}
+        raise
 
-        # Get details for the first (and typically only) landing zone
-        lz_arn = lz_list[0].get('arn', '')
+    lz_list = landing_zones.get('landingZones', [])
 
-        if not lz_arn:
-            utils.log_warning("Landing zone ARN not found")
-            return {}
-
-        # Get detailed landing zone information
-        lz_response = ct_client.get_landing_zone(landingZoneIdentifier=lz_arn)
-        lz_details = lz_response.get('landingZone', {})
-
-        # Parse manifest if available
-        manifest = lz_details.get('manifest', {})
-        if isinstance(manifest, str):
-            try:
-                manifest = json.loads(manifest)
-            except json.JSONDecodeError:
-                manifest = {'raw': manifest}
-
-        # Get governed regions
-        governed_regions = manifest.get('governedRegions', []) if isinstance(manifest, dict) else []
-
-        # Drift status
-        drift_status_summary = lz_details.get('driftStatus', {})
-        drift_status = drift_status_summary.get('status', 'N/A')
-
-        landing_zone_info = {
-            'ARN': lz_details.get('arn', 'N/A'),
-            'Version': lz_details.get('version', 'N/A'),
-            'Latest Available Version': lz_details.get('latestAvailableVersion', 'N/A'),
-            'Status': lz_details.get('status', 'N/A'),
-            'Drift Status': drift_status,
-            'Governed Regions': ', '.join(governed_regions) if governed_regions else 'N/A',
-            'Number of Governed Regions': len(governed_regions) if governed_regions else 0,
-            'Manifest': json.dumps(manifest, indent=2) if isinstance(manifest, dict) else str(manifest)
-        }
-
-        utils.log_success(f"Landing zone found: Version {landing_zone_info['Version']}, Status: {landing_zone_info['Status']}")
-        return landing_zone_info
-
-    except Exception as e:
-        utils.log_warning(f"Could not retrieve landing zone information: {str(e)}")
+    if not lz_list:
+        utils.log_warning("No landing zone found. Control Tower may not be set up.")
         return {}
 
+    # Get details for the first (and typically only) landing zone
+    lz_arn = lz_list[0].get('arn', '')
 
-@utils.aws_error_handler("Collecting organizational units", default_return=[])
+    if not lz_arn:
+        utils.log_warning("Landing zone ARN not found")
+        return {}
+
+    # Get detailed landing zone information. A failure past this point means
+    # a landing zone genuinely exists but we could not read it -- a real
+    # failure, not a "not set up" state.
+    lz_response = ct_client.get_landing_zone(landingZoneIdentifier=lz_arn)
+    lz_details = lz_response.get('landingZone', {})
+
+    # Parse manifest if available
+    manifest = lz_details.get('manifest', {})
+    if isinstance(manifest, str):
+        try:
+            manifest = json.loads(manifest)
+        except json.JSONDecodeError:
+            manifest = {'raw': manifest}
+
+    # Get governed regions
+    governed_regions = manifest.get('governedRegions', []) if isinstance(manifest, dict) else []
+
+    # Drift status
+    drift_status_summary = lz_details.get('driftStatus', {})
+    drift_status = drift_status_summary.get('status', 'N/A')
+
+    landing_zone_info = {
+        'ARN': lz_details.get('arn', 'N/A'),
+        'Version': lz_details.get('version', 'N/A'),
+        'Latest Available Version': lz_details.get('latestAvailableVersion', 'N/A'),
+        'Status': lz_details.get('status', 'N/A'),
+        'Drift Status': drift_status,
+        'Governed Regions': ', '.join(governed_regions) if governed_regions else 'N/A',
+        'Number of Governed Regions': len(governed_regions) if governed_regions else 0,
+        'Manifest': json.dumps(manifest, indent=2) if isinstance(manifest, dict) else str(manifest)
+    }
+
+    utils.log_success(f"Landing zone found: Version {landing_zone_info['Version']}, Status: {landing_zone_info['Status']}")
+    return landing_zone_info
+
+
+def _build_ou_row(ou: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single organizational unit.
+
+    Extracted so per-OU processing can be wrapped in try/except by the
+    caller: a malformed OU entry must not sink the whole recursive branch.
+    Required fields are read with ``.get()`` and a safe default for the
+    same reason.
+
+    Args:
+        ou: A single OrganizationalUnits entry from
+            list_organizational_units_for_parent.
+
+    Returns:
+        dict: The assembled OU row.
+    """
+    return {
+        'OU ID': ou.get('Id', 'N/A'),
+        'OU ARN': ou.get('Arn', 'N/A'),
+        'OU Name': ou.get('Name', 'N/A'),
+        'Type': 'Organizational Unit'
+    }
+
+
 def collect_organizational_units() -> list[dict[str, Any]]:
-    """Collect organizational units from AWS Organizations."""
+    """
+    Collect organizational units from AWS Organizations.
+
+    This is a PRIMARY, account-scope collector (see scripts/shield_export.py
+    / scripts/organizations_export.py for the account-scope reference
+    pattern). It does not swallow errors to an empty list: a swallowed error
+    here would be indistinguishable from an organization with no child OUs,
+    producing silent data loss (see the 07.15.2026 / 07.16.2026 silent-
+    collection-failure audits). AWS Organizations not being in use, or this
+    not being the management account, is a legitimate "not set up" state and
+    returns ``[]`` gracefully. Any other error (client creation, pagination)
+    is allowed to propagate so the caller (main) can record this scope as
+    *failed* rather than *empty*. A single malformed OU entry is logged and
+    skipped rather than aborting the whole branch.
+
+    Returns:
+        list: List of OU information dictionaries.
+
+    Raises:
+        Exception: Any real AWS/pagination error for the account scope
+            (caller records it as a failed scope; it is never masked as
+            empty).
+    """
     print("\n=== COLLECTING ORGANIZATIONAL UNITS ===")
     all_ous = []
 
@@ -107,49 +182,52 @@ def collect_organizational_units() -> list[dict[str, Any]]:
     org_client = utils.get_boto3_client('organizations')
 
     try:
-        # Get organization root
-        roots = org_client.list_roots()['Roots']
-        if not roots:
-            utils.log_warning("No organization root found")
+        roots = org_client.list_roots().get('Roots', [])
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code in ('AWSOrganizationsNotInUseException', 'AccessDeniedException'):
+            utils.log_info(
+                f"AWS Organizations not accessible ({error_code}); treating "
+                "as 'not set up' for Control Tower OU collection."
+            )
             return []
+        raise
 
-        root_id = roots[0]['Id']
-        root_arn = roots[0]['Arn']
+    if not roots:
+        utils.log_warning("No organization root found")
+        return []
 
-        # Add root to the list
-        all_ous.append({
-            'OU ID': root_id,
-            'OU ARN': root_arn,
-            'OU Name': roots[0]['Name'],
-            'Type': 'Root'
-        })
+    root = roots[0]
+    root_id = root.get('Id', 'N/A')
+    root_arn = root.get('Arn', 'N/A')
 
-        # List OUs recursively
-        def list_ous_recursive(parent_id):
-            try:
-                paginator = org_client.get_paginator('list_organizational_units_for_parent')
-                for page in paginator.paginate(ParentId=parent_id):
-                    for ou in page.get('OrganizationalUnits', []):
-                        ou_id = ou.get('Id', 'N/A')
-                        ou_arn = ou.get('Arn', 'N/A')
-                        ou_name = ou.get('Name', 'N/A')
+    # Add root to the list
+    all_ous.append({
+        'OU ID': root_id,
+        'OU ARN': root_arn,
+        'OU Name': root.get('Name', 'N/A'),
+        'Type': 'Root'
+    })
 
-                        all_ous.append({
-                            'OU ID': ou_id,
-                            'OU ARN': ou_arn,
-                            'OU Name': ou_name,
-                            'Type': 'Organizational Unit'
-                        })
+    # List OUs recursively. Pagination errors propagate to the caller (the
+    # recursion is part of this PRIMARY scope); only a single malformed OU
+    # entry is contained.
+    def list_ous_recursive(parent_id):
+        paginator = org_client.get_paginator('list_organizational_units_for_parent')
+        for page in paginator.paginate(ParentId=parent_id):
+            for ou in page.get('OrganizationalUnits', []):
+                try:
+                    ou_row = _build_ou_row(ou)
+                except Exception as e:
+                    ou_id = ou.get('Id', 'Unknown') if isinstance(ou, dict) else 'Unknown'
+                    utils.log_error(f"Skipping malformed OU '{ou_id}' due to a processing error", e)
+                    continue
 
-                        # Recursively list child OUs
-                        list_ous_recursive(ou_id)
-            except Exception as e:
-                utils.log_warning(f"Error listing OUs for parent {parent_id}: {str(e)}")
+                all_ous.append(ou_row)
+                # Recursively list child OUs
+                list_ous_recursive(ou_row['OU ID'])
 
-        list_ous_recursive(root_id)
-
-    except Exception as e:
-        utils.log_warning(f"Error collecting organizational units: {str(e)}")
+    list_ous_recursive(root_id)
 
     utils.log_success(f"Total organizational units collected: {len(all_ous)}")
     return all_ous
@@ -223,9 +301,159 @@ def extract_service_from_control_identifier(control_id: str) -> str:
         return 'Other'
 
 
-@utils.aws_error_handler("Collecting enabled controls", default_return=[])
+def _build_control_row(
+    control: dict[str, Any],
+    ou_name: str,
+    ou_arn: str,
+    ct_client,
+    catalog_client,
+) -> dict[str, Any]:
+    """
+    Build the export row for a single enabled control.
+
+    Extracted so per-control processing can be wrapped in try/except by the
+    caller: a malformed control entry must not sink the whole OU's control
+    listing. Required fields are read with ``.get()`` and a safe default for
+    the same reason. Enrichment calls (GetEnabledControl parameters, control
+    catalog metadata) are contained internally and degrade to 'N/A'/'None'
+    on failure -- they are not treated as scope failures.
+
+    Args:
+        control: A single enabledControls entry from list_enabled_controls.
+        ou_name: Name of the OU this control belongs to.
+        ou_arn: ARN of the OU this control belongs to.
+        ct_client: The boto3 Control Tower client.
+        catalog_client: The boto3 Control Catalog client.
+
+    Returns:
+        dict: The assembled control row.
+    """
+    control_id = control.get('controlIdentifier', 'N/A')
+    control_arn = control.get('arn', 'N/A')
+
+    # Status summary
+    status_summary = control.get('statusSummary', {})
+    status = status_summary.get('status', 'N/A')
+    last_operation = status_summary.get('lastOperationIdentifier', 'N/A')
+
+    # Drift status
+    drift_summary = control.get('driftStatusSummary', {})
+    drift_status = drift_summary.get('driftStatus', 'N/A')
+
+    # Drift types
+    drift_types = drift_summary.get('types', {})
+    inheritance_drift = drift_types.get('inheritance', {}).get('status', 'N/A')
+    resource_drift = drift_types.get('resource', {}).get('status', 'N/A')
+
+    # Initialize control metadata
+    control_name = control_id  # Default to identifier
+    control_description = 'N/A'
+    control_behavior = 'N/A'
+    control_guidance = 'N/A'
+    service_name = 'N/A'
+    params_str = 'None'
+
+    try:
+        # Get control details from GetEnabledControl for parameters
+        enabled_control_details = ct_client.get_enabled_control(
+            enabledControlIdentifier=control_arn
+        )
+
+        enabled_control = enabled_control_details.get('enabledControlDetails', {})
+
+        # Get parameters if available
+        parameters = enabled_control.get('parameters', [])
+        if parameters:
+            params_list = []
+            for param in parameters:
+                key = param.get('key', '')
+                value = param.get('value', '')
+                if key and value:
+                    params_list.append(f"{key}: {value}")
+            params_str = ', '.join(params_list) if params_list else 'None'
+
+    except Exception as e:
+        utils.log_warning(f"Could not get enabled control details for {control_id}: {str(e)}")
+
+    # Try to get control metadata from control catalog
+    try:
+        # Use controlcatalog client to get full metadata
+        catalog_response = catalog_client.get_control(ControlArn=control_id)
+
+        # Extract metadata from control catalog response
+        control_name = catalog_response.get('Name', control_id)
+        control_description = catalog_response.get('Description', 'N/A')
+        control_behavior = catalog_response.get('Behavior', 'N/A')
+
+        # Control catalog doesn't have "Guidance" field - this is Control Tower specific
+        # We'll need to infer it or mark as N/A
+        control_guidance = 'N/A'
+
+        # Extract service from aliases if available
+        aliases = catalog_response.get('Aliases', [])
+        if aliases:
+            # Aliases often have format like "CT.S3.PR.1" or "SH.S3.1"
+            for alias in aliases:
+                if '.' in alias:
+                    parts = alias.split('.')
+                    if len(parts) >= 2:
+                        service_name = parts[1]  # e.g., "S3" from "CT.S3.PR.1"
+                        break
+
+        # If service not found from alias, try extracting from control identifier
+        if service_name == 'N/A':
+            service_name = extract_service_from_control_identifier(control_id)
+
+    except Exception as e:
+        # Fallback: try extracting service from identifier even if catalog call fails
+        service_name = extract_service_from_control_identifier(control_id)
+        utils.log_warning(f"Could not get catalog details for control {control_id}: {str(e)}")
+
+    return {
+        'OU Name': ou_name,
+        'OU ARN': ou_arn,
+        'Control Identifier': control_id,
+        'Service': service_name,
+        'Control Name': control_name,
+        'Control ARN': control_arn,
+        'Status': status,
+        'Drift Status': drift_status,
+        'Inheritance Drift': inheritance_drift,
+        'Resource Drift': resource_drift,
+        'Behavior': control_behavior,
+        'Guidance': control_guidance,
+        'Description': control_description,
+        'Parameters': params_str,
+        'Last Operation ID': last_operation
+    }
+
+
 def collect_enabled_controls(ous: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collect enabled controls for all organizational units."""
+    """
+    Collect enabled controls for all organizational units.
+
+    This is a PRIMARY, account-scope collector (see scripts/shield_export.py
+    / scripts/organizations_export.py for the account-scope reference
+    pattern). It does not swallow errors to an empty list: a swallowed
+    client-creation or pagination-setup error here would be indistinguishable
+    from an account with no enabled controls, producing silent data loss
+    (see the 07.15.2026 / 07.16.2026 silent-collection-failure audits).
+    Per-OU listing failures are logged and skipped (one OU's throttling/API
+    error does not sink the whole account's control inventory); a single
+    malformed control entry is likewise logged and skipped.
+
+    Args:
+        ous: List of OU information dictionaries from
+            collect_organizational_units().
+
+    Returns:
+        list: List of enabled control dictionaries.
+
+    Raises:
+        Exception: Any real AWS error setting up the account-scope clients
+            (caller records it as a failed scope; it is never masked as
+            empty).
+    """
     print("\n=== COLLECTING ENABLED CONTROLS ===")
     all_controls = []
 
@@ -260,104 +488,14 @@ def collect_enabled_controls(ous: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 enabled_controls = page.get('enabledControls', [])
 
                 for control in enabled_controls:
-                    control_id = control.get('controlIdentifier', 'N/A')
-                    control_arn = control.get('arn', 'N/A')
-
-                    # Status summary
-                    status_summary = control.get('statusSummary', {})
-                    status = status_summary.get('status', 'N/A')
-                    last_operation = status_summary.get('lastOperationIdentifier', 'N/A')
-
-                    # Drift status
-                    drift_summary = control.get('driftStatusSummary', {})
-                    drift_status = drift_summary.get('driftStatus', 'N/A')
-
-                    # Drift types
-                    drift_types = drift_summary.get('types', {})
-                    inheritance_drift = drift_types.get('inheritance', {}).get('status', 'N/A')
-                    resource_drift = drift_types.get('resource', {}).get('status', 'N/A')
-
-                    # Initialize control metadata
-                    control_name = control_id  # Default to identifier
-                    control_description = 'N/A'
-                    control_behavior = 'N/A'
-                    control_guidance = 'N/A'
-                    service_name = 'N/A'
-                    params_str = 'None'
-
                     try:
-                        # Get control details from GetEnabledControl for parameters
-                        enabled_control_details = ct_client.get_enabled_control(
-                            enabledControlIdentifier=control_arn
-                        )
-
-                        enabled_control = enabled_control_details.get('enabledControlDetails', {})
-
-                        # Get parameters if available
-                        parameters = enabled_control.get('parameters', [])
-                        if parameters:
-                            params_list = []
-                            for param in parameters:
-                                key = param.get('key', '')
-                                value = param.get('value', '')
-                                if key and value:
-                                    params_list.append(f"{key}: {value}")
-                            params_str = ', '.join(params_list) if params_list else 'None'
-
+                        control_row = _build_control_row(control, ou_name, ou_arn, ct_client, catalog_client)
                     except Exception as e:
-                        utils.log_warning(f"Could not get enabled control details for {control_id}: {str(e)}")
+                        control_id = control.get('controlIdentifier', 'Unknown') if isinstance(control, dict) else 'Unknown'
+                        utils.log_error(f"Skipping control '{control_id}' for OU {ou_name} due to a processing error", e)
+                        continue
 
-                    # Try to get control metadata from control catalog
-                    try:
-                        # Use controlcatalog client to get full metadata
-                        catalog_response = catalog_client.get_control(ControlArn=control_id)
-
-                        # Extract metadata from control catalog response
-                        control_name = catalog_response.get('Name', control_id)
-                        control_description = catalog_response.get('Description', 'N/A')
-                        control_behavior = catalog_response.get('Behavior', 'N/A')
-
-                        # Control catalog doesn't have "Guidance" field - this is Control Tower specific
-                        # We'll need to infer it or mark as N/A
-                        control_guidance = 'N/A'
-
-                        # Extract service from aliases if available
-                        aliases = catalog_response.get('Aliases', [])
-                        if aliases:
-                            # Aliases often have format like "CT.S3.PR.1" or "SH.S3.1"
-                            for alias in aliases:
-                                if '.' in alias:
-                                    parts = alias.split('.')
-                                    if len(parts) >= 2:
-                                        service_name = parts[1]  # e.g., "S3" from "CT.S3.PR.1"
-                                        break
-
-                        # If service not found from alias, try extracting from control identifier
-                        if service_name == 'N/A':
-                            service_name = extract_service_from_control_identifier(control_id)
-
-                    except Exception as e:
-                        # Fallback: try extracting service from identifier even if catalog call fails
-                        service_name = extract_service_from_control_identifier(control_id)
-                        utils.log_warning(f"Could not get catalog details for control {control_id}: {str(e)}")
-
-                    all_controls.append({
-                        'OU Name': ou_name,
-                        'OU ARN': ou_arn,
-                        'Control Identifier': control_id,
-                        'Service': service_name,
-                        'Control Name': control_name,
-                        'Control ARN': control_arn,
-                        'Status': status,
-                        'Drift Status': drift_status,
-                        'Inheritance Drift': inheritance_drift,
-                        'Resource Drift': resource_drift,
-                        'Behavior': control_behavior,
-                        'Guidance': control_guidance,
-                        'Description': control_description,
-                        'Parameters': params_str,
-                        'Last Operation ID': last_operation
-                    })
+                    all_controls.append(control_row)
 
         except Exception as e:
             utils.log_warning(f"Error listing controls for OU {ou_name}: {str(e)}")
@@ -458,7 +596,25 @@ def generate_summary(landing_zone: dict[str, Any],
 
 
 def main():
-    """Main execution function."""
+    """
+    Main execution function.
+
+    AWS Control Tower is a global, account-scope service run from the
+    management account (there is no region scan) -- failures are tracked
+    per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py /
+    scripts/organizations_export.py for the account-scope reference
+    pattern). Control Tower not being set up in this account (no landing
+    zone found, AccessDenied on ListLandingZones) is a legitimate, graceful
+    "service not enabled" state (exit 0, no marker) -- handled by
+    ``collect_landing_zone()`` -- and must not be confused with a real
+    collection failure on the landing-zone, organizational-units, or
+    enabled-controls scopes, which are exported as a partial result
+    (whatever succeeded, plus the always-written Summary sheet) and always
+    surfaced via ``utils.report_collection_failures`` + a non-zero exit. A
+    failed scope must never be silently collapsed into "nothing to report"
+    (07.15.2026 / 07.16.2026 audits).
+    """
     if not utils.ensure_dependencies('pandas', 'openpyxl'):
         return
     global pd
@@ -495,20 +651,59 @@ def main():
     # Collect data
     print("\nCollecting AWS Control Tower configuration...")
 
-    landing_zone = collect_landing_zone()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
 
-    if not landing_zone:
-        utils.log_warning("No Control Tower landing zone found. Exiting.")
+    # PRIMARY scope 1/3: landing zone. A real API error here must propagate
+    # to failed_scopes, never collapse into "Control Tower not set up".
+    try:
+        landing_zone = collect_landing_zone()
+    except Exception as e:
+        failed_scopes.append(('landing-zone', str(e)))
+        utils.log_error(f"Control Tower landing zone collection failed: {e}")
+        landing_zone = {}
+
+    if not landing_zone and not failed_scopes:
+        # Genuine not-set-up state: Control Tower has no landing zone in
+        # this account and the collection itself succeeded (no error).
+        # Nothing to export; not a failure.
+        utils.log_warning(
+            "No Control Tower landing zone found. Control Tower is not set "
+            "up in this account. Exiting."
+        )
         return
 
-    ous = collect_organizational_units()
-    controls = collect_enabled_controls(ous)
+    # PRIMARY scope 2/3: organizational units.
+    try:
+        ous = collect_organizational_units()
+    except Exception as e:
+        failed_scopes.append(('organizational-units', str(e)))
+        utils.log_error(f"Organizational units collection failed: {e}")
+        ous = []
+
+    # PRIMARY scope 3/3: enabled controls.
+    try:
+        controls = collect_enabled_controls(ous)
+    except Exception as e:
+        failed_scopes.append(('enabled-controls', str(e)))
+        utils.log_error(f"Enabled controls collection failed: {e}")
+        controls = []
+
     # Create DataFrames
     utils.log_info("Creating DataFrames...")
 
     dataframes = {}
 
-    # Add Enabled Controls first (user preference)
+    # Summary sheet is ALWAYS written once we reach this point (Control
+    # Tower confirmed set up, or a real failure occurred on a scope) -- a
+    # workbook must always land so a failed/partial export is never
+    # mistaken for "nothing to report" (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    summary_rows = generate_summary(landing_zone, ous, controls)
+    if summary_rows:
+        dataframes['Summary'] = pd.DataFrame(summary_rows)
+
+    # Add Enabled Controls next (user preference)
     if controls:
         df_controls = pd.DataFrame(controls)
 
@@ -553,7 +748,9 @@ def main():
         df_ous = utils.prepare_dataframe_for_export(df_ous)
         dataframes['Organizational Units'] = df_ous
 
-    # Export to Excel
+    # Export to Excel. Whatever succeeded is exported -- a partial export
+    # (Summary + any scopes that succeeded) is required even when some
+    # scopes failed.
     if dataframes:
         filename = utils.create_export_filename(account_name, 'controltower', 'global')
 
@@ -563,8 +760,26 @@ def main():
         # Log summary using correct function signature
         total_resources = len(controls)
         utils.log_export_summary('Control Tower Resources', total_resources, filename)
-    else:
+    elif not failed_scopes:
+        # Genuinely empty: every scope succeeded and there is simply
+        # nothing to export (should not normally happen since Summary is
+        # always populated, but guarded defensively).
         utils.log_warning("No Control Tower data found to export")
+    else:
+        utils.log_error("Control Tower export failed to produce any data.")
+
+    # If any primary scope failed, make it loud: write a marker and exit
+    # non-zero, even though a partial export (Summary + whatever succeeded)
+    # was written. A partial export that looks complete is exactly the
+    # failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'controltower', failed_scopes)
+        print(
+            "\nERROR: Control Tower export completed with failures — data is "
+            "incomplete. See the *-controltower-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Control Tower export completed successfully")
 

--- a/scripts/service_catalog_export.py
+++ b/scripts/service_catalog_export.py
@@ -38,85 +38,212 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Service Catalog portfolios and products to Excel")
 
-@utils.aws_error_handler("Listing portfolios", default_return=[])
-def list_portfolios(region: str) -> list[dict[str, Any]]:
-    """List all portfolios."""
+
+def _build_portfolio_row(portfolio: dict, region: str) -> dict[str, Any]:
+    """Build a single portfolio export row from a list_portfolios item."""
+    return {
+        'Region': region,
+        'PortfolioId': portfolio.get('Id', 'N/A'),
+        'PortfolioARN': portfolio.get('ARN', 'N/A'),
+        'DisplayName': portfolio.get('DisplayName', 'N/A'),
+        'Description': portfolio.get('Description', 'N/A'),
+        'ProviderName': portfolio.get('ProviderName', 'N/A'),
+        'CreatedTime': portfolio.get('CreatedTime'),
+    }
+
+
+def _scan_portfolios_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Service Catalog portfolios from a single region.
+
+    This is one of the primary scope collectors. It deliberately does NOT
+    swallow errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no portfolios" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed portfolios are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     sc = utils.get_boto3_client('servicecatalog', region_name=region)
     portfolios = []
 
     paginator = sc.get_paginator('list_portfolios')
     for page in paginator.paginate():
         for portfolio in page.get('PortfolioDetails', []):
-            portfolios.append({
-                'Region': region,
-                'PortfolioId': portfolio.get('Id', 'N/A'),
-                'PortfolioARN': portfolio.get('ARN', 'N/A'),
-                'DisplayName': portfolio.get('DisplayName', 'N/A'),
-                'Description': portfolio.get('Description', 'N/A'),
-                'ProviderName': portfolio.get('ProviderName', 'N/A'),
-                'CreatedTime': portfolio.get('CreatedTime'),
-            })
+            try:
+                portfolios.append(_build_portfolio_row(portfolio, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed portfolio in {region}: "
+                    f"{portfolio.get('Id', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return portfolios
 
 
-@utils.aws_error_handler("Searching products as admin", default_return=[])
-def search_products_as_admin(region: str) -> list[dict[str, Any]]:
-    """Search all products as admin."""
+def collect_portfolios(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Service Catalog portfolios across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(portfolios, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_portfolios_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_portfolios = [p for result in region_results for p in result]
+    return all_portfolios, failed_regions
+
+
+def _build_product_row(product: dict, region: str) -> dict[str, Any]:
+    """Build a single product export row from a search_products_as_admin item."""
+    product_view = product.get('ProductViewSummary', {})
+    product_arn = product.get('ProductARN', 'N/A')
+
+    return {
+        'Region': region,
+        'ProductId': product_view.get('ProductId', 'N/A'),
+        'ProductARN': product_arn,
+        'Name': product_view.get('Name', 'N/A'),
+        'ShortDescription': product_view.get('ShortDescription', 'N/A'),
+        'Type': product_view.get('Type', 'N/A'),
+        'Owner': product_view.get('Owner', 'N/A'),
+        'Distributor': product_view.get('Distributor', 'N/A'),
+        'SupportDescription': product_view.get('SupportDescription', 'N/A'),
+        'SupportEmail': product_view.get('SupportEmail', 'N/A'),
+        'SupportUrl': product_view.get('SupportUrl', 'N/A'),
+    }
+
+
+def _scan_products_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Service Catalog products (as admin) from a single region.
+
+    Primary scope collector — see ``_scan_portfolios_region`` docstring for
+    the no-swallow contract this follows.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     sc = utils.get_boto3_client('servicecatalog', region_name=region)
     products = []
 
     paginator = sc.get_paginator('search_products_as_admin')
     for page in paginator.paginate():
         for product in page.get('ProductViewDetails', []):
-            product_view = product.get('ProductViewSummary', {})
-            product_arn = product.get('ProductARN', 'N/A')
-
-            products.append({
-                'Region': region,
-                'ProductId': product_view.get('ProductId', 'N/A'),
-                'ProductARN': product_arn,
-                'Name': product_view.get('Name', 'N/A'),
-                'ShortDescription': product_view.get('ShortDescription', 'N/A'),
-                'Type': product_view.get('Type', 'N/A'),
-                'Owner': product_view.get('Owner', 'N/A'),
-                'Distributor': product_view.get('Distributor', 'N/A'),
-                'SupportDescription': product_view.get('SupportDescription', 'N/A'),
-                'SupportEmail': product_view.get('SupportEmail', 'N/A'),
-                'SupportUrl': product_view.get('SupportUrl', 'N/A'),
-            })
+            try:
+                products.append(_build_product_row(product, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed product in {region}: "
+                    f"{product.get('ProductARN', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return products
 
 
-@utils.aws_error_handler("Scanning provisioned products", default_return=[])
-def scan_provisioned_products(region: str) -> list[dict[str, Any]]:
-    """Scan all provisioned products."""
+def collect_products(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Service Catalog products across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(products, failed_regions)`` — see ``collect_portfolios``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_products_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_products = [p for result in region_results for p in result]
+    return all_products, failed_regions
+
+
+def _build_provisioned_product_row(product: dict, region: str) -> dict[str, Any]:
+    """Build a single provisioned-product export row from a scan_provisioned_products item."""
+    return {
+        'Region': region,
+        'ProvisionedProductId': product.get('Id', 'N/A'),
+        'ProvisionedProductARN': product.get('Arn', 'N/A'),
+        'Name': product.get('Name', 'N/A'),
+        'Type': product.get('Type', 'N/A'),
+        'Status': product.get('Status', 'N/A'),
+        'StatusMessage': product.get('StatusMessage', 'N/A'),
+        'CreatedTime': product.get('CreatedTime'),
+        'LastRecordId': product.get('LastRecordId', 'N/A'),
+        'ProductId': product.get('ProductId', 'N/A'),
+        'ProductName': product.get('ProductName', 'N/A'),
+        'ProvisioningArtifactId': product.get('ProvisioningArtifactId', 'N/A'),
+        'ProvisioningArtifactName': product.get('ProvisioningArtifactName', 'N/A'),
+        'UserArn': product.get('UserArn', 'N/A'),
+        'UserArnSession': product.get('UserArnSession', 'N/A'),
+    }
+
+
+def _scan_provisioned_products_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Service Catalog provisioned products from a single region.
+
+    Primary scope collector — see ``_scan_portfolios_region`` docstring for
+    the no-swallow contract this follows.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     sc = utils.get_boto3_client('servicecatalog', region_name=region)
     provisioned = []
 
     paginator = sc.get_paginator('scan_provisioned_products')
     for page in paginator.paginate():
         for product in page.get('ProvisionedProducts', []):
-            provisioned.append({
-                'Region': region,
-                'ProvisionedProductId': product.get('Id', 'N/A'),
-                'ProvisionedProductARN': product.get('Arn', 'N/A'),
-                'Name': product.get('Name', 'N/A'),
-                'Type': product.get('Type', 'N/A'),
-                'Status': product.get('Status', 'N/A'),
-                'StatusMessage': product.get('StatusMessage', 'N/A'),
-                'CreatedTime': product.get('CreatedTime'),
-                'LastRecordId': product.get('LastRecordId', 'N/A'),
-                'ProductId': product.get('ProductId', 'N/A'),
-                'ProductName': product.get('ProductName', 'N/A'),
-                'ProvisioningArtifactId': product.get('ProvisioningArtifactId', 'N/A'),
-                'ProvisioningArtifactName': product.get('ProvisioningArtifactName', 'N/A'),
-                'UserArn': product.get('UserArn', 'N/A'),
-                'UserArnSession': product.get('UserArnSession', 'N/A'),
-            })
+            try:
+                provisioned.append(_build_provisioned_product_row(product, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed provisioned product in {region}: "
+                    f"{product.get('Id', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return provisioned
+
+
+def collect_provisioned_products(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Service Catalog provisioned products across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(provisioned_products, failed_regions)`` — see ``collect_portfolios``.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_provisioned_products_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_provisioned = [p for result in region_results for p in result]
+    return all_provisioned, failed_regions
 
 
 @utils.aws_error_handler("Listing provisioning artifacts", default_return=[])
@@ -172,44 +299,48 @@ def list_portfolio_principals(region: str, portfolio_id: str) -> list[dict[str, 
 
 def _run_export(account_id: str, account_name: str, regions: list) -> None:
     """Collect Service Catalog data and write the Excel export."""
-    all_portfolios = []
-    all_products = []
-    all_provisioned = []
-    all_artifacts = []
-    all_principals = []
+    # STEP 1: Collect the primary scopes (portfolios, products, provisioned
+    # products). Each is routed through scan_regions_concurrent with
+    # collect_failures=True so a region that errors is recorded as failed
+    # rather than silently collapsed into "empty" — see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md.
+    failed_regions: list = []
 
-    for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
+    utils.log_info("=== COLLECTING PORTFOLIOS ===")
+    all_portfolios, portfolio_failures = collect_portfolios(regions)
+    utils.log_success(f"Total portfolios collected: {len(all_portfolios)}")
+    failed_regions.extend(portfolio_failures)
 
-        # Collect portfolios
-        portfolios = list_portfolios(region)
-        if portfolios:
-            utils.log_info(f"  Found {len(portfolios)} portfolio(s)")
-            all_portfolios.extend(portfolios)
+    utils.log_info("=== COLLECTING PRODUCTS ===")
+    all_products, product_failures = collect_products(regions)
+    utils.log_success(f"Total products collected: {len(all_products)}")
+    failed_regions.extend(product_failures)
 
-            # Collect principals for each portfolio
-            for portfolio in portfolios:
-                portfolio_id = portfolio['PortfolioId']
-                principals = list_portfolio_principals(region, portfolio_id)
-                all_principals.extend(principals)
+    utils.log_info("=== COLLECTING PROVISIONED PRODUCTS ===")
+    all_provisioned, provisioned_failures = collect_provisioned_products(regions)
+    utils.log_success(f"Total provisioned products collected: {len(all_provisioned)}")
+    failed_regions.extend(provisioned_failures)
 
-        # Collect products
-        products = search_products_as_admin(region)
-        if products:
-            utils.log_info(f"  Found {len(products)} product(s)")
-            all_products.extend(products)
+    # STEP 2: Secondary, best-effort detail (per-portfolio/per-product lookups).
+    # These are not primary scopes — a failure here is logged and skipped
+    # rather than tracked as a failed region.
+    all_principals: list[dict[str, Any]] = []
+    for portfolio in all_portfolios:
+        portfolio_id = portfolio.get('PortfolioId')
+        portfolio_region = portfolio.get('Region')
+        if not portfolio_id or portfolio_id == 'N/A' or not portfolio_region:
+            continue
+        principals = list_portfolio_principals(portfolio_region, portfolio_id)
+        all_principals.extend(principals)
 
-            # Collect artifacts for each product (sample first 10)
-            for product in products[:10]:
-                product_id = product['ProductId']
-                artifacts = list_provisioning_artifacts(region, product_id)
-                all_artifacts.extend(artifacts)
-
-        # Collect provisioned products
-        provisioned = scan_provisioned_products(region)
-        if provisioned:
-            utils.log_info(f"  Found {len(provisioned)} provisioned product(s)")
-            all_provisioned.extend(provisioned)
+    all_artifacts: list[dict[str, Any]] = []
+    for product in all_products[:10]:
+        product_id = product.get('ProductId')
+        product_region = product.get('Region')
+        if not product_id or product_id == 'N/A' or not product_region:
+            continue
+        artifacts = list_provisioning_artifacts(product_region, product_id)
+        all_artifacts.extend(artifacts)
 
     if not all_portfolios and not all_products:
         utils.log_warning("No Service Catalog portfolios or products found in any selected region.")
@@ -226,7 +357,9 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     df_artifacts = utils.prepare_dataframe_for_export(pd.DataFrame(all_artifacts))
     df_principals = utils.prepare_dataframe_for_export(pd.DataFrame(all_principals))
 
-    # Create summary
+    # Create summary — this sheet is ALWAYS written, even when collection
+    # partially failed, so a workbook always lands. Failure signaling is
+    # handled separately via the FAILED marker + non-zero exit below.
     summary_data = []
     summary_data.append({'Metric': 'Total Portfolios', 'Value': len(all_portfolios)})
     summary_data.append({'Metric': 'Total Products', 'Value': len(all_products)})
@@ -270,6 +403,19 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     utils.log_info(f"  Provisioned Products: {len(all_provisioned)}")
 
     utils.log_success("Service Catalog export completed successfully!")
+
+    # If ANY primary scope failed collection in any region, make it loud: a
+    # workbook always landed above (Summary sheet is always written), but a
+    # partial export that looks complete is exactly the failure mode this
+    # guards against. Write a marker and exit non-zero. A genuinely empty
+    # account (no failures, no data) stays exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'service-catalog', failed_regions)
+        print(
+            "\nERROR: Service Catalog export completed with failures — data is incomplete. "
+            "See the *-service-catalog-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/stepfunctions_export.py
+++ b/scripts/stepfunctions_export.py
@@ -30,84 +30,134 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Step Functions state machines to Excel")
 
-def _scan_state_machines_region(region: str) -> list[dict[str, Any]]:
-    """Scan a single region for Step Functions state machines."""
-    state_machines_data = []
+def _build_state_machine_row(sm_summary: dict[str, Any], region: str, sfn_client) -> dict[str, Any]:
+    """
+    Build a single Step Functions state machine export row.
+
+    Extracted so the per-item processing can be wrapped in try/except by the
+    caller: a malformed/unexpected state machine entry is logged and skipped
+    rather than discarding the whole region's results. Every field is read
+    with ``.get()`` — a hard subscript (e.g. ``sm['X-Ray Tracing']``) on a
+    divergent resource variant is exactly the RDS-Custom failure mode from
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``.
+    """
+    state_machine_arn = sm_summary.get('stateMachineArn', 'N/A')
+    name = sm_summary.get('name', 'N/A')
+    sm_type = sm_summary.get('type', 'N/A')
+
+    creation_date = sm_summary.get('creationDate')
+    creation_date_str = creation_date.strftime('%Y-%m-%d %H:%M:%S') if creation_date else 'N/A'
 
     try:
-        sfn_client = utils.get_boto3_client('stepfunctions', region_name=region)
-        paginator = sfn_client.get_paginator('list_state_machines')
+        sm_response = sfn_client.describe_state_machine(stateMachineArn=state_machine_arn)
+        role_arn = sm_response.get('roleArn', 'N/A')
+        role_name = role_arn.split('/')[-1] if role_arn != 'N/A' and '/' in role_arn else 'N/A'
 
-        for page in paginator.paginate():
-            for sm_summary in page.get('stateMachines', []):
-                state_machine_arn = sm_summary.get('stateMachineArn', 'N/A')
-                name = sm_summary.get('name', 'N/A')
-                sm_type = sm_summary.get('type', 'N/A')
+        definition = sm_response.get('definition', 'N/A')
+        state_count = 'N/A'
+        try:
+            if definition != 'N/A':
+                definition_json = json.loads(definition)
+                state_count = len(definition_json.get('States', {}))
+        except Exception:
+            state_count = 'Parse Error'
 
-                creation_date = sm_summary.get('creationDate')
-                creation_date_str = creation_date.strftime('%Y-%m-%d %H:%M:%S') if creation_date else 'N/A'
+        logging_config = sm_response.get('loggingConfiguration', {})
+        log_destinations = logging_config.get('destinations', [])
+        log_groups = []
+        for dest in log_destinations:
+            arn = dest.get('cloudWatchLogsLogGroup', {}).get('logGroupArn', '')
+            if ':log-group:' in arn:
+                log_groups.append(arn.split(':log-group:')[-1].split(':')[0])
 
-                try:
-                    sm_response = sfn_client.describe_state_machine(stateMachineArn=state_machine_arn)
-                    role_arn = sm_response.get('roleArn', 'N/A')
-                    role_name = role_arn.split('/')[-1] if role_arn != 'N/A' and '/' in role_arn else 'N/A'
+        tracing_config = sm_response.get('tracingConfiguration', {})
 
-                    definition = sm_response.get('definition', 'N/A')
-                    state_count = 'N/A'
-                    try:
-                        if definition != 'N/A':
-                            definition_json = json.loads(definition)
-                            state_count = len(definition_json.get('States', {}))
-                    except Exception:
-                        state_count = 'Parse Error'
-
-                    logging_config = sm_response.get('loggingConfiguration', {})
-                    log_destinations = logging_config.get('destinations', [])
-                    log_groups = []
-                    for dest in log_destinations:
-                        arn = dest.get('cloudWatchLogsLogGroup', {}).get('logGroupArn', '')
-                        if ':log-group:' in arn:
-                            log_groups.append(arn.split(':log-group:')[-1].split(':')[0])
-
-                    tracing_config = sm_response.get('tracingConfiguration', {})
-
-                    state_machines_data.append({
-                        'Region': region,
-                        'State Machine Name': name,
-                        'Type': sm_type,
-                        'Status': sm_response.get('status', 'N/A'),
-                        'Role': role_name,
-                        'State Count': state_count,
-                        'Logging Level': logging_config.get('level', 'OFF'),
-                        'Include Execution Data': 'Yes' if logging_config.get('includeExecutionData', False) else 'No',
-                        'Log Groups': ', '.join(log_groups) if log_groups else 'None',
-                        'X-Ray Tracing': 'Enabled' if tracing_config.get('enabled', False) else 'Disabled',
-                        'Label': sm_response.get('label', 'N/A'),
-                        'Created': creation_date_str,
-                        'ARN': state_machine_arn,
-                    })
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for state machine {name}: {str(e)}")
-                    state_machines_data.append({
-                        'Region': region, 'State Machine Name': name, 'Type': sm_type,
-                        'Status': 'Unknown', 'Role': 'N/A', 'State Count': 'N/A',
-                        'Logging Level': 'N/A', 'Include Execution Data': 'N/A',
-                        'Log Groups': 'N/A', 'X-Ray Tracing': 'N/A', 'Label': 'N/A',
-                        'Created': creation_date_str, 'ARN': state_machine_arn,
-                    })
+        return {
+            'Region': region,
+            'State Machine Name': name,
+            'Type': sm_type,
+            'Status': sm_response.get('status', 'N/A'),
+            'Role': role_name,
+            'State Count': state_count,
+            'Logging Level': logging_config.get('level', 'OFF'),
+            'Include Execution Data': 'Yes' if logging_config.get('includeExecutionData', False) else 'No',
+            'Log Groups': ', '.join(log_groups) if log_groups else 'None',
+            'X-Ray Tracing': 'Enabled' if tracing_config.get('enabled', False) else 'Disabled',
+            'Label': sm_response.get('label', 'N/A'),
+            'Created': creation_date_str,
+            'ARN': state_machine_arn,
+        }
     except Exception as e:
-        utils.log_error(f"Error scanning state machines in {region}", e)
+        utils.log_warning(f"Could not get details for state machine {name}: {str(e)}")
+        return {
+            'Region': region, 'State Machine Name': name, 'Type': sm_type,
+            'Status': 'Unknown', 'Role': 'N/A', 'State Count': 'N/A',
+            'Logging Level': 'N/A', 'Include Execution Data': 'N/A',
+            'Log Groups': 'N/A', 'X-Ray Tracing': 'N/A', 'Label': 'N/A',
+            'Created': creation_date_str, 'ARN': state_machine_arn,
+        }
+
+
+def _scan_state_machines_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Step Functions state machines from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no state machines" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed state machines are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    state_machines_data = []
+
+    sfn_client = utils.get_boto3_client('stepfunctions', region_name=region)
+    paginator = sfn_client.get_paginator('list_state_machines')
+
+    for page in paginator.paginate():
+        for sm_summary in page.get('stateMachines', []):
+            try:
+                state_machines_data.append(_build_state_machine_row(sm_summary, region, sfn_client))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Step Functions state machine in {region}: "
+                    f"{sm_summary.get('name', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return state_machines_data
 
 
-@utils.aws_error_handler("Collecting Step Functions state machines", default_return=[])
-def collect_state_machines(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Step Functions state machine information from AWS regions."""
-    results = utils.scan_regions_concurrent(regions, _scan_state_machines_region)
-    all_state_machines = [sm for result in results for sm in result]
+def collect_state_machines(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Step Functions state machine information across regions,
+    surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(state_machines, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_state_machines_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_state_machines = [sm for result in region_results for sm in result]
     utils.log_success(f"Collected {len(all_state_machines)} Step Functions state machines")
-    return all_state_machines
+    return all_state_machines, failed_regions
 
 
 @utils.aws_error_handler("Collecting Step Functions executions", default_return=[])
@@ -120,11 +170,11 @@ def collect_executions(regions: list[str], state_machines: list[dict[str, Any]])
         sfn_client = utils.get_boto3_client('stepfunctions', region_name=region)
 
         # Get executions for each state machine (limit to recent executions)
-        region_state_machines = [sm for sm in state_machines if sm['Region'] == region]
+        region_state_machines = [sm for sm in state_machines if sm.get('Region') == region]
 
         for sm in region_state_machines:
-            state_machine_arn = sm['ARN']
-            state_machine_name = sm['State Machine Name']
+            state_machine_arn = sm.get('ARN', 'N/A')
+            state_machine_name = sm.get('State Machine Name', 'N/A')
 
             try:
                 # Get recent executions (default max results is 100)
@@ -229,7 +279,7 @@ def generate_summary(state_machines: list[dict[str, Any]],
     summary.append({
         'Metric': 'Total State Machines',
         'Count': len(state_machines),
-        'Details': f"{len([sm for sm in state_machines if sm['Status'] == 'ACTIVE'])} active"
+        'Details': f"{len([sm for sm in state_machines if sm.get('Status') == 'ACTIVE'])} active"
     })
 
     summary.append({
@@ -262,7 +312,7 @@ def generate_summary(state_machines: list[dict[str, Any]],
     if executions:
         statuses = {}
         for execution in executions:
-            status = execution['Status']
+            status = execution.get('Status', 'N/A')
             statuses[status] = statuses.get(status, 0) + 1
 
         status_details = ', '.join([f"{status}: {count}" for status, count in sorted(statuses.items())])
@@ -274,7 +324,7 @@ def generate_summary(state_machines: list[dict[str, Any]],
 
     # Logging enabled
     if state_machines:
-        logging_enabled = len([sm for sm in state_machines if sm['Logging Level'] not in ['OFF', 'N/A']])
+        logging_enabled = len([sm for sm in state_machines if sm.get('Logging Level') not in ['OFF', 'N/A']])
         summary.append({
             'Metric': 'State Machines with Logging',
             'Count': logging_enabled,
@@ -283,7 +333,7 @@ def generate_summary(state_machines: list[dict[str, Any]],
 
     # X-Ray tracing
     if state_machines:
-        tracing_enabled = len([sm for sm in state_machines if sm['X-Ray Tracing'] == 'Enabled'])
+        tracing_enabled = len([sm for sm in state_machines if sm.get('X-Ray Tracing') == 'Enabled'])
         summary.append({
             'Metric': 'State Machines with X-Ray Tracing',
             'Count': tracing_enabled,
@@ -294,7 +344,7 @@ def generate_summary(state_machines: list[dict[str, Any]],
     if state_machines:
         regions = {}
         for sm in state_machines:
-            region = sm['Region']
+            region = sm.get('Region', 'N/A')
             regions[region] = regions.get(region, 0) + 1
 
         region_details = ', '.join([f"{region}: {count}" for region, count in sorted(regions.items())])
@@ -306,8 +356,8 @@ def generate_summary(state_machines: list[dict[str, Any]],
 
     # Average state count
     if state_machines:
-        state_counts = [sm['State Count'] for sm in state_machines
-                       if isinstance(sm['State Count'], int)]
+        state_counts = [sm.get('State Count') for sm in state_machines
+                       if isinstance(sm.get('State Count'), int)]
         if state_counts:
             avg_states = sum(state_counts) / len(state_counts)
             summary.append({
@@ -321,9 +371,10 @@ def generate_summary(state_machines: list[dict[str, Any]],
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect Step Functions data and write the Excel export."""
-    # Collect data
+    # Collect data. State machines is the primary scope — region failures
+    # must propagate as failed_regions, never collapse into "empty".
     print("\n=== Collecting Step Functions Data ===")
-    state_machines = collect_state_machines(regions)
+    state_machines, failed_regions = collect_state_machines(regions)
     executions = collect_executions(regions, state_machines)
     activities = collect_activities(regions)
 
@@ -360,6 +411,19 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     }
 
     utils.save_multiple_dataframes_to_excel(dataframes, filename)
+
+    # If ANY region failed the primary state-machine scope collection, make
+    # it loud: write a marker and exit non-zero, even though the Summary
+    # sheet always lands. A complete-looking workbook that hides a zero-row
+    # data sheet is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'stepfunctions', failed_regions)
+        print(
+            "\nERROR: Step Functions export completed with failures — data is incomplete. "
+            "See the *-stepfunctions-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
+
 
 def main():
     """Main execution function — 3-step state machine (region -> confirm -> export)."""

--- a/tests/test_exporters/test_backup_export.py
+++ b/tests/test_exporters/test_backup_export.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for backup_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import backup_export  # noqa: E402
+from backup_export import _scan_backup_vaults_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_vault(client, name):
+    """Create a backup vault named ``name``."""
+    client.create_backup_vault(BackupVaultName=name)
+
+
+class TestScanBackupVaultsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_vaults(self):
+        client = boto3.client("backup", region_name=REGION)
+        _create_vault(client, "prod-vault")
+
+        rows = _scan_backup_vaults_region(REGION)
+
+        names = {row["Vault Name"] for row in rows}
+        assert "prod-vault" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("backup", region_name=REGION)  # region exists, no vaults
+
+        rows = _scan_backup_vaults_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One vault that fails to process must not discard the whole region."""
+        client = boto3.client("backup", region_name=REGION)
+        _create_vault(client, "good-vault")
+        _create_vault(client, "bad-vault")
+
+        original = backup_export._build_vault_row
+
+        def raise_for_bad(vault, region):
+            if vault.get("BackupVaultName") == "bad-vault":
+                raise KeyError("SomeUnexpectedField")
+            return original(vault, region)
+
+        monkeypatch.setattr(backup_export, "_build_vault_row", raise_for_bad)
+
+        rows = _scan_backup_vaults_region(REGION)
+
+        names = {row["Vault Name"] for row in rows}
+        assert "good-vault" in names, "healthy vault was lost when a sibling failed"
+        assert "bad-vault" not in names, "malformed vault should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListBackupVaults",
+            )
+
+        monkeypatch.setattr(backup_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_backup_vaults_region(REGION)
+
+    @mock_aws
+    def test_collect_backup_vaults_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListBackupVaults",
+            )
+
+        monkeypatch.setattr(backup_export, "_scan_backup_vaults_region", boom)
+
+        vaults, failed_regions = backup_export.collect_backup_vaults([REGION])
+
+        assert vaults == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_cloudformation_export.py
+++ b/tests/test_exporters/test_cloudformation_export.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for cloudformation_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cloudformation_export  # noqa: E402
+from cloudformation_export import _scan_stacks_region  # noqa: E402
+
+REGION = "us-east-1"
+
+MINIMAL_TEMPLATE = """{
+  "Resources": {
+    "MyBucket": {"Type": "AWS::S3::Bucket"}
+  }
+}"""
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_stack(client, name):
+    """Create a CloudFormation stack named ``name``."""
+    client.create_stack(StackName=name, TemplateBody=MINIMAL_TEMPLATE)
+
+
+class TestScanStacksRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_stacks(self):
+        client = boto3.client("cloudformation", region_name=REGION)
+        _create_stack(client, "web-stack")
+
+        rows = _scan_stacks_region(REGION)
+
+        names = {row["StackName"] for row in rows}
+        assert "web-stack" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("cloudformation", region_name=REGION)  # region exists, no stacks
+
+        rows = _scan_stacks_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One stack that fails to process must not discard the whole region."""
+        client = boto3.client("cloudformation", region_name=REGION)
+        _create_stack(client, "good-stack")
+        _create_stack(client, "bad-stack")
+
+        original = cloudformation_export._build_stack_row
+
+        def raise_for_bad(stack, region):
+            if stack.get("StackName") == "bad-stack":
+                raise KeyError("SomeUnexpectedField")
+            return original(stack, region)
+
+        monkeypatch.setattr(cloudformation_export, "_build_stack_row", raise_for_bad)
+
+        rows = _scan_stacks_region(REGION)
+
+        names = {row["StackName"] for row in rows}
+        assert "good-stack" in names, "healthy stack was lost when a sibling failed"
+        assert "bad-stack" not in names, "malformed stack should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeStacks",
+            )
+
+        monkeypatch.setattr(cloudformation_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_stacks_region(REGION)
+
+    @mock_aws
+    def test_collect_stacks_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeStacks",
+            )
+
+        monkeypatch.setattr(cloudformation_export, "_scan_stacks_region", boom)
+
+        stacks, failed_regions = cloudformation_export.collect_stacks([REGION])
+
+        assert stacks == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_cloudwatch_export.py
+++ b/tests/test_exporters/test_cloudwatch_export.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for cloudwatch_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cloudwatch_export  # noqa: E402
+from cloudwatch_export import _scan_cloudwatch_alarms_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_alarm(client, name, dimensions=None):
+    """Create a CloudWatch metric alarm named ``name``."""
+    client.put_metric_alarm(
+        AlarmName=name,
+        MetricName="CPUUtilization",
+        Namespace="AWS/EC2",
+        Statistic="Average",
+        Period=300,
+        EvaluationPeriods=1,
+        Threshold=80.0,
+        ComparisonOperator="GreaterThanThreshold",
+        Dimensions=dimensions if dimensions is not None else [
+            {"Name": "InstanceId", "Value": "i-1234567890abcdef0"}
+        ],
+    )
+
+
+class TestScanCloudwatchAlarmsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_alarms(self):
+        client = boto3.client("cloudwatch", region_name=REGION)
+        _create_alarm(client, "cpu-high-alarm")
+
+        rows = _scan_cloudwatch_alarms_region(REGION)
+
+        names = {row["Alarm Name"] for row in rows}
+        assert "cpu-high-alarm" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("cloudwatch", region_name=REGION)  # region exists, no alarms
+
+        rows = _scan_cloudwatch_alarms_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One alarm that fails to process must not discard the whole region."""
+        client = boto3.client("cloudwatch", region_name=REGION)
+        _create_alarm(client, "good-alarm")
+        _create_alarm(client, "bad-alarm")
+
+        original = cloudwatch_export._build_alarm_row
+
+        def raise_for_bad(alarm, region):
+            if alarm.get("AlarmName") == "bad-alarm":
+                raise KeyError("SomeUnexpectedField")
+            return original(alarm, region)
+
+        monkeypatch.setattr(cloudwatch_export, "_build_alarm_row", raise_for_bad)
+
+        rows = _scan_cloudwatch_alarms_region(REGION)
+
+        names = {row["Alarm Name"] for row in rows}
+        assert "good-alarm" in names, "healthy alarm was lost when a sibling failed"
+        assert "bad-alarm" not in names, "malformed alarm should have been skipped"
+
+    def test_dimensions_missing_name_key_is_skipped_not_fatal(self):
+        """
+        Known KeyError trigger from the audit: a dimension entry missing the
+        'Name' key used to raise via a hard subscript (d['Name']) at the old
+        line ~84. moto's put_metric_alarm validates dimension shape, so this
+        malformed shape cannot be produced through the API — it is exercised
+        directly against ``_build_alarm_row`` to prove the ``.get()``
+        conversion holds and no KeyError is raised.
+        """
+        malformed_alarm = {
+            "AlarmName": "weird-dims-alarm",
+            "MetricName": "CPUUtilization",
+            "Namespace": "AWS/EC2",
+            "Dimensions": [{"Value": "i-missing-name-key"}],
+        }
+        row = cloudwatch_export._build_alarm_row(malformed_alarm, REGION)
+        assert row["Dimensions"] == "N/A=i-missing-name-key"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeAlarms",
+            )
+
+        monkeypatch.setattr(cloudwatch_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_cloudwatch_alarms_region(REGION)
+
+    @mock_aws
+    def test_collect_cloudwatch_alarms_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeAlarms",
+            )
+
+        monkeypatch.setattr(cloudwatch_export, "_scan_cloudwatch_alarms_region", boom)
+
+        alarms, failed_regions = cloudwatch_export.collect_cloudwatch_alarms([REGION])
+
+        assert alarms == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_codebuild_export.py
+++ b/tests/test_exporters/test_codebuild_export.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for codebuild_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's codebuild backend implements create_project / list_projects /
+batch_get_projects, so the primary scope (_scan_projects_region /
+collect_projects) is exercised with @mock_aws directly. It does not
+implement list_report_groups (raises NotImplementedError) or
+batch_get_builds, but those are enrichment scopes outside this file's
+assigned surface (_scan_projects_region / collect_projects) and are not
+touched by this fix.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import codebuild_export  # noqa: E402
+from codebuild_export import _scan_projects_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_project(client, name):
+    """Create a minimal CodeBuild project named ``name``."""
+    client.create_project(
+        name=name,
+        source={"type": "GITHUB", "location": "https://github.com/example/repo.git"},
+        artifacts={"type": "NO_ARTIFACTS"},
+        environment={
+            "type": "LINUX_CONTAINER",
+            "image": "aws/codebuild/standard:5.0",
+            "computeType": "BUILD_GENERAL1_SMALL",
+        },
+        serviceRole="arn:aws:iam::123456789012:role/service-role/codebuild-role",
+    )
+
+
+class TestScanProjectsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_projects(self):
+        client = boto3.client("codebuild", region_name=REGION)
+        _create_project(client, "web-project")
+
+        rows = _scan_projects_region(REGION)
+
+        names = {row["Project Name"] for row in rows}
+        assert "web-project" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("codebuild", region_name=REGION)  # region exists, no projects
+
+        rows = _scan_projects_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One CodeBuild project that fails to process must not discard the whole region."""
+        client = boto3.client("codebuild", region_name=REGION)
+        _create_project(client, "good-project")
+        _create_project(client, "bad-project")
+
+        original = codebuild_export._build_project_row
+
+        def raise_for_bad(project, region):
+            if project.get("name") == "bad-project":
+                raise KeyError("SomeUnexpectedField")
+            return original(project, region)
+
+        monkeypatch.setattr(codebuild_export, "_build_project_row", raise_for_bad)
+
+        rows = _scan_projects_region(REGION)
+
+        names = {row["Project Name"] for row in rows}
+        assert "good-project" in names, "healthy project was lost when a sibling failed"
+        assert "bad-project" not in names, "malformed project should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListProjects",
+            )
+
+        monkeypatch.setattr(codebuild_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_projects_region(REGION)
+
+    @mock_aws
+    def test_collect_projects_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListProjects",
+            )
+
+        monkeypatch.setattr(codebuild_export, "_scan_projects_region", boom)
+
+        projects, failed_regions = codebuild_export.collect_projects([REGION])
+
+        assert projects == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_codepipeline_export.py
+++ b/tests/test_exporters/test_codepipeline_export.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for codepipeline_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's codepipeline backend implements create_pipeline / list_pipelines
+/ get_pipeline, but raises NotImplementedError for get_pipeline_state. That
+call is an enrichment lookup in codepipeline_export._build_pipeline_row and
+is already wrapped in its own try/except (degrades to 'Unknown'), so it does
+not block these tests — it just means "Latest Status" is always 'Unknown'
+under moto.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import codepipeline_export  # noqa: E402
+from codepipeline_export import _scan_pipelines_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_role(region=REGION):
+    """Create a minimal IAM role CodePipeline can assume, return its ARN."""
+    iam = boto3.client("iam", region_name=region)
+    role = iam.create_role(
+        RoleName="codepipeline-role",
+        AssumeRolePolicyDocument=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "codepipeline.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        ),
+    )
+    return role["Role"]["Arn"]
+
+
+def _create_pipeline(client, name, role_arn):
+    """Create a minimal two-stage CodePipeline pipeline named ``name``."""
+    client.create_pipeline(
+        pipeline={
+            "name": name,
+            "roleArn": role_arn,
+            "artifactStore": {"type": "S3", "location": "test-bucket"},
+            "stages": [
+                {
+                    "name": "Source",
+                    "actions": [
+                        {
+                            "name": "SourceAction",
+                            "actionTypeId": {
+                                "category": "Source",
+                                "owner": "AWS",
+                                "provider": "S3",
+                                "version": "1",
+                            },
+                            "outputArtifacts": [{"name": "SourceOutput"}],
+                            "configuration": {
+                                "S3Bucket": "test-bucket",
+                                "S3ObjectKey": "source.zip",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [
+                        {
+                            "name": "DeployAction",
+                            "actionTypeId": {
+                                "category": "Deploy",
+                                "owner": "AWS",
+                                "provider": "S3",
+                                "version": "1",
+                            },
+                            "inputArtifacts": [{"name": "SourceOutput"}],
+                            "configuration": {
+                                "BucketName": "test-bucket",
+                                "Extract": "true",
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+
+class TestScanPipelinesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_pipelines(self):
+        role_arn = _create_role()
+        client = boto3.client("codepipeline", region_name=REGION)
+        _create_pipeline(client, "web-pipeline", role_arn)
+
+        rows = _scan_pipelines_region(REGION)
+
+        names = {row["Pipeline Name"] for row in rows}
+        assert "web-pipeline" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("codepipeline", region_name=REGION)  # region exists, no pipelines
+
+        rows = _scan_pipelines_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list, indistinguishable
+    from a genuinely empty region. codepipeline_export.py is Tier-3 PARTIAL: a
+    forced Summary sheet already means a workbook always lands, but the export
+    must still ADD failed-scope tracking so a failure is never indistinguishable
+    from a genuinely empty account.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One pipeline that fails to process must not discard the whole region."""
+        role_arn = _create_role()
+        client = boto3.client("codepipeline", region_name=REGION)
+        _create_pipeline(client, "good-pipeline", role_arn)
+        _create_pipeline(client, "bad-pipeline", role_arn)
+
+        original = codepipeline_export._build_pipeline_row
+
+        def raise_for_bad(client, pipeline_summary, region):
+            if pipeline_summary.get("name") == "bad-pipeline":
+                raise KeyError("SomeUnexpectedField")
+            return original(client, pipeline_summary, region)
+
+        monkeypatch.setattr(codepipeline_export, "_build_pipeline_row", raise_for_bad)
+
+        rows = _scan_pipelines_region(REGION)
+
+        names = {row["Pipeline Name"] for row in rows}
+        assert "good-pipeline" in names, "healthy pipeline was lost when a sibling failed"
+        assert "bad-pipeline" not in names, "malformed pipeline should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListPipelines",
+            )
+
+        monkeypatch.setattr(codepipeline_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_pipelines_region(REGION)
+
+    @mock_aws
+    def test_collect_pipelines_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the forced Summary sheet means a workbook still lands.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListPipelines",
+            )
+
+        monkeypatch.setattr(codepipeline_export, "_scan_pipelines_region", boom)
+
+        pipelines, failed_regions = codepipeline_export.collect_pipelines([REGION])
+
+        assert pipelines == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_controltower_export.py
+++ b/tests/test_exporters/test_controltower_export.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+Tests for controltower_export.py.
+
+Covers:
+- collect_landing_zone() as a dual-purpose PRIMARY collector / "is Control
+  Tower set up" gate: graceful "not set up" handling vs. real API-error
+  propagation
+- collect_organizational_units() / collect_enabled_controls() per-item
+  guarding and account-scope failure propagation
+- main()'s failed-scope tracking, always-written Summary sheet, and
+  exit-code behavior
+
+AWS Control Tower is a global, account-scope service run from the
+management account (no region scan) -- collect_landing_zone(),
+collect_organizational_units(), and collect_enabled_controls() are the
+PRIMARY account-scope collectors -- mirrors the scripts/shield_export.py /
+scripts/organizations_export.py account-scope pattern (see
+scripts/lambda_export.py for the finalize shape).
+
+NOTE on moto: moto has NO Control Tower support at all (no
+``moto.controltower`` module -- confirmed via
+``import moto.controltower.models`` raising ``ModuleNotFoundError``), and
+the botocore version pinned by this project (1.34.46) does not even
+recognize ``controlcatalog`` as a valid boto3 service name (confirmed via
+``boto3.client('controlcatalog')`` raising ``UnknownServiceError``). Because
+of this, every test below drives the module through monkeypatched boto3
+clients / module functions rather than real moto-backed Control Tower
+state; ``tests/test_smoke.py::test_exporter_smoke[controltower_export]`` is
+expected to fail/report a real (non-mock) collection failure for the same
+reason -- see that test's run notes.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import controltower_export  # noqa: E402
+from controltower_export import (  # noqa: E402
+    collect_enabled_controls,
+    collect_landing_zone,
+    collect_organizational_units,
+)
+
+REGION = "us-east-1"
+
+# save_multiple_dataframes_to_excel() logs via the raw module-level `logger`
+# (not the null-safe get_logger() used by utils.log_*()). controltower's
+# main() -- unlike shield/organizations -- has no wrapping try/except around
+# its export call, so leaving utils.logger as None (its default) when
+# setup_logging() is mocked away would surface as an unrelated
+# AttributeError instead of exercising the behavior under test.
+_NULL_LOGGER = logging.getLogger("stratusscan-test-controltower")
+_NULL_LOGGER.addHandler(logging.NullHandler())
+_NULL_LOGGER.propagate = False
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(controltower_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _client_error(code, operation, message="boom"):
+    return botocore.exceptions.ClientError({"Error": {"Code": code, "Message": message}}, operation)
+
+
+class TestCollectLandingZone:
+    """
+    collect_landing_zone() is the PRIMARY, account-scope collector that also
+    doubles as the "is Control Tower set up" gate. An empty landing-zone
+    list, or AccessDenied/ResourceNotFound on ListLandingZones, is the
+    legitimate "not set up" state and returns ``{}`` gracefully -- never a
+    raise. Any other error (real API failure) must propagate.
+    """
+
+    def test_no_landing_zones_returns_empty_dict_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.list_landing_zones.return_value = {"landingZones": []}
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert collect_landing_zone() == {}
+
+    def test_access_denied_returns_empty_dict_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.list_landing_zones.side_effect = _client_error(
+            "AccessDeniedException", "ListLandingZones"
+        )
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert collect_landing_zone() == {}
+
+    def test_resource_not_found_returns_empty_dict_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.list_landing_zones.side_effect = _client_error(
+            "ResourceNotFoundException", "ListLandingZones"
+        )
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert collect_landing_zone() == {}
+
+    def test_landing_zone_details_collected_successfully(self, monkeypatch):
+        client = MagicMock()
+        client.list_landing_zones.return_value = {
+            "landingZones": [{"arn": "arn:aws:controltower::123456789012:landingzone/LZ1"}]
+        }
+        client.get_landing_zone.return_value = {
+            "landingZone": {
+                "arn": "arn:aws:controltower::123456789012:landingzone/LZ1",
+                "version": "3.3",
+                "status": "ACTIVE",
+                "driftStatus": {"status": "IN_SYNC"},
+                "manifest": {"governedRegions": ["us-east-1", "us-west-2"]},
+            }
+        }
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        result = collect_landing_zone()
+
+        assert result["Status"] == "ACTIVE"
+        assert result["Number of Governed Regions"] == 2
+
+
+class TestCollectOrganizationalUnits:
+    """collect_organizational_units() is a PRIMARY, account-scope collector."""
+
+    def test_org_not_in_use_returns_empty_list_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.list_roots.side_effect = _client_error(
+            "AWSOrganizationsNotInUseException", "ListRoots"
+        )
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert collect_organizational_units() == []
+
+    def test_access_denied_returns_empty_list_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.list_roots.side_effect = _client_error("AccessDeniedException", "ListRoots")
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert collect_organizational_units() == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-
+    failure audits, applied to Control Tower. Before this fix,
+    ``collect_landing_zone()``, ``collect_organizational_units()``, and
+    ``collect_enabled_controls()`` were all decorated with
+    ``@utils.aws_error_handler(default_return=...)``, silently collapsing a
+    real API error into an empty result indistinguishable from "Control
+    Tower not set up" / "no OUs" / "no controls". ``main()`` also had no way
+    to signal that failure downstream (it wrote no file at all when
+    ``collect_landing_zone()`` came back empty, for ANY reason).
+
+    Covers:
+        (a) a malformed item (OU / control) is skipped, not fatal
+        (b) a PRIMARY collector raises rather than swallowing a real API error
+        (c) a collector failure surfaces through main() as a non-zero exit
+            plus a utils.report_collection_failures() call
+        (d) a genuine "Control Tower not set up" state is a graceful exit 0
+            with no failure marker
+    """
+
+    # -- (a) Per-item guards -------------------------------------------------
+
+    def test_malformed_ou_is_skipped_not_fatal(self, monkeypatch):
+        """One OU entry that fails to process must not discard its sibling
+        or abort the whole recursive branch."""
+        client = MagicMock()
+        client.list_roots.return_value = {
+            "Roots": [
+                {"Id": "r-root", "Arn": "arn:aws:organizations::123456789012:root/o-abc/r-root", "Name": "Root"}
+            ]
+        }
+
+        good = {"Id": "ou-good", "Arn": "arn:aws:organizations::123456789012:ou/o-abc/ou-good", "Name": "good-ou"}
+        bad = {"Id": "ou-bad", "Arn": "arn:aws:organizations::123456789012:ou/o-abc/ou-bad", "Name": "bad-ou"}
+
+        paginator = MagicMock()
+
+        def paginate(ParentId, **kwargs):  # noqa: N803 (matches boto3 kwarg casing)
+            if ParentId == "r-root":
+                return [{"OrganizationalUnits": [good, bad]}]
+            return []
+
+        paginator.paginate.side_effect = paginate
+        client.get_paginator.return_value = paginator
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = controltower_export._build_ou_row
+
+        def raise_for_bad(ou):
+            if ou.get("Id") == "ou-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(ou)
+
+        monkeypatch.setattr(controltower_export, "_build_ou_row", raise_for_bad)
+
+        result = collect_organizational_units()
+
+        ids = {row["OU ID"] for row in result}
+        assert "ou-good" in ids, "healthy OU was lost when a sibling failed"
+        assert "ou-bad" not in ids, "malformed OU should have been skipped"
+
+    def test_malformed_control_is_skipped_not_fatal(self, monkeypatch):
+        """One control entry that fails to process must not discard its
+        sibling or abort the whole OU's control listing."""
+        ct_client = MagicMock()
+        catalog_client = MagicMock()
+
+        good = {"controlIdentifier": "AWS-GR_GOOD", "arn": "arn:aws:controltower::123456789012:control/good"}
+        bad = {"controlIdentifier": "AWS-GR_BAD", "arn": "arn:aws:controltower::123456789012:control/bad"}
+
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"enabledControls": [good, bad]}]
+        ct_client.get_paginator.return_value = paginator
+        ct_client.get_enabled_control.return_value = {"enabledControlDetails": {}}
+        catalog_client.get_control.return_value = {"Name": "N", "Description": "D", "Behavior": "B"}
+
+        def fake_get_boto3_client(service, *a, **kw):
+            return ct_client if service == "controltower" else catalog_client
+
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", fake_get_boto3_client)
+
+        original = controltower_export._build_control_row
+
+        def raise_for_bad(control, ou_name, ou_arn, ctc, catc):
+            if control.get("controlIdentifier") == "AWS-GR_BAD":
+                raise KeyError("SomeUnexpectedField")
+            return original(control, ou_name, ou_arn, ctc, catc)
+
+        monkeypatch.setattr(controltower_export, "_build_control_row", raise_for_bad)
+
+        ous = [{"OU ARN": "arn:aws:organizations::123456789012:ou/o-abc/ou-1", "OU Name": "ou-1", "Type": "Organizational Unit"}]
+
+        result = collect_enabled_controls(ous)
+
+        ids = {row["Control Identifier"] for row in result}
+        assert "AWS-GR_GOOD" in ids, "healthy control was lost when a sibling failed"
+        assert "AWS-GR_BAD" not in ids, "malformed control should have been skipped"
+
+    # -- (b) Account-scope failure propagation --------------------------------
+
+    def test_collect_landing_zone_raises_on_real_api_error_not_swallowed(self, monkeypatch):
+        """A real Control Tower API error must propagate, not collapse into
+        'not set up'."""
+        client = MagicMock()
+        client.list_landing_zones.side_effect = _client_error(
+            "InternalErrorException", "ListLandingZones"
+        )
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_landing_zone()
+
+    def test_collect_landing_zone_raises_on_get_details_error_not_swallowed(self, monkeypatch):
+        """A landing zone genuinely exists (list succeeded) but fetching its
+        details fails -- a real failure, not 'not set up'."""
+        client = MagicMock()
+        client.list_landing_zones.return_value = {
+            "landingZones": [{"arn": "arn:aws:controltower::123456789012:landingzone/LZ1"}]
+        }
+        client.get_landing_zone.side_effect = _client_error(
+            "InternalErrorException", "GetLandingZone"
+        )
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_landing_zone()
+
+    def test_collect_organizational_units_raises_on_real_api_error_not_swallowed(self, monkeypatch):
+        client = MagicMock()
+        client.list_roots.side_effect = _client_error("InternalErrorException", "ListRoots")
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_organizational_units()
+
+    def test_collect_enabled_controls_raises_on_client_creation_error_not_swallowed(self, monkeypatch):
+        """A real error creating the account-scope clients (e.g. the
+        botocore version in use not recognizing 'controlcatalog') must
+        propagate, not collapse into an empty controls list."""
+
+        def boom(service, *a, **kw):
+            raise RuntimeError(f"Unknown service: {service}")
+
+        monkeypatch.setattr(controltower_export.utils, "get_boto3_client", boom)
+
+        ous = [{"OU ARN": "arn:aws:organizations::123456789012:ou/o-abc/ou-1", "OU Name": "ou-1", "Type": "Organizational Unit"}]
+
+        with pytest.raises(RuntimeError):
+            collect_enabled_controls(ous)
+
+    # -- (c) main(): failure surfaced, non-zero exit ---------------------------
+
+    def _patch_main_scaffolding(self, monkeypatch):
+        """Patch everything main() needs to run except the collectors under test."""
+        monkeypatch.setattr(controltower_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(controltower_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(controltower_export.utils, "log_script_start", lambda *a, **kw: None)
+        monkeypatch.setattr(controltower_export.utils, "logger", _NULL_LOGGER)
+        monkeypatch.setattr(
+            controltower_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(controltower_export.utils, "mask_account_id", lambda account_id: "1234****9012")
+        # detect_partition() with no args makes a real boto3.Session().client('sts')
+        # call outside utils.get_boto3_client -- avoid any real network dependency.
+        monkeypatch.setattr(controltower_export.utils, "detect_partition", lambda *a, **kw: "aws")
+
+    def test_main_landing_zone_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A landing-zone API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into
+        'not set up'."""
+        self._patch_main_scaffolding(monkeypatch)
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListLandingZones",
+            )
+
+        monkeypatch.setattr(controltower_export, "collect_landing_zone", boom)
+        monkeypatch.setattr(controltower_export, "collect_organizational_units", lambda: [])
+        monkeypatch.setattr(controltower_export, "collect_enabled_controls", lambda ous: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(controltower_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            controltower_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "controltower"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "landing-zone"
+
+    def test_main_enabled_controls_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An enabled-controls failure in main() (landing zone + OUs both
+        succeeded) must still exit non-zero and report -- a partial export
+        that looks complete must never mask a failed scope."""
+        self._patch_main_scaffolding(monkeypatch)
+
+        monkeypatch.setattr(
+            controltower_export,
+            "collect_landing_zone",
+            lambda: {"ARN": "arn:...", "Status": "ACTIVE", "Number of Governed Regions": 1, "Governed Regions": "us-east-1"},
+        )
+        monkeypatch.setattr(controltower_export, "collect_organizational_units", lambda: [])
+
+        def boom(ous):
+            raise RuntimeError("Unknown service: controlcatalog")
+
+        monkeypatch.setattr(controltower_export, "collect_enabled_controls", boom)
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(controltower_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            controltower_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "enabled-controls"
+
+    # -- (d) Control Tower not set up: graceful skip, no marker ---------------
+
+    def test_not_set_up_exits_zero_no_marker(self, monkeypatch):
+        """Control Tower not being set up in this account (no landing zone
+        found, and no error) is a legitimate, expected state -- exit 0 (via
+        a plain return), and utils.report_collection_failures is never
+        called (no *-FAILED-*.txt marker is written)."""
+        self._patch_main_scaffolding(monkeypatch)
+
+        monkeypatch.setattr(controltower_export, "collect_landing_zone", lambda: {})
+
+        # These must not even be reached, but stub them defensively.
+        monkeypatch.setattr(
+            controltower_export,
+            "collect_organizational_units",
+            lambda: pytest.fail("collect_organizational_units should not run when CT is not set up"),
+        )
+        monkeypatch.setattr(
+            controltower_export,
+            "collect_enabled_controls",
+            lambda ous: pytest.fail("collect_enabled_controls should not run when CT is not set up"),
+        )
+
+        report_called = []
+        monkeypatch.setattr(
+            controltower_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        result = controltower_export.main()
+
+        assert result is None
+        assert report_called == []
+
+    def test_partial_success_with_no_failures_exits_cleanly_with_summary(self, monkeypatch, tmp_path):
+        """A fully successful run (no failed scopes) writes a file (with a
+        Summary sheet always present) and does not call
+        report_collection_failures or exit non-zero."""
+        self._patch_main_scaffolding(monkeypatch)
+
+        monkeypatch.setattr(
+            controltower_export,
+            "collect_landing_zone",
+            lambda: {
+                "ARN": "arn:aws:controltower::123456789012:landingzone/LZ1",
+                "Version": "3.3",
+                "Status": "ACTIVE",
+                "Drift Status": "IN_SYNC",
+                "Governed Regions": "us-east-1",
+                "Number of Governed Regions": 1,
+            },
+        )
+        monkeypatch.setattr(controltower_export, "collect_organizational_units", lambda: [])
+        monkeypatch.setattr(controltower_export, "collect_enabled_controls", lambda ous: [])
+
+        report_called = []
+        monkeypatch.setattr(
+            controltower_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        result = controltower_export.main()
+
+        assert result is None
+        assert report_called == []
+        exported_files = list(tmp_path.glob("test-account-controltower-*"))
+        assert exported_files, "expected an exported workbook with the always-written Summary sheet"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_service_catalog_export.py
+++ b/tests/test_exporters/test_service_catalog_export.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for service_catalog_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's Service Catalog support covers create_portfolio/list_portfolios
+well, but search_products_as_admin and scan_provisioned_products are not
+meaningfully implemented (they return empty results regardless of state), so
+the regression tests below target the portfolios scope directly (which is
+fully supported) and monkeypatch the scan function where moto coverage would
+otherwise mask the behavior under test.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import service_catalog_export  # noqa: E402
+from service_catalog_export import _scan_portfolios_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_portfolio(client, name):
+    """Create a Service Catalog portfolio named ``name``."""
+    return client.create_portfolio(DisplayName=name, ProviderName="test-provider")
+
+
+class TestScanPortfoliosRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_portfolios(self):
+        client = boto3.client("servicecatalog", region_name=REGION)
+        _create_portfolio(client, "web-portfolio")
+
+        rows = _scan_portfolios_region(REGION)
+
+        names = {row["DisplayName"] for row in rows}
+        assert "web-portfolio" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("servicecatalog", region_name=REGION)  # region exists, no portfolios
+
+        rows = _scan_portfolios_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One portfolio that fails to process must not discard the whole region."""
+        client = boto3.client("servicecatalog", region_name=REGION)
+        _create_portfolio(client, "good-portfolio")
+        _create_portfolio(client, "bad-portfolio")
+
+        original = service_catalog_export._build_portfolio_row
+
+        def raise_for_bad(portfolio, region):
+            if portfolio.get("DisplayName") == "bad-portfolio":
+                raise KeyError("SomeUnexpectedField")
+            return original(portfolio, region)
+
+        monkeypatch.setattr(service_catalog_export, "_build_portfolio_row", raise_for_bad)
+
+        rows = _scan_portfolios_region(REGION)
+
+        names = {row["DisplayName"] for row in rows}
+        assert "good-portfolio" in names, "healthy portfolio was lost when a sibling failed"
+        assert "bad-portfolio" not in names, "malformed portfolio should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListPortfolios",
+            )
+
+        monkeypatch.setattr(service_catalog_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_portfolios_region(REGION)
+
+    @mock_aws
+    def test_collect_portfolios_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the Tier-3 Summary sheet is always written.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListPortfolios",
+            )
+
+        monkeypatch.setattr(service_catalog_export, "_scan_portfolios_region", boom)
+
+        portfolios, failed_regions = service_catalog_export.collect_portfolios([REGION])
+
+        assert portfolios == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_stepfunctions_export.py
+++ b/tests/test_exporters/test_stepfunctions_export.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for stepfunctions_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Unlike the Tier-1/Tier-2 exporters, stepfunctions_export.py already writes a
+forced Summary sheet, so a workbook always lands even when a scope collection
+fails. The fix under test here is *additive*: on any state-machine-region
+failure, ALSO write the FAILED marker and exit non-zero; a genuinely-empty
+account (every region succeeded, nothing found) stays exit 0 with no marker.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import stepfunctions_export  # noqa: E402
+from stepfunctions_export import _scan_state_machines_region  # noqa: E402
+
+REGION = "us-east-1"
+ROLE_ARN = "arn:aws:iam::123456789012:role/test-role"
+DEFINITION = (
+    '{"Comment": "test", "StartAt": "A", '
+    '"States": {"A": {"Type": "Pass", "End": true}}}'
+)
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_state_machine(client, name):
+    """Create a Step Functions state machine named ``name``."""
+    return client.create_state_machine(
+        name=name,
+        definition=DEFINITION,
+        roleArn=ROLE_ARN,
+    )
+
+
+class TestScanStateMachinesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_state_machines(self):
+        client = boto3.client("stepfunctions", region_name=REGION)
+        _create_state_machine(client, "web-workflow")
+
+        rows = _scan_state_machines_region(REGION)
+
+        names = {row["State Machine Name"] for row in rows}
+        assert "web-workflow" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("stepfunctions", region_name=REGION)  # region exists, none created
+
+        rows = _scan_state_machines_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty (or zero-row)
+    result, indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One state machine that fails to process must not discard the whole region."""
+        client = boto3.client("stepfunctions", region_name=REGION)
+        _create_state_machine(client, "good-workflow")
+        _create_state_machine(client, "bad-workflow")
+
+        original = stepfunctions_export._build_state_machine_row
+
+        def raise_for_bad(sm_summary, region, sfn_client):
+            if sm_summary.get("name") == "bad-workflow":
+                raise KeyError("SomeUnexpectedField")
+            return original(sm_summary, region, sfn_client)
+
+        monkeypatch.setattr(stepfunctions_export, "_build_state_machine_row", raise_for_bad)
+
+        rows = _scan_state_machines_region(REGION)
+
+        names = {row["State Machine Name"] for row in rows}
+        assert "good-workflow" in names, "healthy state machine was lost when a sibling failed"
+        assert "bad-workflow" not in names, "malformed state machine should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListStateMachines",
+            )
+
+        monkeypatch.setattr(stepfunctions_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_state_machines_region(REGION)
+
+    @mock_aws
+    def test_collect_state_machines_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1
+        even though the Summary sheet is always written.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListStateMachines",
+            )
+
+        monkeypatch.setattr(stepfunctions_export, "_scan_state_machines_region", boom)
+
+        state_machines, failed_regions = stepfunctions_export.collect_state_machines([REGION])
+
+        assert state_machines == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -77,6 +77,8 @@ _EXCLUDED = {
     #   rolesanywhere:ListTrustAnchors      -> 404 "Not yet implemented"
     #   ec2:DescribeVerifiedAccessInstances -> NotImplementedError
     #   verifiedpermissions:ListPolicyStores-> 404 "Not yet implemented"
+    #   servicecatalog:SearchProductsAsAdmin-> NotImplementedError
+    #   controltower:ListLandingZones       -> 404 "Not yet implemented"
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -91,6 +93,8 @@ _EXCLUDED = {
     "iam_rolesanywhere_export.py",
     "verifiedaccess_export.py",
     "verifiedpermissions_export.py",
+    "service_catalog_export.py",
+    "controltower_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **Fourth Tier-3 (PARTIAL) phase — Batch I: devops & governance (8 exporters).**

| Exporter | Type | Slug |
|---|---|---|
| cloudformation | multi-region | `cloudformation` |
| codebuild | multi-region | `codebuild` |
| codepipeline | multi-region | `codepipeline` |
| backup | multi-region | `aws-backup` |
| cloudwatch | multi-region | `cloudwatch` |
| stepfunctions | multi-region | `stepfunctions` |
| service_catalog | multi-region (3 scopes) | `service-catalog` |
| controltower | account-scope | `controltower` |

Primary scope collector RAISES on error → surfaced failures → per-item `_build_*_row` guard → marker + `sys.exit(1)`; genuine-empty stays exit 0. KeyError sites guarded (`d['Name']`, `portfolio['PortfolioId']`/`product['ProductId']`, `sm['X-Ray Tracing']` + more).

`controltower` distinguishes not-set-up (landing zone absent / AccessDenied → graceful exit 0, no marker) from a real API error, and wires in its previously-dead `generate_summary()` to honor the always-written Summary contract.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite (controltower +16 incl not-set-up→exit-0). **Batch-I suites: 52 passed. Full suite: 1117 passed, 2 skipped.** `ruff check .` clean (py39 floor).

## test_smoke.py exclusions
`service_catalog`, `controltower` added to `_EXCLUDED` — moto has no backend for their primary APIs. The other 6 pass smoke.

## Remaining
Final Tier-3 batch **K** (networking/misc, 8) next → completes the entire 96-exporter sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)