### PR TITLE
Silent collection failure: Tier-3k (networking & misc) — completes the sweep

### DIFF
--- a/scripts/nacl_export.py
+++ b/scripts/nacl_export.py
@@ -73,8 +73,8 @@ def get_tag_value(tags, key='Name'):
         return "N/A"
 
     for tag in tags:
-        if tag['Key'] == key:
-            return tag['Value']
+        if tag.get('Key') == key:
+            return tag.get('Value', 'N/A')
 
     return "N/A"
 
@@ -111,10 +111,73 @@ def format_rule(rule):
 
     return f"{rule_number}: {action.upper()} {protocol}:{port_range} from {cidr}"
 
-@utils.aws_error_handler("Collecting Network ACL data", default_return=[])
+def _build_nacl_row(nacl, region):
+    """Build a single Network ACL export row from a describe response."""
+    nacl_id = nacl.get('NetworkAclId', 'N/A')
+    vpc_id = nacl.get('VpcId', 'N/A')
+    is_default = nacl.get('IsDefault', False)
+
+    # Get NACL name from tags
+    nacl_name = get_tag_value(nacl.get('Tags', []))
+
+    # Format tags as a string
+    tags_str = '; '.join([f"{tag.get('Key', 'N/A')}={tag.get('Value', 'N/A')}" for tag in nacl.get('Tags', [])])
+    if not tags_str:
+        tags_str = "N/A"
+
+    # Get inbound and outbound rules
+    inbound_rules = [rule for rule in nacl.get('Entries', []) if not rule.get('Egress', False)]
+    outbound_rules = [rule for rule in nacl.get('Entries', []) if rule.get('Egress', False)]
+
+    # Format rules as strings
+    inbound_rules_str = '; '.join([format_rule(rule) for rule in sorted(inbound_rules, key=lambda x: x.get('RuleNumber', 0))])
+    outbound_rules_str = '; '.join([format_rule(rule) for rule in sorted(outbound_rules, key=lambda x: x.get('RuleNumber', 0))])
+
+    if not inbound_rules_str:
+        inbound_rules_str = "N/A"
+    if not outbound_rules_str:
+        outbound_rules_str = "N/A"
+
+    # Get subnet associations
+    subnet_associations = []
+    for assoc in nacl.get('Associations', []):
+        subnet_id = assoc.get('SubnetId', 'N/A')
+        if subnet_id != 'N/A':
+            subnet_associations.append(subnet_id)
+
+    subnet_associations_str = '; '.join(subnet_associations) if subnet_associations else "N/A"
+
+    # Get owner information
+    owner_id = nacl.get('OwnerId', 'N/A')
+    owner_formatted = utils.get_account_name_formatted(owner_id)
+
+    return {
+        'Region': region,
+        'NACL ID': nacl_id,
+        'NACL Name': nacl_name,
+        'VPC ID': vpc_id,
+        'Is Default': 'Yes' if is_default else 'No',
+        'Inbound Rules': inbound_rules_str,
+        'Outbound Rules': outbound_rules_str,
+        'Subnet Associations': subnet_associations_str,
+        'Owner ID': owner_formatted,
+        'Tags': tags_str
+    }
+
+
 def get_nacl_data(region):
     """
     Get Network ACL information for a specific AWS region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no NACLs" (the silent-collection-
+    loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed NACLs are skipped (logged) rather than aborting the
+    whole region.
 
     Args:
         region: AWS region name
@@ -139,59 +202,16 @@ def get_nacl_data(region):
         all_nacls.extend(page.get('NetworkAcls', []))
 
     for nacl in all_nacls:
-        nacl_id = nacl.get('NetworkAclId', 'N/A')
-        vpc_id = nacl.get('VpcId', 'N/A')
-        is_default = nacl.get('IsDefault', False)
-
-        # Get NACL name from tags
-        nacl_name = get_tag_value(nacl.get('Tags', []))
-
-        # Format tags as a string
-        tags_str = '; '.join([f"{tag['Key']}={tag['Value']}" for tag in nacl.get('Tags', [])])
-        if not tags_str:
-            tags_str = "N/A"
-
-        # Get inbound and outbound rules
-        inbound_rules = [rule for rule in nacl.get('Entries', []) if not rule.get('Egress', False)]
-        outbound_rules = [rule for rule in nacl.get('Entries', []) if rule.get('Egress', False)]
-
-        # Format rules as strings
-        inbound_rules_str = '; '.join([format_rule(rule) for rule in sorted(inbound_rules, key=lambda x: x.get('RuleNumber', 0))])
-        outbound_rules_str = '; '.join([format_rule(rule) for rule in sorted(outbound_rules, key=lambda x: x.get('RuleNumber', 0))])
-
-        if not inbound_rules_str:
-            inbound_rules_str = "N/A"
-        if not outbound_rules_str:
-            outbound_rules_str = "N/A"
-
-        # Get subnet associations
-        subnet_associations = []
-        for assoc in nacl.get('Associations', []):
-            subnet_id = assoc.get('SubnetId', 'N/A')
-            if subnet_id != 'N/A':
-                subnet_associations.append(subnet_id)
-
-        subnet_associations_str = '; '.join(subnet_associations) if subnet_associations else "N/A"
-
-        # Get owner information
-        owner_id = nacl.get('OwnerId', 'N/A')
-        owner_formatted = utils.get_account_name_formatted(owner_id)
-
-        # Add NACL data
-        nacl_entry = {
-            'Region': region,
-            'NACL ID': nacl_id,
-            'NACL Name': nacl_name,
-            'VPC ID': vpc_id,
-            'Is Default': 'Yes' if is_default else 'No',
-            'Inbound Rules': inbound_rules_str,
-            'Outbound Rules': outbound_rules_str,
-            'Subnet Associations': subnet_associations_str,
-            'Owner ID': owner_formatted,
-            'Tags': tags_str
-        }
-
-        nacl_data.append(nacl_entry)
+        try:
+            nacl_data.append(_build_nacl_row(nacl, region))
+        except Exception as e:
+            # One malformed NACL is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed NACL in {region}: "
+                f"{nacl.get('NetworkAclId', '<unknown>')}",
+                e,
+            )
+            continue
 
     return nacl_data
 
@@ -230,11 +250,13 @@ def main():
             utils.log_info(f"Found {len(region_data)} NACLs in {region}")
             return region_data
 
-        # Use concurrent region scanning
-        region_results = utils.scan_regions_concurrent(
+        # Use concurrent region scanning, surfacing per-region failures so a
+        # failed collection is never silently collapsed into "no NACLs".
+        region_results, failed_regions = utils.scan_regions_concurrent(
             regions=regions,
             scan_function=scan_region_nacls,
-            show_progress=True
+            show_progress=True,
+            collect_failures=True,
         )
 
         # Flatten results
@@ -272,6 +294,18 @@ def main():
             print("\nScript execution completed.")
         else:
             utils.log_error("Error exporting data. Please check the logs.")
+            sys.exit(1)
+
+        # If ANY region failed the primary NACL scope collection, make it loud:
+        # write a marker and exit non-zero, even though a workbook was written.
+        # A partial export that looks complete is exactly the failure mode this
+        # guards against.
+        if failed_regions:
+            utils.report_collection_failures(account_name, 'nacl', failed_regions)
+            print(
+                "\nERROR: NACL export completed with failures — data is incomplete. "
+                "See the *-nacl-FAILED-*.txt marker in the output directory."
+            )
             sys.exit(1)
 
     except KeyboardInterrupt:

--- a/scripts/network_manager_export.py
+++ b/scripts/network_manager_export.py
@@ -48,33 +48,80 @@ utils.setup_logging('network-manager-export')
 home_region: str = 'us-west-2'
 
 
-@utils.aws_error_handler("Collecting global networks", default_return=[])
+def _build_global_network_row(network: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single Network Manager global network.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed global network entry must not sink the whole
+    account-scope collection. Required fields are read with ``.get()`` and a
+    safe default for the same reason (the previous hard
+    ``network['GlobalNetworkId']`` subscript was the KeyError source flagged
+    in the 07.16.2026 silent-collection-failure audit).
+
+    Args:
+        network: A single GlobalNetworks entry from describe_global_networks.
+
+    Returns:
+        dict: The assembled global network row.
+    """
+    tags = []
+    for tag in network.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    return {
+        'GlobalNetworkId': network.get('GlobalNetworkId', 'N/A'),
+        'GlobalNetworkArn': network.get('GlobalNetworkArn', 'N/A'),
+        'Description': network.get('Description', 'N/A'),
+        'State': network.get('State', 'N/A'),
+        'CreatedAt': network.get('CreatedAt'),
+        'Tags': ', '.join(tags) if tags else 'N/A',
+    }
+
+
 def collect_global_networks() -> list[dict[str, Any]]:
-    """Collect all Network Manager global networks."""
+    """
+    Collect all Network Manager global networks.
+
+    Network Manager is a global, account-scope service (not multi-region —
+    see scripts/shield_export.py for the account-scope reference pattern
+    this follows). Not wrapped in ``aws_error_handler`` and does not swallow
+    account-scope errors (client creation, pagination) to an empty list: a
+    swallowed error here would be indistinguishable from a genuinely empty
+    account (no global networks configured), producing silent data loss
+    (see the 07.16.2026 silent-collection-failure audit). Per-item errors
+    are contained internally (logged and skipped) via
+    ``_build_global_network_row``.
+
+    Returns:
+        list: List of global network dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     # Network Manager is a global service, use us-west-2
     # Networkmanager is a global service - use partition-aware home region
     nm = utils.get_boto3_client('networkmanager', region_name=home_region)
     networks = []
+    skipped = 0
 
-    try:
-        paginator = nm.get_paginator('describe_global_networks')
-        for page in paginator.paginate():
-            for network in page.get('GlobalNetworks', []):
-                # Format tags
-                tags = []
-                for tag in network.get('Tags', []):
-                    tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+    paginator = nm.get_paginator('describe_global_networks')
+    for page in paginator.paginate():
+        for network in page.get('GlobalNetworks', []):
+            try:
+                networks.append(_build_global_network_row(network))
+            except Exception as e:
+                skipped += 1
+                network_id = network.get('GlobalNetworkId', 'Unknown') if isinstance(network, dict) else 'Unknown'
+                utils.log_error(f"Skipping Network Manager global network '{network_id}' due to a processing error", e)
+                continue
 
-                networks.append({
-                    'GlobalNetworkId': network.get('GlobalNetworkId', 'N/A'),
-                    'GlobalNetworkArn': network.get('GlobalNetworkArn', 'N/A'),
-                    'Description': network.get('Description', 'N/A'),
-                    'State': network.get('State', 'N/A'),
-                    'CreatedAt': network.get('CreatedAt'),
-                    'Tags': ', '.join(tags) if tags else 'N/A',
-                })
-    except Exception as e:
-        utils.log_warning(f"Error collecting Network Manager global networks: {e}")
+    if skipped:
+        utils.log_warning(
+            f"{skipped} Network Manager global network(s) were skipped due to "
+            "processing errors (see log above); the remaining global networks were still collected."
+        )
 
     return networks
 
@@ -278,16 +325,42 @@ def collect_cgw_associations(global_network_id: str) -> list[dict[str, Any]]:
 
 
 def _run_export(account_id: str, account_name: str) -> None:
-    """Collect Network Manager data and write the Excel export."""
+    """
+    Collect Network Manager data and write the Excel export.
+
+    Network Manager is a global, account-scope service, so failures are
+    tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py for the
+    account-scope reference pattern). The ``global_networks`` scope is the
+    primary collector: a real API error there must propagate to
+    ``failed_scopes`` and never collapse into "no global networks
+    configured" (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    Per-global-network enrichment (sites/links/devices/connections/TGW
+    registrations/CGW associations) stays graceful via its own
+    ``aws_error_handler`` decorators.
+    """
     utils.log_info("Network Manager is a global service accessed through us-west-2.")
     utils.log_info("Scanning for global networks and SD-WAN topology...")
 
-    # Collect global networks
-    global_networks = collect_global_networks()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes: list = []
+
+    # STEP 1: Collect global networks (PRIMARY scope — a real API error here
+    # must propagate to failed_scopes, never collapse into an empty list
+    # that reads as "no global networks configured").
+    try:
+        global_networks = collect_global_networks()
+    except Exception as e:
+        failed_scopes.append(('global_networks', str(e)))
+        utils.log_error(f"Network Manager global networks collection failed: {e}")
+        global_networks = []
 
     if not global_networks:
-        utils.log_warning("No Network Manager global networks found.")
-        utils.log_info("Creating empty export file...")
+        if failed_scopes:
+            utils.log_warning("Global networks collection failed; proceeding with an empty result set.")
+        else:
+            utils.log_warning("No Network Manager global networks found.")
+        utils.log_info("Creating export file with forced Summary sheet...")
     else:
         utils.log_info(f"Found {len(global_networks)} global network(s)")
 
@@ -300,7 +373,7 @@ def _run_export(account_id: str, account_name: str) -> None:
     all_cgw_associations = []
 
     for idx, network in enumerate(global_networks, 1):
-        global_network_id = network['GlobalNetworkId']
+        global_network_id = network.get('GlobalNetworkId', 'N/A')
         utils.log_info(f"[{idx}/{len(global_networks)}] Processing global network: {global_network_id}")
 
         # Collect sites
@@ -414,6 +487,19 @@ def _run_export(account_id: str, account_name: str) -> None:
     utils.log_info(f"  CGW Associations: {len(all_cgw_associations)}")
 
     utils.log_success("Network Manager export completed successfully!")
+
+    # If the global_networks scope failed, make it loud: write a marker and
+    # exit non-zero, even though a workbook (with a forced Summary sheet)
+    # was written. A partial export that looks complete is exactly the
+    # failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'network-manager', failed_scopes)
+        print(
+            "\nERROR: Network Manager export completed with failures — data is "
+            "incomplete. See the *-network-manager-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/rekognition_export.py
+++ b/scripts/rekognition_export.py
@@ -26,50 +26,94 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export Amazon Rekognition collections to Excel")
 
-@utils.aws_error_handler("Collecting Rekognition projects", default_return=[])
-def collect_projects(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect Rekognition custom model projects from AWS regions."""
-    all_projects = []
+def _build_project_row(project: dict, region: str) -> dict[str, Any]:
+    """Build a single Rekognition project export row from a describe response."""
+    project_arn = project.get('ProjectArn', 'N/A')
+    creation_timestamp = project.get('CreationTimestamp', 'N/A')
+    status = project.get('Status', 'N/A')
 
-    for region in regions:
-        utils.log_info(f"Collecting Rekognition projects in {region}...")
-        rekognition_client = utils.get_boto3_client('rekognition', region_name=region)
+    if creation_timestamp != 'N/A':
+        creation_timestamp = creation_timestamp.strftime('%Y-%m-%d %H:%M:%S')
 
-        try:
-            paginator = rekognition_client.get_paginator('describe_projects')
-            for page in paginator.paginate():
-                projects = page.get('ProjectDescriptions', [])
+    # Extract project name from ARN
+    # ARN format: arn:aws:rekognition:region:account-id:project/project-name/timestamp
+    project_name = 'N/A'
+    if project_arn != 'N/A' and '/project/' in project_arn:
+        parts = project_arn.split('/project/')
+        if len(parts) > 1:
+            project_name = parts[1].split('/')[0]
 
-                for project in projects:
-                    project_arn = project.get('ProjectArn', 'N/A')
-                    creation_timestamp = project.get('CreationTimestamp', 'N/A')
-                    status = project.get('Status', 'N/A')
+    return {
+        'Region': region,
+        'Project Name': project_name,
+        'Project ARN': project_arn,
+        'Status': status,
+        'Created': creation_timestamp
+    }
 
-                    if creation_timestamp != 'N/A':
-                        creation_timestamp = creation_timestamp.strftime('%Y-%m-%d %H:%M:%S')
 
-                    # Extract project name from ARN
-                    # ARN format: arn:aws:rekognition:region:account-id:project/project-name/timestamp
-                    project_name = 'N/A'
-                    if project_arn != 'N/A' and '/project/' in project_arn:
-                        parts = project_arn.split('/project/')
-                        if len(parts) > 1:
-                            project_name = parts[1].split('/')[0]
+def _scan_projects_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Rekognition custom model projects from a single region.
 
-                    all_projects.append({
-                        'Region': region,
-                        'Project Name': project_name,
-                        'Project ARN': project_arn,
-                        'Status': status,
-                        'Created': creation_timestamp
-                    })
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no projects" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
 
-        except Exception as e:
-            utils.log_warning(f"Error listing Rekognition projects in {region}: {str(e)}")
-            continue
+    Individual malformed projects are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
 
+    utils.log_info(f"Collecting Rekognition projects in {region}...")
+    rekognition_client = utils.get_boto3_client('rekognition', region_name=region)
+
+    region_projects = []
+    paginator = rekognition_client.get_paginator('describe_projects')
+    for page in paginator.paginate():
+        projects = page.get('ProjectDescriptions', [])
+
+        for project in projects:
+            try:
+                region_projects.append(_build_project_row(project, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Rekognition project in {region}: "
+                    f"{project.get('ProjectArn', '<unknown>')}",
+                    e,
+                )
+                continue
+
+    utils.log_info(f"Collected {len(region_projects)} projects in {region}")
+    return region_projects
+
+
+def collect_projects(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Rekognition custom model projects across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(projects, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_projects_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_projects = [project for result in region_results for project in result]
     utils.log_info(f"Collected {len(all_projects)} projects")
-    return all_projects
+    return all_projects, failed_regions
 
 
 @utils.aws_error_handler("Collecting Rekognition project versions", default_return=[])
@@ -397,7 +441,9 @@ def main():
     # Collect data
     print("\nCollecting Amazon Rekognition data...")
 
-    projects = collect_projects(regions)
+    # Collect projects (primary scope — region failures must propagate as
+    # failed_regions, never collapse into "empty").
+    projects, failed_regions = collect_projects(regions)
     versions = collect_project_versions(regions)
     collections = collect_collections(regions)
     stream_processors = collect_stream_processors(regions)
@@ -444,6 +490,18 @@ def main():
         # Log summary
     else:
         utils.log_warning("No Amazon Rekognition data found to export")
+
+    # If ANY region failed the projects scope collection, make it loud: write
+    # a marker and exit non-zero, even though the always-written Summary
+    # sheet means a workbook still lands. A partial export that looks
+    # complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'rekognition', failed_regions)
+        print(
+            "\nERROR: Rekognition export completed with failures — data is incomplete. "
+            "See the *-rekognition-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Amazon Rekognition export completed successfully")
 

--- a/scripts/route53_export.py
+++ b/scripts/route53_export.py
@@ -50,13 +50,114 @@ except ImportError:
 args = utils.parse_script_args("Export Route 53 hosted zones and records to Excel")
 
 
-@utils.aws_error_handler("Collecting Route 53 hosted zones", default_return=[])
+def _build_hosted_zone_row(route53, zone: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single Route 53 hosted zone.
+
+    Extracted so per-zone processing can be wrapped in try/except by the
+    caller: a malformed zone entry or a failed detail lookup for one zone
+    must not sink the whole account-scope hosted-zones collection. Required
+    fields are read with ``.get()`` and a safe default for the same reason.
+
+    Args:
+        route53: The boto3 Route 53 client.
+        zone: A single HostedZones entry from list_hosted_zones.
+
+    Returns:
+        dict: The assembled hosted zone row.
+    """
+    zone_id = zone.get('Id', '').split('/')[-1]  # Extract ID from ARN
+    zone_name = zone.get('Name', '')
+
+    print(f"  Processing hosted zone: {zone_name} ({zone_id})")
+
+    # Get detailed zone information
+    zone_detail = route53.get_hosted_zone(Id=zone_id)
+    zone_info = zone_detail.get('HostedZone', {})
+    zone_config = zone_info.get('Config', {})
+
+    # Basic information
+    is_private = zone_config.get('PrivateZone', False)
+    zone_type = 'Private' if is_private else 'Public'
+    comment = zone_config.get('Comment', 'N/A')
+
+    # VPC associations (for private zones)
+    vpcs = zone_detail.get('VPCs', [])
+    vpc_list = []
+    for vpc in vpcs:
+        vpc_id = vpc.get('VPCId', '')
+        vpc_region = vpc.get('VPCRegion', '')
+        vpc_list.append(f"{vpc_id} ({vpc_region})")
+    vpc_associations = ', '.join(vpc_list) if vpc_list else 'N/A'
+
+    # Resource record set count
+    record_count = zone_info.get('ResourceRecordSetCount', 0)
+
+    # Get DNSSEC status
+    dnssec_status = 'N/A'
+    try:
+        dnssec = route53.get_dnssec(HostedZoneId=zone_id)
+        dnssec_status = dnssec.get('Status', {}).get('ServeSignature', 'DISABLED')
+    except Exception:
+        # DNSSEC not configured
+        dnssec_status = 'NOT_CONFIGURED'
+
+    # Get query logging config
+    query_logging = 'Disabled'
+    try:
+        query_configs = route53.list_query_logging_configs(HostedZoneId=zone_id)
+        configs = query_configs.get('QueryLoggingConfigs', [])
+        if configs:
+            query_logging = f"Enabled ({len(configs)} configs)"
+    except Exception:
+        pass
+
+    # Tags
+    try:
+        tags_response = route53.list_tags_for_resource(
+            ResourceType='hostedzone',
+            ResourceId=zone_id
+        )
+        tags_list = tags_response.get('ResourceTagSet', {}).get('Tags', [])
+        tags = ', '.join([f"{tag.get('Key')}={tag.get('Value')}" for tag in tags_list]) if tags_list else 'N/A'
+    except Exception:
+        tags = 'N/A'
+
+    return {
+        'Zone ID': zone_id,
+        'Zone Name': zone_name,
+        'Type': zone_type,
+        'Record Count': record_count,
+        'VPC Associations': vpc_associations,
+        'DNSSEC Status': dnssec_status,
+        'Query Logging': query_logging,
+        'Comment': comment,
+        'Tags': tags
+    }
+
+
 def collect_hosted_zones() -> list[dict[str, Any]]:
     """
     Collect Route 53 hosted zone information.
 
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no hosted zones configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Route 53 hosted zones are a global, account-scope resource (not
+    multi-region — see scripts/shield_export.py for the account-scope
+    reference pattern this follows). Account-scope failures (client
+    creation, pagination) are allowed to raise so the caller
+    (export_route53_data) can record this scope as *failed* rather than
+    *empty*. Per-zone errors are contained internally (logged and skipped)
+    via ``_build_hosted_zone_row``.
+
     Returns:
-        list: List of dictionaries with hosted zone details
+        list: List of dictionaries with hosted zone details.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
     """
     print("\n=== COLLECTING HOSTED ZONES ===")
     utils.log_info("Route 53 is a global service - collecting from us-east-1")
@@ -70,91 +171,32 @@ def collect_hosted_zones() -> list[dict[str, Any]]:
     paginator = route53.get_paginator('list_hosted_zones')
 
     total_count = 0
+    skipped = 0
+
     for page in paginator.paginate():
         zone_list = page.get('HostedZones', [])
         total_count += len(zone_list)
 
+        # Process each zone. One malformed zone (or a failed detail lookup
+        # for it) must not sink the whole account-scope collection, so each
+        # is built inside try/except; failures are logged and skipped.
         for zone in zone_list:
-            zone_id = zone.get('Id', '').split('/')[-1]  # Extract ID from ARN
-            zone_name = zone.get('Name', '')
-
-            print(f"  Processing hosted zone: {zone_name} ({zone_id})")
-
             try:
-                # Get detailed zone information
-                zone_detail = route53.get_hosted_zone(Id=zone_id)
-                zone_info = zone_detail.get('HostedZone', {})
-                zone_config = zone_info.get('Config', {})
-
-                # Basic information
-                is_private = zone_config.get('PrivateZone', False)
-                zone_type = 'Private' if is_private else 'Public'
-                comment = zone_config.get('Comment', 'N/A')
-
-                # VPC associations (for private zones)
-                vpcs = zone_detail.get('VPCs', [])
-                vpc_list = []
-                for vpc in vpcs:
-                    vpc_id = vpc.get('VPCId', '')
-                    vpc_region = vpc.get('VPCRegion', '')
-                    vpc_list.append(f"{vpc_id} ({vpc_region})")
-                vpc_associations = ', '.join(vpc_list) if vpc_list else 'N/A'
-
-                # Resource record set count
-                record_count = zone_info.get('ResourceRecordSetCount', 0)
-
-                # Get DNSSEC status
-                dnssec_status = 'N/A'
-                try:
-                    dnssec = route53.get_dnssec(HostedZoneId=zone_id)
-                    dnssec_status = dnssec.get('Status', {}).get('ServeSignature', 'DISABLED')
-                except Exception:
-                    # DNSSEC not configured
-                    dnssec_status = 'NOT_CONFIGURED'
-
-                # Get query logging config
-                query_logging = 'Disabled'
-                try:
-                    query_configs = route53.list_query_logging_configs(HostedZoneId=zone_id)
-                    configs = query_configs.get('QueryLoggingConfigs', [])
-                    if configs:
-                        query_logging = f"Enabled ({len(configs)} configs)"
-                except Exception:
-                    pass
-
-                # Tags
-                try:
-                    tags_response = route53.list_tags_for_resource(
-                        ResourceType='hostedzone',
-                        ResourceId=zone_id
-                    )
-                    tags_list = tags_response.get('ResourceTagSet', {}).get('Tags', [])
-                    tags = ', '.join([f"{tag['Key']}={tag['Value']}" for tag in tags_list]) if tags_list else 'N/A'
-                except Exception:
-                    tags = 'N/A'
-
-                zones.append({
-                    'Zone ID': zone_id,
-                    'Zone Name': zone_name,
-                    'Type': zone_type,
-                    'Record Count': record_count,
-                    'VPC Associations': vpc_associations,
-                    'DNSSEC Status': dnssec_status,
-                    'Query Logging': query_logging,
-                    'Comment': comment,
-                    'Tags': tags
-                })
-
+                zones.append(_build_hosted_zone_row(route53, zone))
             except Exception as e:
-                utils.log_error(f"Error getting details for zone {zone_id}", e)
-                zones.append({
-                    'Zone ID': zone_id,
-                    'Zone Name': zone_name,
-                    'Error': f'Could not retrieve full details: {str(e)}'
-                })
+                skipped += 1
+                zone_name = zone.get('Name', 'Unknown') if isinstance(zone, dict) else 'Unknown'
+                utils.log_error(f"Skipping Route 53 hosted zone '{zone_name}' due to a processing error", e)
+                continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {total_count} Route 53 hosted zone(s) were skipped due to "
+            "processing errors (see log above); the remaining zones were still collected."
+        )
 
     print(f"\nTotal hosted zones found: {total_count}")
-    utils.log_success(f"Total Route 53 hosted zones collected: {total_count}")
+    utils.log_success(f"Total Route 53 hosted zones collected: {len(zones)}")
 
     return zones
 
@@ -683,32 +725,44 @@ def export_route53_data(account_id: str, account_name: str, regions: list[str]):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect hosted zones
-    zones = collect_hosted_zones()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect hosted zones (PRIMARY scope — a real API error here
+    # must propagate to failed_scopes, never collapse into an empty list
+    # that reads as "no hosted zones configured").
+    try:
+        zones = collect_hosted_zones()
+    except Exception as e:
+        failed_scopes.append(('hosted_zones', str(e)))
+        utils.log_error(f"Route 53 hosted zones collection failed: {e}")
+        zones = []
     if zones:
         data_frames['Hosted Zones'] = pd.DataFrame(zones)
 
-    # STEP 2: Collect DNS records
+    # STEP 2: Collect DNS records (enrichment — per-zone; degrades
+    # gracefully via its own aws_error_handler decorator, so a failure here
+    # does not fail the whole export).
     records = collect_dns_records()
     if records:
         data_frames['DNS Records'] = pd.DataFrame(records)
 
-    # STEP 3: Collect health checks
+    # STEP 3: Collect health checks (enrichment)
     health_checks = collect_health_checks()
     if health_checks:
         data_frames['Health Checks'] = pd.DataFrame(health_checks)
 
-    # STEP 4: Collect resolver endpoints (regional)
+    # STEP 4: Collect resolver endpoints (regional, enrichment)
     endpoints = collect_resolver_endpoints(regions)
     if endpoints:
         data_frames['Resolver Endpoints'] = pd.DataFrame(endpoints)
 
-    # STEP 5: Collect resolver rules (regional)
+    # STEP 5: Collect resolver rules (regional, enrichment)
     rules = collect_resolver_rules(regions)
     if rules:
         data_frames['Resolver Rules'] = pd.DataFrame(rules)
 
-    # STEP 6: Collect query logging configs
+    # STEP 6: Collect query logging configs (enrichment)
     query_configs = collect_query_logging_configs()
     if query_configs:
         data_frames['Query Logging Configs'] = pd.DataFrame(query_configs)
@@ -757,6 +811,28 @@ def export_route53_data(account_id: str, account_name: str, regions: list[str]):
 
     except Exception as e:
         utils.log_error("Error creating Excel file", e)
+
+    # Genuinely empty vs failed: the hosted-zones scope succeeded (no
+    # exception) but every scope came back with nothing configured. This is
+    # a plain informational warning, not a failure — the always-written
+    # Summary sheet still lands above.
+    has_any_data = bool(zones or records or health_checks or endpoints or rules or query_configs)
+    if not has_any_data and not failed_scopes:
+        utils.log_warning("No Route 53 resources were found in this account. Nothing collected.")
+
+    # If the hosted-zones scope failed, make it loud: write a marker and
+    # exit non-zero, even though a partial/summary-only workbook was still
+    # written above. A file that looks complete is exactly the failure mode
+    # this guards against (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'route53', failed_scopes)
+        print(
+            "\nERROR: Route 53 export completed with failures — data is "
+            "incomplete. See the *-route53-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/ses_export.py
+++ b/scripts/ses_export.py
@@ -32,98 +32,130 @@ args = utils.parse_script_args("Export Amazon SES identities and configuration t
 logger = utils.setup_logging('ses-export')
 
 def _scan_email_identities_region(region: str) -> list[dict[str, Any]]:
-    """Scan email identities in a single region."""
+    """
+    Collect SES email identities from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no identities" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed identities are skipped (logged) rather than aborting
+    the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_identities = []
     ses_client = utils.get_boto3_client('sesv2', region_name=region)
 
-    try:
-        next_token = None
-        while True:
-            params = {}
-            if next_token:
-                params['NextToken'] = next_token
-            page = ses_client.list_email_identities(**params)
-            identities = page.get('EmailIdentities', [])
+    next_token = None
+    while True:
+        params = {}
+        if next_token:
+            params['NextToken'] = next_token
+        page = ses_client.list_email_identities(**params)
+        identities = page.get('EmailIdentities', [])
 
-            for identity_summary in identities:
-                identity_name = identity_summary.get('IdentityName', 'N/A')
-                identity_type = identity_summary.get('IdentityType', 'N/A')
+        for identity_summary in identities:
+            identity_name = identity_summary.get('IdentityName', '<unknown>')
+            try:
+                regional_identities.append(
+                    _build_identity_row(identity_summary, region, ses_client)
+                )
+            except Exception as e:
+                # One malformed/inaccessible identity is skipped, not fatal
+                # to the region.
+                utils.log_error(
+                    f"Skipping SES identity in {region}: {identity_name}", e
+                )
+                continue
 
-                try:
-                    # Get detailed identity information
-                    identity_response = ses_client.get_email_identity(
-                        EmailIdentity=identity_name
-                    )
-
-                    verified = identity_response.get('VerifiedForSendingStatus', False)
-                    dkim_enabled = False
-                    dkim_status = 'N/A'
-                    dkim_tokens = 'N/A'
-
-                    dkim_attributes = identity_response.get('DkimAttributes', {})
-                    if dkim_attributes:
-                        dkim_enabled = dkim_attributes.get('SigningEnabled', False)
-                        dkim_status = dkim_attributes.get('Status', 'N/A')
-                        tokens = dkim_attributes.get('Tokens', [])
-                        if tokens:
-                            dkim_tokens = ', '.join(tokens[:3])  # First 3 tokens
-
-                    # Mail FROM domain
-                    mail_from_attributes = identity_response.get('MailFromAttributes', {})
-                    mail_from_domain = mail_from_attributes.get('MailFromDomain', 'N/A')
-                    mail_from_status = mail_from_attributes.get('MailFromDomainStatus', 'N/A')
-
-                    # Feedback forwarding
-                    feedback_attributes = identity_response.get('FeedbackForwardingStatus', False)
-
-                    # Get tags
-                    tags_str = 'N/A'
-                    try:
-                        tags_response = ses_client.list_tags_for_resource(
-                            ResourceArn=identity_response.get('IdentityArn', '')
-                        )
-                        tags = tags_response.get('Tags', [])
-                        if tags:
-                            tags_str = ', '.join([f"{tag['Key']}={tag['Value']}" for tag in tags])
-                    except Exception:
-                        pass
-
-                    regional_identities.append({
-                        'Region': region,
-                        'Identity Name': identity_name,
-                        'Identity Type': identity_type,
-                        'Verified': verified,
-                        'DKIM Enabled': dkim_enabled,
-                        'DKIM Status': dkim_status,
-                        'DKIM Tokens': dkim_tokens,
-                        'Mail From Domain': mail_from_domain,
-                        'Mail From Status': mail_from_status,
-                        'Feedback Forwarding': feedback_attributes,
-                        'Tags': tags_str
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for identity {identity_name} in {region}: {str(e)}")
-                    continue
-
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-
-    except Exception as e:
-        utils.log_warning(f"Error listing email identities in {region}: {str(e)}")
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
 
     return regional_identities
 
 
-@utils.aws_error_handler("Collecting email identities", default_return=[])
-def collect_email_identities(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect SES email identity information from AWS regions."""
+def _build_identity_row(identity_summary: dict, region: str, ses_client) -> dict[str, Any]:
+    """Build a single SES email identity export row (includes detail lookups)."""
+    identity_name = identity_summary.get('IdentityName', 'N/A')
+    identity_type = identity_summary.get('IdentityType', 'N/A')
+
+    # Get detailed identity information
+    identity_response = ses_client.get_email_identity(EmailIdentity=identity_name)
+
+    verified = identity_response.get('VerifiedForSendingStatus', False)
+    dkim_enabled = False
+    dkim_status = 'N/A'
+    dkim_tokens = 'N/A'
+
+    dkim_attributes = identity_response.get('DkimAttributes', {})
+    if dkim_attributes:
+        dkim_enabled = dkim_attributes.get('SigningEnabled', False)
+        dkim_status = dkim_attributes.get('Status', 'N/A')
+        tokens = dkim_attributes.get('Tokens', [])
+        if tokens:
+            dkim_tokens = ', '.join(tokens[:3])  # First 3 tokens
+
+    # Mail FROM domain
+    mail_from_attributes = identity_response.get('MailFromAttributes', {})
+    mail_from_domain = mail_from_attributes.get('MailFromDomain', 'N/A')
+    mail_from_status = mail_from_attributes.get('MailFromDomainStatus', 'N/A')
+
+    # Feedback forwarding
+    feedback_attributes = identity_response.get('FeedbackForwardingStatus', False)
+
+    # Get tags
+    tags_str = 'N/A'
+    try:
+        tags_response = ses_client.list_tags_for_resource(
+            ResourceArn=identity_response.get('IdentityArn', '')
+        )
+        tags = tags_response.get('Tags', [])
+        if tags:
+            tags_str = ', '.join([f"{tag.get('Key')}={tag.get('Value')}" for tag in tags])
+    except Exception:
+        pass
+
+    return {
+        'Region': region,
+        'Identity Name': identity_name,
+        'Identity Type': identity_type,
+        'Verified': verified,
+        'DKIM Enabled': dkim_enabled,
+        'DKIM Status': dkim_status,
+        'DKIM Tokens': dkim_tokens,
+        'Mail From Domain': mail_from_domain,
+        'Mail From Status': mail_from_status,
+        'Feedback Forwarding': feedback_attributes,
+        'Tags': tags_str
+    }
+
+
+def collect_email_identities(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect SES email identity information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(identities, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING EMAIL IDENTITIES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_email_identities_region)
+    results, failed_regions = utils.scan_regions_concurrent(
+        regions, _scan_email_identities_region, collect_failures=True
+    )
     all_identities = [identity for result in results for identity in result]
     utils.log_success(f"Total email identities collected: {len(all_identities)}")
-    return all_identities
+    return all_identities, failed_regions
 
 
 def _scan_configuration_sets_region(region: str) -> list[dict[str, Any]]:
@@ -425,7 +457,11 @@ def main():
     # Collect data
     print("\nCollecting SES data...")
 
-    identities = collect_email_identities(regions)
+    # PRIMARY scope: region failures must propagate as failed_regions, never
+    # collapse into "empty" (see .collab/audit/07.16.2026-...).
+    identities, failed_regions = collect_email_identities(regions)
+    # Enrichment scopes: degrade gracefully; a region-level failure here does
+    # not fail the whole export.
     config_sets = collect_configuration_sets(regions)
     templates = collect_email_templates(regions)
     quotas = collect_sending_quotas(regions)
@@ -461,7 +497,9 @@ def main():
         df_quotas = utils.prepare_dataframe_for_export(df_quotas)
         dataframes['Sending Quotas'] = df_quotas
 
-    # Export to Excel
+    # Export to Excel. The Summary sheet is always populated (forced), so a
+    # workbook always lands here even when identities/config_sets/templates
+    # are empty — that behavior is preserved as-is.
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'ses', region_suffix)
@@ -474,6 +512,19 @@ def main():
         utils.log_warning("No SES data found to export")
 
     utils.log_success("SES export completed successfully")
+
+    # If ANY region failed the Email Identities scope collection, make it
+    # loud: write a marker and exit non-zero, even though the always-written
+    # Summary sheet (and possibly other data) still landed. A workbook that
+    # looks complete but silently hides a zero-row/incomplete data sheet is
+    # exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ses', failed_regions)
+        print(
+            "\nERROR: SES export completed with failures — data is incomplete. "
+            "See the *-ses-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/ses_pinpoint_export.py
+++ b/scripts/ses_pinpoint_export.py
@@ -41,66 +41,124 @@ args = utils.parse_script_args("Export Amazon SES and Pinpoint resources to Exce
 utils.setup_logging('ses-pinpoint-export')
 
 
-@utils.aws_error_handler("Collecting SES identities", default_return=[])
-def collect_ses_identities(region: str) -> list[dict[str, Any]]:
-    """Collect SES email identities (v2 API)."""
+def _build_identity_row(identity: dict[str, Any], region: str, sesv2_client: Any) -> dict[str, Any]:
+    """
+    Build a single SES identity export row.
+
+    The detail lookup (``get_email_identity``) is best-effort: if it fails,
+    the row still includes the summary fields (with detail fields set to
+    'N/A') rather than being dropped — a detail-fetch failure for one
+    identity must not discard the whole identity.
+    """
+    identity_name = identity.get('IdentityName', 'N/A')
+    identity_type = identity.get('IdentityType', 'N/A')
+    sending_enabled = identity.get('SendingEnabled', False)
+
+    try:
+        detail = sesv2_client.get_email_identity(EmailIdentity=identity_name)
+
+        # Extract DKIM attributes
+        dkim = detail.get('DkimAttributes', {})
+        mail_from = detail.get('MailFromAttributes', {})
+
+        return {
+            'Region': region,
+            'IdentityName': identity_name,
+            'IdentityType': identity_type,
+            'SendingEnabled': sending_enabled,
+            'VerificationStatus': detail.get('VerifiedForSendingStatus', False),
+            'DkimEnabled': dkim.get('SigningEnabled', False),
+            'DkimStatus': dkim.get('Status', 'N/A'),
+            'DkimTokens': ', '.join(dkim.get('Tokens', [])) if dkim.get('Tokens') else 'N/A',
+            'MailFromDomain': mail_from.get('MailFromDomain', 'N/A'),
+            'MailFromStatus': mail_from.get('MailFromDomainStatus', 'N/A'),
+            'FeedbackForwardingEnabled': detail.get('FeedbackForwardingStatus', False),
+        }
+    except Exception:
+        # Fallback to summary data — the detail lookup failing is not a
+        # reason to drop the identity itself.
+        return {
+            'Region': region,
+            'IdentityName': identity_name,
+            'IdentityType': identity_type,
+            'SendingEnabled': sending_enabled,
+            'VerificationStatus': 'N/A',
+            'DkimEnabled': 'N/A',
+            'DkimStatus': 'N/A',
+            'DkimTokens': 'N/A',
+            'MailFromDomain': 'N/A',
+            'MailFromStatus': 'N/A',
+            'FeedbackForwardingEnabled': 'N/A',
+        }
+
+
+def _scan_ses_identities_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect SES email identities from a single region (v2 API).
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no SES identities" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed identities are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     sesv2 = utils.get_boto3_client('sesv2', region_name=region)
     identities = []
 
-    try:
-        next_token = None
-        while True:
-            params = {}
-            if next_token:
-                params['NextToken'] = next_token
-            page = sesv2.list_email_identities(**params)
-            for identity in page.get('EmailIdentities', []):
-                identity_name = identity.get('IdentityName', 'N/A')
+    next_token = None
+    while True:
+        params = {}
+        if next_token:
+            params['NextToken'] = next_token
+        page = sesv2.list_email_identities(**params)
 
-                # Get detailed identity information
-                try:
-                    detail = sesv2.get_email_identity(EmailIdentity=identity_name)
+        for identity in page.get('EmailIdentities', []):
+            try:
+                identities.append(_build_identity_row(identity, region, sesv2))
+            except Exception as e:
+                # One malformed identity is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed SES identity in {region}: "
+                    f"{identity.get('IdentityName', '<unknown>')}",
+                    e,
+                )
+                continue
 
-                    # Extract DKIM attributes
-                    dkim = detail.get('DkimAttributes', {})
-                    mail_from = detail.get('MailFromAttributes', {})
-
-                    identities.append({
-                        'Region': region,
-                        'IdentityName': identity_name,
-                        'IdentityType': identity.get('IdentityType', 'N/A'),
-                        'SendingEnabled': identity.get('SendingEnabled', False),
-                        'VerificationStatus': detail.get('VerifiedForSendingStatus', False),
-                        'DkimEnabled': dkim.get('SigningEnabled', False),
-                        'DkimStatus': dkim.get('Status', 'N/A'),
-                        'DkimTokens': ', '.join(dkim.get('Tokens', [])) if dkim.get('Tokens') else 'N/A',
-                        'MailFromDomain': mail_from.get('MailFromDomain', 'N/A'),
-                        'MailFromStatus': mail_from.get('MailFromDomainStatus', 'N/A'),
-                        'FeedbackForwardingEnabled': detail.get('FeedbackForwardingStatus', False),
-                    })
-                except Exception:
-                    # Fallback to summary data
-                    identities.append({
-                        'Region': region,
-                        'IdentityName': identity_name,
-                        'IdentityType': identity.get('IdentityType', 'N/A'),
-                        'SendingEnabled': identity.get('SendingEnabled', False),
-                        'VerificationStatus': 'N/A',
-                        'DkimEnabled': 'N/A',
-                        'DkimStatus': 'N/A',
-                        'DkimTokens': 'N/A',
-                        'MailFromDomain': 'N/A',
-                        'MailFromStatus': 'N/A',
-                        'FeedbackForwardingEnabled': 'N/A',
-                    })
-
-            next_token = page.get('NextToken')
-            if not next_token:
-                break
-    except Exception as e:
-        utils.log_warning(f"Error collecting SES identities in region {region}: {e}")
+        next_token = page.get('NextToken')
+        if not next_token:
+            break
 
     return identities
+
+
+def collect_ses_identities(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect SES email identities across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(identities, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_ses_identities_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_identities = [identity for result in region_results for identity in result]
+    return all_identities, failed_regions
 
 
 @utils.aws_error_handler("Collecting SES configuration sets", default_return=[])
@@ -327,8 +385,15 @@ def collect_pinpoint_segments(region: str, app_ids: list[str]) -> list[dict[str,
 
 def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect SES and Pinpoint data and write the Excel export."""
-    # Collect all resources
-    all_ses_identities = []
+    # STEP 1: Collect SES identities (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    utils.log_info("=== COLLECTING SES IDENTITIES ===")
+    all_ses_identities, failed_regions = collect_ses_identities(regions)
+    utils.log_success(f"Total SES identities collected: {len(all_ses_identities)}")
+
+    # STEP 2: Enrichment collections (SES config sets/templates/account info,
+    # Pinpoint apps/campaigns/segments) — secondary scopes that degrade
+    # gracefully and do not affect failed_regions tracking.
     all_ses_config_sets = []
     all_ses_templates = []
     all_ses_account = []
@@ -338,12 +403,6 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
 
     for idx, region in enumerate(regions, 1):
         utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
-
-        # Collect SES resources
-        identities = collect_ses_identities(region)
-        if identities:
-            utils.log_info(f"  Found {len(identities)} SES identit(ies)")
-            all_ses_identities.extend(identities)
 
         config_sets = collect_ses_config_sets(region)
         if config_sets:
@@ -366,7 +425,7 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
             all_pinpoint_apps.extend(pinpoint_apps)
 
             # Get app IDs for campaigns and segments
-            app_ids = [app['ApplicationId'] for app in pinpoint_apps if app['ApplicationId'] != 'N/A']
+            app_ids = [app.get('ApplicationId', 'N/A') for app in pinpoint_apps if app.get('ApplicationId', 'N/A') != 'N/A']
 
             # Collect campaigns and segments
             campaigns = collect_pinpoint_campaigns(region, app_ids)
@@ -375,7 +434,8 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
             segments = collect_pinpoint_segments(region, app_ids)
             all_pinpoint_segments.extend(segments)
 
-    if not all_ses_identities and not all_pinpoint_apps:
+    if not all_ses_identities and not all_pinpoint_apps and not failed_regions:
+        # Genuinely empty account: every region succeeded and returned nothing.
         utils.log_warning("No SES or Pinpoint resources found in any selected region.")
         utils.log_info("Creating empty export file...")
 
@@ -450,6 +510,20 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.save_multiple_dataframes_to_excel(sheets, filename)
 
     utils.log_success("SES/Pinpoint export completed successfully!")
+
+    # If ANY region failed the primary SES-identities scope collection, make
+    # it loud: write a marker and exit non-zero, even though the workbook
+    # (including the always-written Summary sheet) has already landed. A
+    # complete-looking file that silently omits failed-region data is
+    # exactly the failure mode this guards against. Genuinely-empty stays
+    # exit 0 with no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ses-pinpoint', failed_regions)
+        print(
+            "\nERROR: SES/Pinpoint export completed with failures — data is incomplete. "
+            "See the *-ses-pinpoint-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -54,102 +54,130 @@ def scan_vpn_connections_in_region(region: str) -> list[dict[str, Any]]:
     """
     Scan Site-to-Site VPN connections in a single AWS region.
 
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no VPN connections" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed VPN connections are skipped (logged) rather than
+    aborting the whole region.
+
     Args:
         region: AWS region to scan
 
     Returns:
         list: List of VPN connection dictionaries for this region
     """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    ec2 = utils.get_boto3_client('ec2', region_name=region)
+
+    # Describe VPN connections
+    response = ec2.describe_vpn_connections()
+    vpn_list = response.get('VpnConnections', [])
+
     vpn_connections = []
-
-    try:
-        ec2 = utils.get_boto3_client('ec2', region_name=region)
-
-        # Describe VPN connections
-        response = ec2.describe_vpn_connections()
-        vpn_list = response.get('VpnConnections', [])
-
-        for vpn in vpn_list:
-            vpn_id = vpn.get('VpnConnectionId', '')
-            state = vpn.get('State', '')
-            vpn_type = vpn.get('Type', '')
-
-            print(f"    Processing VPN connection: {vpn_id} ({state})")
-
-            # Gateway IDs
-            customer_gateway_id = vpn.get('CustomerGatewayId', 'N/A')
-            vpn_gateway_id = vpn.get('VpnGatewayId', 'N/A')
-            transit_gateway_id = vpn.get('TransitGatewayId', 'N/A')
-
-            # Routing
-            static_routes_only = vpn.get('Options', {}).get('StaticRoutesOnly', False)
-            routing_type = 'Static' if static_routes_only else 'Dynamic (BGP)'
-
-            # Static routes
-            static_routes = vpn.get('Routes', [])
-            route_list = [f"{r.get('DestinationCidrBlock', '')} ({r.get('State', '')})" for r in static_routes]
-            routes = ', '.join(route_list) if route_list else 'N/A'
-
-            # Tunnel details (count)
-            vgw_telemetry = vpn.get('VgwTelemetry', [])
-            tunnel_count = len(vgw_telemetry)
-
-            # Check tunnel status
-            tunnels_up = sum(1 for t in vgw_telemetry if t.get('Status', '') == 'UP')
-            tunnel_status = f"{tunnels_up}/{tunnel_count} UP"
-
-            # Tags
-            tags = vpn.get('Tags', [])
-            tag_dict = {tag['Key']: tag['Value'] for tag in tags}
-            name = tag_dict.get('Name', 'N/A')
-            tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
-
-            vpn_connections.append({
-                'Region': region,
-                'VPN Connection ID': vpn_id,
-                'Name': name,
-                'State': state,
-                'Type': vpn_type,
-                'Routing Type': routing_type,
-                'Customer Gateway ID': customer_gateway_id,
-                'Virtual Private Gateway ID': vpn_gateway_id,
-                'Transit Gateway ID': transit_gateway_id,
-                'Tunnel Status': tunnel_status,
-                'Tunnel Count': tunnel_count,
-                'Static Routes': routes,
-                'Tags': tags_str
-            })
-
-    except Exception as e:
-        utils.log_error(f"Error collecting VPN connections in {region}", e)
+    for vpn in vpn_list:
+        try:
+            vpn_connections.append(_build_vpn_row(vpn, region))
+        except Exception as e:
+            # One malformed VPN connection is skipped, not fatal to the region.
+            utils.log_error(
+                f"Skipping malformed VPN connection in {region}: "
+                f"{vpn.get('VpnConnectionId', '<unknown>')}",
+                e,
+            )
+            continue
 
     utils.log_info(f"Found {len(vpn_connections)} VPN connections in {region}")
     return vpn_connections
 
 
-@utils.aws_error_handler("Collecting Site-to-Site VPN connections", default_return=[])
-def collect_vpn_connections(regions: list[str]) -> list[dict[str, Any]]:
+def _build_vpn_row(vpn: dict, region: str) -> dict[str, Any]:
+    """Build a single Site-to-Site VPN connection export row from a describe response."""
+    vpn_id = vpn.get('VpnConnectionId', '')
+    state = vpn.get('State', '')
+    vpn_type = vpn.get('Type', '')
+
+    print(f"    Processing VPN connection: {vpn_id} ({state})")
+
+    # Gateway IDs
+    customer_gateway_id = vpn.get('CustomerGatewayId', 'N/A')
+    vpn_gateway_id = vpn.get('VpnGatewayId', 'N/A')
+    transit_gateway_id = vpn.get('TransitGatewayId', 'N/A')
+
+    # Routing
+    static_routes_only = vpn.get('Options', {}).get('StaticRoutesOnly', False)
+    routing_type = 'Static' if static_routes_only else 'Dynamic (BGP)'
+
+    # Static routes
+    static_routes = vpn.get('Routes', [])
+    route_list = [f"{r.get('DestinationCidrBlock', '')} ({r.get('State', '')})" for r in static_routes]
+    routes = ', '.join(route_list) if route_list else 'N/A'
+
+    # Tunnel details (count)
+    vgw_telemetry = vpn.get('VgwTelemetry', [])
+    tunnel_count = len(vgw_telemetry)
+
+    # Check tunnel status
+    tunnels_up = sum(1 for t in vgw_telemetry if t.get('Status', '') == 'UP')
+    tunnel_status = f"{tunnels_up}/{tunnel_count} UP"
+
+    # Tags
+    tags = vpn.get('Tags', [])
+    tag_dict = {tag.get('Key'): tag.get('Value') for tag in tags if 'Key' in tag}
+    name = tag_dict.get('Name', 'N/A')
+    tags_str = ', '.join([f"{k}={v}" for k, v in tag_dict.items()]) if tag_dict else 'N/A'
+
+    return {
+        'Region': region,
+        'VPN Connection ID': vpn_id,
+        'Name': name,
+        'State': state,
+        'Type': vpn_type,
+        'Routing Type': routing_type,
+        'Customer Gateway ID': customer_gateway_id,
+        'Virtual Private Gateway ID': vpn_gateway_id,
+        'Transit Gateway ID': transit_gateway_id,
+        'Tunnel Status': tunnel_status,
+        'Tunnel Count': tunnel_count,
+        'Static Routes': routes,
+        'Tags': tags_str
+    }
+
+
+def collect_vpn_connections(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
     """
-    Collect Site-to-Site VPN connection information across regions.
+    Collect Site-to-Site VPN connection information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
 
     Args:
         regions: List of AWS regions to scan
 
     Returns:
-        list: List of dictionaries with VPN connection details
+        tuple: ``(vpn_connections, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
     """
     print("\n=== COLLECTING SITE-TO-SITE VPN CONNECTIONS ===")
     utils.log_info("Using concurrent region scanning for improved performance")
 
-    vpn_connections = []
-    for region_data in utils.scan_regions_concurrent(
+    region_results, failed_regions = utils.scan_regions_concurrent(
         regions=regions,
         scan_function=scan_vpn_connections_in_region,
-    ):
-        vpn_connections.extend(region_data)
+        show_progress=True,
+        collect_failures=True,
+    )
+    vpn_connections = [vpn for result in region_results for vpn in result]
 
     utils.log_success(f"Total Site-to-Site VPN connections collected: {len(vpn_connections)}")
-    return vpn_connections
+    return vpn_connections, failed_regions
 
 
 def scan_vpn_tunnels_in_region(region: str) -> list[dict[str, Any]]:
@@ -762,8 +790,9 @@ def export_vpn_data(account_id: str, account_name: str, regions: list[str]):
     # Dictionary to hold all DataFrames for export
     data_frames = {}
 
-    # STEP 1: Collect Site-to-Site VPN connections
-    vpn_connections = collect_vpn_connections(regions)
+    # STEP 1: Collect Site-to-Site VPN connections (primary scope — region
+    # failures must propagate as failed_regions, never collapse into "empty").
+    vpn_connections, failed_regions = collect_vpn_connections(regions)
     if vpn_connections:
         data_frames['S2S VPN Connections'] = pd.DataFrame(vpn_connections)
 
@@ -797,46 +826,62 @@ def export_vpn_data(account_id: str, account_name: str, regions: list[str]):
     if summary:
         data_frames['Summary'] = pd.DataFrame(summary)
 
-    # Check if we have any data
+    # Check if we have any data. In practice the Summary sheet above is forced
+    # (it always includes unconditional Gateways/Auth Rules categories), so
+    # this branch is a defense-in-depth guard rather than the common path —
+    # the workbook is expected to always land.
     if not data_frames:
-        utils.log_warning("No VPN data was collected. Nothing to export.")
-        print("\nNo VPN resources found in the selected regions.")
-        return
+        if not failed_regions:
+            # Genuinely empty account: every region succeeded and returned nothing.
+            utils.log_warning("No VPN data was collected. Nothing to export.")
+            print("\nNo VPN resources found in the selected regions.")
+    else:
+        # STEP 8: Prepare all DataFrames for export
+        for sheet_name in data_frames:
+            data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
 
-    # STEP 8: Prepare all DataFrames for export
-    for sheet_name in data_frames:
-        data_frames[sheet_name] = utils.prepare_dataframe_for_export(data_frames[sheet_name])
+        # STEP 9: Create filename and export
+        current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+        region_suffix = 'multi-region' if len(regions) > 1 else regions[0]
+        final_excel_file = utils.create_export_filename(
+            account_name,
+            'vpn',
+            region_suffix,
+            current_date
+        )
 
-    # STEP 9: Create filename and export
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    region_suffix = 'multi-region' if len(regions) > 1 else regions[0]
-    final_excel_file = utils.create_export_filename(
-        account_name,
-        'vpn',
-        region_suffix,
-        current_date
-    )
+        # Save using utils module for consistent formatting
+        try:
+            output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
 
-    # Save using utils module for consistent formatting
-    try:
-        output_path = utils.save_multiple_dataframes_to_excel(data_frames, final_excel_file)
+            if output_path:
+                utils.log_success("VPN data exported successfully!")
+                utils.log_success(f"File location: {output_path}")
 
-        if output_path:
-            utils.log_success("VPN data exported successfully!")
-            utils.log_success(f"File location: {output_path}")
+                # Summary of exported data
+                print("\n" + "=" * 60)
+                print("EXPORT SUMMARY")
+                print("=" * 60)
+                for sheet_name, df in data_frames.items():
+                    utils.log_info(f"  - {sheet_name}: {len(df)} records")
+                    print(f"  - {sheet_name}: {len(df)} records")
+            else:
+                utils.log_error("Error creating Excel file. Please check the logs.")
 
-            # Summary of exported data
-            print("\n" + "=" * 60)
-            print("EXPORT SUMMARY")
-            print("=" * 60)
-            for sheet_name, df in data_frames.items():
-                utils.log_info(f"  - {sheet_name}: {len(df)} records")
-                print(f"  - {sheet_name}: {len(df)} records")
-        else:
-            utils.log_error("Error creating Excel file. Please check the logs.")
+        except Exception as e:
+            utils.log_error("Error creating Excel file", e)
 
-    except Exception as e:
-        utils.log_error("Error creating Excel file", e)
+    # If ANY region failed the primary VPN connection scope collection, make
+    # it loud: write a marker and exit non-zero, even though the Summary sheet
+    # (and any successfully-collected data) was still exported above. A
+    # partial export that looks complete is exactly the failure mode this guards.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'vpn', failed_regions)
+        print(
+            "\nERROR: VPN export completed with failures — data is incomplete. "
+            "See the *-vpn-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/xray_export.py
+++ b/scripts/xray_export.py
@@ -28,83 +28,123 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS X-Ray groups and sampling rules to Excel")
 
+def _build_sampling_rule_row(rule_record: dict, region: str) -> dict[str, Any]:
+    """Build a single X-Ray sampling rule export row from a get_sampling_rules record."""
+    rule = rule_record.get('SamplingRule', {})
+    created_at = rule_record.get('CreatedAt', 'N/A')
+    modified_at = rule_record.get('ModifiedAt', 'N/A')
+
+    if created_at != 'N/A':
+        created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
+    if modified_at != 'N/A':
+        modified_at = modified_at.strftime('%Y-%m-%d %H:%M:%S')
+
+    rule_name = rule.get('RuleName', 'N/A')
+    rule_arn = rule.get('RuleARN', 'N/A')
+    priority = rule.get('Priority', 'N/A')
+    fixed_rate = rule.get('FixedRate', 0)
+    reservoir_size = rule.get('ReservoirSize', 0)
+    service_name = rule.get('ServiceName', '*')
+    service_type = rule.get('ServiceType', '*')
+    host = rule.get('Host', '*')
+    http_method = rule.get('HTTPMethod', '*')
+    url_path = rule.get('URLPath', '*')
+    resource_arn = rule.get('ResourceARN', '*')
+    version = rule.get('Version', 1)
+
+    # Attributes
+    attributes = rule.get('Attributes', {})
+    attributes_str = json.dumps(attributes) if attributes else 'None'
+
+    return {
+        'Region': region,
+        'Rule Name': rule_name,
+        'Priority': priority,
+        'Fixed Rate': fixed_rate,
+        'Reservoir Size': reservoir_size,
+        'Service Name': service_name,
+        'Service Type': service_type,
+        'Host': host,
+        'HTTP Method': http_method,
+        'URL Path': url_path,
+        'Resource ARN': resource_arn,
+        'Version': version,
+        'Attributes': attributes_str,
+        'Created': created_at,
+        'Modified': modified_at,
+        'Rule ARN': rule_arn
+    }
+
+
 def _scan_sampling_rules_region(region: str) -> list[dict[str, Any]]:
-    """Scan X-Ray sampling rules in a single region."""
+    """
+    Collect X-Ray sampling rules from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no sampling rules" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed sampling rules are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     regional_rules = []
     xray_client = utils.get_boto3_client('xray', region_name=region)
 
-    try:
-        # Get sampling rules (manual NextToken loop — no boto3 paginator for get_sampling_rules)
-        sampling_rules = []
-        kwargs = {}
-        while True:
-            response = xray_client.get_sampling_rules(**kwargs)
-            sampling_rules.extend(response.get('SamplingRuleRecords', []))
-            next_token = response.get('NextToken')
-            if not next_token:
-                break
-            kwargs = {'NextToken': next_token}
+    # Get sampling rules (manual NextToken loop — no boto3 paginator for get_sampling_rules)
+    sampling_rules = []
+    kwargs = {}
+    while True:
+        response = xray_client.get_sampling_rules(**kwargs)
+        sampling_rules.extend(response.get('SamplingRuleRecords', []))
+        next_token = response.get('NextToken')
+        if not next_token:
+            break
+        kwargs = {'NextToken': next_token}
 
-        for rule_record in sampling_rules:
-            rule = rule_record.get('SamplingRule', {})
-            created_at = rule_record.get('CreatedAt', 'N/A')
-            modified_at = rule_record.get('ModifiedAt', 'N/A')
-
-            if created_at != 'N/A':
-                created_at = created_at.strftime('%Y-%m-%d %H:%M:%S')
-            if modified_at != 'N/A':
-                modified_at = modified_at.strftime('%Y-%m-%d %H:%M:%S')
-
-            rule_name = rule.get('RuleName', 'N/A')
-            rule_arn = rule.get('RuleARN', 'N/A')
-            priority = rule.get('Priority', 'N/A')
-            fixed_rate = rule.get('FixedRate', 0)
-            reservoir_size = rule.get('ReservoirSize', 0)
-            service_name = rule.get('ServiceName', '*')
-            service_type = rule.get('ServiceType', '*')
-            host = rule.get('Host', '*')
-            http_method = rule.get('HTTPMethod', '*')
-            url_path = rule.get('URLPath', '*')
-            resource_arn = rule.get('ResourceARN', '*')
-            version = rule.get('Version', 1)
-
-            # Attributes
-            attributes = rule.get('Attributes', {})
-            attributes_str = json.dumps(attributes) if attributes else 'None'
-
-            regional_rules.append({
-                'Region': region,
-                'Rule Name': rule_name,
-                'Priority': priority,
-                'Fixed Rate': fixed_rate,
-                'Reservoir Size': reservoir_size,
-                'Service Name': service_name,
-                'Service Type': service_type,
-                'Host': host,
-                'HTTP Method': http_method,
-                'URL Path': url_path,
-                'Resource ARN': resource_arn,
-                'Version': version,
-                'Attributes': attributes_str,
-                'Created': created_at,
-                'Modified': modified_at,
-                'Rule ARN': rule_arn
-            })
-
-    except Exception as e:
-        utils.log_warning(f"Error getting sampling rules in {region}: {str(e)}")
+    for rule_record in sampling_rules:
+        try:
+            regional_rules.append(_build_sampling_rule_row(rule_record, region))
+        except Exception as e:
+            # One malformed sampling rule is skipped, not fatal to the region.
+            rule_name = rule_record.get('SamplingRule', {}).get('RuleName', '<unknown>')
+            utils.log_error(
+                f"Skipping malformed X-Ray sampling rule in {region}: {rule_name}",
+                e,
+            )
+            continue
 
     return regional_rules
 
 
-@utils.aws_error_handler("Collecting X-Ray sampling rules", default_return=[])
-def collect_sampling_rules(regions: list[str]) -> list[dict[str, Any]]:
-    """Collect X-Ray sampling rule information from AWS regions."""
+def collect_sampling_rules(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect X-Ray sampling rule information across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(rules, failed_regions)`` where ``failed_regions`` is a list of
+        ``(region, error_message)`` tuples.
+    """
     print("\n=== COLLECTING X-RAY SAMPLING RULES ===")
-    results = utils.scan_regions_concurrent(regions, _scan_sampling_rules_region)
-    all_rules = [rule for result in results for rule in result]
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_sampling_rules_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_rules = [rule for result in region_results for rule in result]
     utils.log_success(f"Total sampling rules collected: {len(all_rules)}")
-    return all_rules
+    return all_rules, failed_regions
 
 
 def _scan_groups_region(region: str) -> list[dict[str, Any]]:
@@ -276,7 +316,11 @@ def main():
     # Collect data
     print("\nCollecting X-Ray configuration data...")
 
-    sampling_rules = collect_sampling_rules(regions)
+    # STEP 1: Collect sampling rules (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    sampling_rules, failed_regions = collect_sampling_rules(regions)
+    # Groups and encryption config are enrichment: they already degrade
+    # gracefully (per-region try/except) and do not affect failed_regions.
     groups = collect_groups(regions)
     encryption_configs = collect_encryption_config(regions)
     summary = generate_summary(sampling_rules, groups, encryption_configs)
@@ -306,7 +350,10 @@ def main():
         df_encryption = utils.prepare_dataframe_for_export(df_encryption)
         dataframes['Encryption Config'] = df_encryption
 
-    # Export to Excel
+    # Export to Excel — the Summary sheet is forced above, so a workbook is
+    # always written even when the primary scope collected nothing (partial
+    # export is preferred over no file; see the silent-collection-failure
+    # blast-radius audit).
     if dataframes:
         region_suffix = 'all-regions' if len(regions) > 1 else regions[0]
         filename = utils.create_export_filename(account_name, 'xray', region_suffix)
@@ -316,6 +363,18 @@ def main():
 
     else:
         utils.log_warning("No X-Ray data found to export")
+
+    # If ANY region failed the sampling rules scope collection, make it loud:
+    # write a marker and exit non-zero, even though a workbook was still
+    # written above. A complete-looking file with silently zero-row data is
+    # exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'xray', failed_regions)
+        print(
+            "\nERROR: X-Ray export completed with failures — data is incomplete. "
+            "See the *-xray-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("X-Ray export completed successfully")
 

--- a/tests/test_exporters/test_nacl_export.py
+++ b/tests/test_exporters/test_nacl_export.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for nacl_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import nacl_export  # noqa: E402
+from nacl_export import get_nacl_data  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_nacl(client, vpc_id, name):
+    """Create a Network ACL named ``name`` (via a Name tag) in ``vpc_id``."""
+    resp = client.create_network_acl(VpcId=vpc_id)
+    nacl_id = resp["NetworkAcl"]["NetworkAclId"]
+    client.create_tags(Resources=[nacl_id], Tags=[{"Key": "Name", "Value": name}])
+    return nacl_id
+
+
+class TestGetNaclData:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_nacls(self):
+        client = boto3.client("ec2", region_name=REGION)
+        vpc = client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        _create_nacl(client, vpc, "web-nacl")
+
+        rows = get_nacl_data(REGION)
+
+        names = {row["NACL Name"] for row in rows}
+        assert "web-nacl" in names
+
+    @mock_aws
+    def test_no_custom_nacls_returns_only_defaults(self):
+        """
+        A region with no custom NACLs still has moto's default-VPC default NACL.
+        Genuinely-empty here means "nothing but the default" — never an error.
+        """
+        boto3.client("ec2", region_name=REGION)  # region exists, no custom NACLs
+
+        rows = get_nacl_data(REGION)
+
+        assert all(row["Is Default"] == "Yes" for row in rows)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list, indistinguishable
+    from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One NACL that fails to process must not discard the whole region."""
+        client = boto3.client("ec2", region_name=REGION)
+        vpc = client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        _create_nacl(client, vpc, "good-nacl")
+        _create_nacl(client, vpc, "bad-nacl")
+
+        original = nacl_export._build_nacl_row
+
+        def raise_for_bad(nacl, region):
+            if nacl.get("NetworkAclId") and _tag_name(nacl) == "bad-nacl":
+                raise KeyError("SomeUnexpectedField")
+            return original(nacl, region)
+
+        def _tag_name(nacl):
+            for tag in nacl.get("Tags", []):
+                if tag.get("Key") == "Name":
+                    return tag.get("Value")
+            return None
+
+        monkeypatch.setattr(nacl_export, "_build_nacl_row", raise_for_bad)
+
+        rows = get_nacl_data(REGION)
+
+        names = {row["NACL Name"] for row in rows}
+        assert "good-nacl" in names, "healthy NACL was lost when a sibling failed"
+        assert "bad-nacl" not in names, "malformed NACL should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeNetworkAcls",
+            )
+
+        monkeypatch.setattr(nacl_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_nacl_data(REGION)
+
+    @mock_aws
+    def test_scan_regions_concurrent_surfaces_failed_regions(self, monkeypatch):
+        """
+        With ``collect_failures=True``, a region whose collector raises must be
+        reported back as a failed region, not dropped — this is what lets
+        ``main()`` write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeNetworkAcls",
+            )
+
+        monkeypatch.setattr(nacl_export, "get_nacl_data", boom)
+
+        results, failed_regions = nacl_export.utils.scan_regions_concurrent(
+            regions=[REGION],
+            scan_function=lambda r: nacl_export.get_nacl_data(r),
+            show_progress=False,
+            collect_failures=True,
+        )
+
+        assert results == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_network_manager_export.py
+++ b/tests/test_exporters/test_network_manager_export.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Tests for network_manager_export.py.
+
+Covers:
+- collect_global_networks() per-item guarding and account-scope failure
+  propagation
+- main()'s failed-scope tracking, always-written Summary sheet, and
+  exit-code behavior
+
+Network Manager is a global, account-scope service (not multi-region), so
+collect_global_networks() is the account-scope PRIMARY collector -- mirrors
+the scripts/shield_export.py account-scope pattern (see
+scripts/lambda_export.py for the finalize shape). This script is a Tier-3
+PARTIAL case: it already builds an always-written Summary sheet, so the fix
+adds failed-scope tracking + a *-FAILED-*.txt marker + non-zero exit on top
+of that, without breaking the "a workbook always lands" guarantee.
+
+moto's ``networkmanager`` backend supports ``create_global_network`` /
+``describe_global_networks`` (including the paginator), which is enough to
+exercise the PRIMARY scope realistically. Per-global-network enrichment
+(get_sites / get_links / get_devices / get_connections /
+get_transit_gateway_registrations / get_customer_gateway_associations) is
+NOT exercised against moto here -- moto's support for those calls is thin
+and the enrichment collectors are unaffected by this fix (they keep their
+own ``aws_error_handler`` decorators and degrade gracefully). The (c) main()
+failure test never reaches enrichment because the PRIMARY scope raises
+before any global network exists.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import network_manager_export  # noqa: E402
+from network_manager_export import collect_global_networks  # noqa: E402
+
+REGION = "us-west-2"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def fixed_home_region(monkeypatch):
+    """collect_global_networks() reads the module-level home_region."""
+    monkeypatch.setattr(network_manager_export, "home_region", REGION)
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 silent-collection-failure audit,
+    applied to Network Manager: collect_global_networks() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error into
+    an empty list (and separately had a hard ``network['GlobalNetworkId']``
+    subscript in the per-global-network enrichment loop), indistinguishable
+    from an account with no global networks configured. main() also had no
+    way to signal that failure downstream despite always writing a Summary
+    sheet. These tests cover: (a) a malformed global network is skipped, not
+    fatal; (b) collect_global_networks() raises rather than swallowing a
+    real API error; (c) that failure surfaces through main() as a non-zero
+    exit plus a utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------
+
+    @mock_aws
+    def test_malformed_global_network_is_skipped_not_fatal(self, monkeypatch):
+        """One global network that fails to process must not discard the others."""
+        client = boto3.client("networkmanager", region_name=REGION)
+        good_id = client.create_global_network(Description="good-network")[
+            "GlobalNetwork"
+        ]["GlobalNetworkId"]
+        bad_id = client.create_global_network(Description="bad-network")[
+            "GlobalNetwork"
+        ]["GlobalNetworkId"]
+
+        original = network_manager_export._build_global_network_row
+
+        def raise_for_bad(network):
+            if network.get("GlobalNetworkId") == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(network)
+
+        monkeypatch.setattr(network_manager_export, "_build_global_network_row", raise_for_bad)
+
+        rows = collect_global_networks()
+
+        ids = {row["GlobalNetworkId"] for row in rows}
+        assert good_id in ids, "healthy global network was lost when a sibling failed"
+        assert bad_id not in ids, "malformed global network should have been skipped"
+
+    # -- (b) Account-scope failure propagation --------------------------
+
+    def test_collect_global_networks_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Network Manager API error during collection must propagate,
+        not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "DescribeGlobalNetworks",
+            )
+
+        monkeypatch.setattr(network_manager_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_global_networks()
+
+    # -- (c) main(): failure surfaced, non-zero exit, marker written ----
+
+    def test_main_failure_exits_nonzero_and_reports_despite_summary_sheet(self, monkeypatch, tmp_path):
+        """
+        A global_networks-scope failure must exit non-zero and call
+        utils.report_collection_failures -- even though this script always
+        builds a non-empty Summary sheet and would otherwise write a
+        complete-looking workbook (the Tier-3 PARTIAL failure mode).
+        """
+        monkeypatch.setattr(network_manager_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            network_manager_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(network_manager_export.utils, "mask_account_id", lambda *a, **kw: "1234****9012")
+        monkeypatch.setattr(network_manager_export.utils, "prompt_region_selection", lambda *a, **kw: [REGION])
+        monkeypatch.setattr(network_manager_export.utils, "prompt_confirmation", lambda *a, **kw: "confirm")
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerException", "Message": "Something broke"}},
+                "DescribeGlobalNetworks",
+            )
+
+        monkeypatch.setattr(network_manager_export, "collect_global_networks", boom)
+
+        monkeypatch.setattr(network_manager_export.utils, "create_export_filename", lambda *a, **kw: "fake.xlsx")
+        monkeypatch.setattr(
+            network_manager_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda *a, **kw: str(tmp_path / "fake.xlsx"),
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(network_manager_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            network_manager_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "network-manager"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "global_networks"
+
+    # -- (d) Genuinely empty: graceful, no marker ------------------------
+
+    @mock_aws
+    def test_main_genuinely_empty_completes_no_marker(self, monkeypatch, tmp_path):
+        """
+        An account with zero global networks (primary scope succeeds, just
+        returns nothing) must complete without raising and never call
+        utils.report_collection_failures -- a real Summary-only workbook is
+        not a failure. main() has no explicit ``sys.exit(0)`` on the success
+        path (unlike the failure path), so success here means "returns
+        normally," not "raises SystemExit(0)".
+        """
+        monkeypatch.setattr(network_manager_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            network_manager_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(network_manager_export.utils, "mask_account_id", lambda *a, **kw: "1234****9012")
+        monkeypatch.setattr(network_manager_export.utils, "prompt_region_selection", lambda *a, **kw: [REGION])
+        monkeypatch.setattr(network_manager_export.utils, "prompt_confirmation", lambda *a, **kw: "confirm")
+
+        monkeypatch.setattr(network_manager_export.utils, "create_export_filename", lambda *a, **kw: "fake.xlsx")
+        monkeypatch.setattr(
+            network_manager_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda *a, **kw: str(tmp_path / "fake.xlsx"),
+        )
+
+        report_called = []
+        monkeypatch.setattr(
+            network_manager_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # No sys.exit(0) on the success path -- main() should simply return.
+        network_manager_export.main()
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_rekognition_export.py
+++ b/tests/test_exporters/test_rekognition_export.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Tests for rekognition_export.py.
+
+Covers:
+- collect_projects() per-item guarding and region-scope failure propagation
+- main()'s failed-scope tracking, always-written Summary sheet, and
+  exit-code behavior
+
+moto's Amazon Rekognition support does not implement ``describe_projects``
+(custom model projects) as of moto 5.1 -- calling it against ``mock_aws``
+raises ``NotImplementedError`` unconditionally, so it cannot be used to
+build realistic collection-success or collection-failure fixtures. These
+tests drive the module through monkeypatched boto3 clients / module
+functions instead, mirroring the approach already used for
+tests/test_exporters/test_globalaccelerator_export.py.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import rekognition_export  # noqa: E402
+from rekognition_export import _scan_projects_region, collect_projects  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(rekognition_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_rekognition_client(projects=None):
+    """Build a MagicMock standing in for a boto3 Rekognition client."""
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"ProjectDescriptions": projects or []}]
+    client.get_paginator.return_value = paginator
+    return client
+
+
+class TestScanProjectsRegion:
+    """Happy-path collection."""
+
+    def test_collects_projects(self, monkeypatch):
+        project = {
+            "ProjectArn": "arn:aws:rekognition:us-east-1:123456789012:project/good-project/1699999999999",
+            "Status": "CREATED",
+            "CreationTimestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        }
+        client = _fake_rekognition_client(projects=[project])
+        monkeypatch.setattr(rekognition_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        rows = _scan_projects_region(REGION)
+
+        arns = {row["Project ARN"] for row in rows}
+        assert project["ProjectArn"] in arns
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _fake_rekognition_client(projects=[])
+        monkeypatch.setattr(rekognition_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        rows = _scan_projects_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region -- and, for scripts like
+    this one that always build a non-empty Summary sheet, the loss was
+    additionally hidden inside a complete-looking workbook (Tier-3 PARTIAL).
+    """
+
+    # -- (a) Per-item guard ---------------------------------------------
+
+    def test_malformed_project_is_skipped_not_fatal(self, monkeypatch):
+        """One project that fails to process must not discard the whole region."""
+        good = {
+            "ProjectArn": "arn:aws:rekognition:us-east-1:123456789012:project/good-project/1699999999999",
+            "Status": "CREATED",
+            "CreationTimestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        }
+        bad = {
+            "ProjectArn": "arn:aws:rekognition:us-east-1:123456789012:project/bad-project/1699999999999",
+            "Status": "CREATED",
+            "CreationTimestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        }
+
+        client = _fake_rekognition_client(projects=[good, bad])
+        monkeypatch.setattr(rekognition_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = rekognition_export._build_project_row
+
+        def raise_for_bad(project, region):
+            if "bad-project" in project.get("ProjectArn", ""):
+                raise KeyError("SomeUnexpectedField")
+            return original(project, region)
+
+        monkeypatch.setattr(rekognition_export, "_build_project_row", raise_for_bad)
+
+        rows = _scan_projects_region(REGION)
+
+        arns = {row["Project ARN"] for row in rows}
+        assert good["ProjectArn"] in arns, "healthy project was lost when a sibling failed"
+        assert bad["ProjectArn"] not in arns, "malformed project should have been skipped"
+
+    # -- (b) Region-scope failure propagation ----------------------------
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalServerError", "Message": "Something broke"}},
+                "DescribeProjects",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(rekognition_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_projects_region(REGION)
+
+    def test_collect_projects_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them -- this is what lets main() write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeProjects",
+            )
+
+        monkeypatch.setattr(rekognition_export, "_scan_projects_region", boom)
+
+        projects, failed_regions = collect_projects([REGION])
+
+        assert projects == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    # -- (c) main(): failure surfaced, non-zero exit, marker written -----
+
+    def test_main_failure_exits_nonzero_and_reports_despite_summary_sheet(self, monkeypatch, tmp_path):
+        """
+        A projects-scope failure must exit non-zero and call
+        utils.report_collection_failures -- even though this script always
+        builds a non-empty Summary sheet and would otherwise write a
+        complete-looking workbook (the Tier-3 PARTIAL failure mode).
+        """
+        monkeypatch.setattr(rekognition_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(rekognition_export.utils, "detect_partition", lambda *a, **kw: "aws")
+        monkeypatch.setattr(
+            rekognition_export.utils, "is_service_available_in_partition", lambda *a, **kw: True
+        )
+        monkeypatch.setattr(
+            rekognition_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(rekognition_export.utils, "mask_account_id", lambda *a, **kw: "1234****9012")
+        monkeypatch.setattr(rekognition_export.utils, "prompt_region_selection", lambda *a, **kw: [REGION])
+
+        monkeypatch.setattr(rekognition_export, "collect_projects", lambda regions: ([], [(REGION, "boom")]))
+        monkeypatch.setattr(rekognition_export, "collect_project_versions", lambda regions: [])
+        monkeypatch.setattr(rekognition_export, "collect_collections", lambda regions: [])
+        monkeypatch.setattr(rekognition_export, "collect_stream_processors", lambda regions: [])
+
+        monkeypatch.setattr(rekognition_export.utils, "create_export_filename", lambda *a, **kw: "fake.xlsx")
+        monkeypatch.setattr(
+            rekognition_export.utils, "save_multiple_dataframes_to_excel", lambda *a, **kw: str(tmp_path / "fake.xlsx")
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(rekognition_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            rekognition_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "rekognition"
+        assert calls.get("failed_scopes") == [(REGION, "boom")]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_route53_export.py
+++ b/tests/test_exporters/test_route53_export.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Tests for route53_export.py.
+
+Covers:
+- _build_hosted_zone_row() per-item guarding
+- collect_hosted_zones() -- the PRIMARY, global/account-scope collector --
+  account-scope failure propagation
+- export_route53_data()'s failed-scope tracking, finalize, and exit-code
+  behavior
+
+Route 53 hosted zones are a global/account-scope resource (not multi-region
+-- see scripts/shield_export.py for the account-scope reference pattern;
+scripts/lambda_export.py for the finalize shape). This mirrors
+tests/test_exporters/test_shield_export.py.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import route53_export  # noqa: E402
+from route53_export import collect_hosted_zones  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(route53_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Route 53: collect_hosted_zones() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error into
+    an empty list (via ``@utils.aws_error_handler(default_return=[])``),
+    indistinguishable from an account with no hosted zones. Route 53 is a
+    Tier-3 PARTIAL case: a forced Summary sheet always lands a workbook, so
+    the fix is failed-scope tracking + marker + non-zero exit layered on top
+    of the existing always-written export. These tests cover: (a) a
+    malformed hosted zone is skipped, not fatal; (b) collect_hosted_zones()
+    raises rather than swallowing a real API error; (c) that failure
+    surfaces through export_route53_data() as a non-zero exit plus a
+    utils.report_collection_failures() call.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------
+
+    @mock_aws
+    def test_malformed_hosted_zone_is_skipped_not_fatal(self, monkeypatch):
+        """One hosted zone whose detail lookup fails must not discard the
+        others."""
+        client = route53_export.utils.get_boto3_client("route53", region_name=REGION)
+        good = client.create_hosted_zone(
+            Name="good.example.com.",
+            CallerReference="good-ref",
+        )["HostedZone"]
+        bad = client.create_hosted_zone(
+            Name="bad.example.com.",
+            CallerReference="bad-ref",
+        )["HostedZone"]
+
+        good_id = good["Id"].split("/")[-1]
+        bad_id = bad["Id"].split("/")[-1]
+
+        original = route53_export._build_hosted_zone_row
+
+        def raise_for_bad(route53_client, zone):
+            zone_id = zone.get("Id", "").split("/")[-1]
+            if zone_id == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(route53_client, zone)
+
+        monkeypatch.setattr(route53_export, "_build_hosted_zone_row", raise_for_bad)
+
+        result = collect_hosted_zones()
+
+        ids = {row["Zone ID"] for row in result}
+        assert good_id in ids, "healthy hosted zone was lost when a sibling failed"
+        assert bad_id not in ids, "malformed hosted zone should have been skipped"
+
+    # -- (b) Account-scope failure propagation --------------------------
+
+    def test_collect_hosted_zones_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Route 53 API error during collection must propagate, not
+        collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalError", "Message": "Something broke"}},
+                "ListHostedZones",
+            )
+
+        client = MagicMock()
+        client.get_paginator.side_effect = boom
+        monkeypatch.setattr(route53_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_hosted_zones()
+
+    # -- (c) export_route53_data(): failure surfaced, non-zero exit -----
+
+    def test_export_hosted_zones_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A hosted-zones API failure must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty/summary-only export that looks complete."""
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalError", "Message": "Something broke"}},
+                "ListHostedZones",
+            )
+
+        monkeypatch.setattr(route53_export, "collect_hosted_zones", boom)
+        monkeypatch.setattr(route53_export, "collect_dns_records", lambda: [])
+        monkeypatch.setattr(route53_export, "collect_health_checks", lambda: [])
+        monkeypatch.setattr(route53_export, "collect_resolver_endpoints", lambda regions: [])
+        monkeypatch.setattr(route53_export, "collect_resolver_rules", lambda regions: [])
+        monkeypatch.setattr(route53_export, "collect_query_logging_configs", lambda: [])
+
+        # Let the (forced) Summary sheet still get "written" without
+        # touching real Excel I/O.
+        monkeypatch.setattr(
+            route53_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda data_frames, filename, **kw: str(Path("fake") / filename),
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(route53_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            route53_export.export_route53_data("123456789012", "test-account", [REGION])
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "route53"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "hosted_zones"
+
+    # -- (d) Genuinely empty: no failure marker, exit path not taken ----
+
+    def test_genuinely_empty_account_reports_no_failure(self, monkeypatch):
+        """Every scope succeeding with zero resources is NOT a failure --
+        utils.report_collection_failures must never be called and no
+        SystemExit(1) should be raised."""
+        monkeypatch.setattr(route53_export, "collect_hosted_zones", lambda: [])
+        monkeypatch.setattr(route53_export, "collect_dns_records", lambda: [])
+        monkeypatch.setattr(route53_export, "collect_health_checks", lambda: [])
+        monkeypatch.setattr(route53_export, "collect_resolver_endpoints", lambda regions: [])
+        monkeypatch.setattr(route53_export, "collect_resolver_rules", lambda regions: [])
+        monkeypatch.setattr(route53_export, "collect_query_logging_configs", lambda: [])
+
+        monkeypatch.setattr(
+            route53_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda data_frames, filename, **kw: str(Path("fake") / filename),
+        )
+
+        report_called = []
+        monkeypatch.setattr(
+            route53_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # Should return normally -- no SystemExit.
+        route53_export.export_route53_data("123456789012", "test-account", [REGION])
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_ses_export.py
+++ b/tests/test_exporters/test_ses_export.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ses_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ses_export  # noqa: E402
+from ses_export import _scan_email_identities_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_identity(client, domain):
+    """Create a verified SES domain identity named ``domain``.
+
+    Domain identities are used (rather than email-address identities)
+    because moto's sesv2 ``get_email_identity`` mock has a lookup bug for
+    email-address identity names containing ``@``.
+    """
+    client.create_email_identity(EmailIdentity=domain)
+
+
+class TestScanEmailIdentitiesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_identities(self):
+        client = boto3.client("sesv2", region_name=REGION)
+        _create_identity(client, "web.example.com")
+
+        rows = _scan_email_identities_region(REGION)
+
+        names = {row["Identity Name"] for row in rows}
+        assert "web.example.com" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("sesv2", region_name=REGION)  # region exists, no identities
+
+        rows = _scan_email_identities_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One identity that fails to process must not discard the whole region."""
+        client = boto3.client("sesv2", region_name=REGION)
+        _create_identity(client, "good.example.com")
+        _create_identity(client, "bad.example.com")
+
+        original = ses_export._build_identity_row
+
+        def raise_for_bad(identity_summary, region, ses_client):
+            if identity_summary.get("IdentityName") == "bad.example.com":
+                raise KeyError("SomeUnexpectedField")
+            return original(identity_summary, region, ses_client)
+
+        monkeypatch.setattr(ses_export, "_build_identity_row", raise_for_bad)
+
+        rows = _scan_email_identities_region(REGION)
+
+        names = {row["Identity Name"] for row in rows}
+        assert "good.example.com" in names, "healthy identity was lost when a sibling failed"
+        assert "bad.example.com" not in names, "malformed identity should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListEmailIdentities",
+            )
+
+        monkeypatch.setattr(ses_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_email_identities_region(REGION)
+
+    @mock_aws
+    def test_collect_email_identities_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListEmailIdentities",
+            )
+
+        monkeypatch.setattr(ses_export, "_scan_email_identities_region", boom)
+
+        identities, failed_regions = ses_export.collect_email_identities([REGION])
+
+        assert identities == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_ses_pinpoint_export.py
+++ b/tests/test_exporters/test_ses_pinpoint_export.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ses_pinpoint_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL) for the
+primary SES-identities scope. See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note: moto's sesv2/pinpoint support is partial — in particular,
+``get_email_identity`` has a lookup bug for email-address identity names
+containing ``@`` (it URL-encodes the name before looking it up), so tests
+use domain identities instead. That bug also means moto exercises the
+best-effort detail-lookup fallback in ``_build_identity_row`` for free.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ses_pinpoint_export  # noqa: E402
+from ses_pinpoint_export import _scan_ses_identities_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_identity(client, domain):
+    """Create a verified SES domain identity named ``domain``.
+
+    Domain identities are used (rather than email-address identities)
+    because moto's sesv2 ``get_email_identity`` mock has a lookup bug for
+    email-address identity names containing ``@``.
+    """
+    client.create_email_identity(EmailIdentity=domain)
+
+
+class TestScanSesIdentitiesRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_identities(self):
+        client = boto3.client("sesv2", region_name=REGION)
+        _create_identity(client, "web.example.com")
+
+        rows = _scan_ses_identities_region(REGION)
+
+        names = {row["IdentityName"] for row in rows}
+        assert "web.example.com" in names
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("sesv2", region_name=REGION)  # region exists, no identities
+
+        rows = _scan_ses_identities_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One SES identity that fails to process must not discard the whole region."""
+        client = boto3.client("sesv2", region_name=REGION)
+        _create_identity(client, "good.example.com")
+        _create_identity(client, "bad.example.com")
+
+        original = ses_pinpoint_export._build_identity_row
+
+        def raise_for_bad(identity, region, sesv2_client):
+            if identity.get("IdentityName") == "bad.example.com":
+                raise KeyError("SomeUnexpectedField")
+            return original(identity, region, sesv2_client)
+
+        monkeypatch.setattr(ses_pinpoint_export, "_build_identity_row", raise_for_bad)
+
+        rows = _scan_ses_identities_region(REGION)
+
+        names = {row["IdentityName"] for row in rows}
+        assert "good.example.com" in names, "healthy identity was lost when a sibling failed"
+        assert "bad.example.com" not in names, "malformed identity should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListEmailIdentities",
+            )
+
+        monkeypatch.setattr(ses_pinpoint_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_ses_identities_region(REGION)
+
+    @mock_aws
+    def test_collect_ses_identities_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListEmailIdentities",
+            )
+
+        monkeypatch.setattr(ses_pinpoint_export, "_scan_ses_identities_region", boom)
+
+        identities, failed_regions = ses_pinpoint_export.collect_ses_identities([REGION])
+
+        assert identities == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_vpn_export.py
+++ b/tests/test_exporters/test_vpn_export.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for vpn_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import vpn_export  # noqa: E402
+from vpn_export import scan_vpn_connections_in_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _create_vpn_connection(client, bgp_asn=65000, public_ip="203.0.113.1"):
+    """Create a customer gateway + VPN gateway + Site-to-Site VPN connection."""
+    cgw_id = client.create_customer_gateway(
+        BgpAsn=bgp_asn,
+        PublicIp=public_ip,
+        Type="ipsec.1",
+    )["CustomerGateway"]["CustomerGatewayId"]
+
+    vgw_id = client.create_vpn_gateway(Type="ipsec.1")["VpnGateway"]["VpnGatewayId"]
+
+    conn = client.create_vpn_connection(
+        CustomerGatewayId=cgw_id,
+        VpnGatewayId=vgw_id,
+        Type="ipsec.1",
+    )["VpnConnection"]
+
+    return conn["VpnConnectionId"]
+
+
+class TestScanVpnConnectionsRegion:
+    """Happy-path collection."""
+
+    @mock_aws
+    def test_collects_vpn_connections(self):
+        client = boto3.client("ec2", region_name=REGION)
+        vpn_id = _create_vpn_connection(client)
+
+        rows = scan_vpn_connections_in_region(REGION)
+
+        ids = {row["VPN Connection ID"] for row in rows}
+        assert vpn_id in ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ec2", region_name=REGION)  # region exists, no VPN connections
+
+        rows = scan_vpn_connections_in_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed to an empty list, indistinguishable
+    from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One VPN connection that fails to process must not discard the whole region."""
+        client = boto3.client("ec2", region_name=REGION)
+        good_id = _create_vpn_connection(client, bgp_asn=65000, public_ip="203.0.113.1")
+        bad_id = _create_vpn_connection(client, bgp_asn=65001, public_ip="203.0.113.2")
+
+        original = vpn_export._build_vpn_row
+
+        def raise_for_bad(vpn, region):
+            if vpn.get("VpnConnectionId") == bad_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(vpn, region)
+
+        monkeypatch.setattr(vpn_export, "_build_vpn_row", raise_for_bad)
+
+        rows = scan_vpn_connections_in_region(REGION)
+
+        ids = {row["VPN Connection ID"] for row in rows}
+        assert good_id in ids, "healthy VPN connection was lost when a sibling failed"
+        assert bad_id not in ids, "malformed VPN connection should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeVpnConnections",
+            )
+
+        monkeypatch.setattr(vpn_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            scan_vpn_connections_in_region(REGION)
+
+    @mock_aws
+    def test_collect_vpn_connections_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeVpnConnections",
+            )
+
+        monkeypatch.setattr(vpn_export, "scan_vpn_connections_in_region", boom)
+
+        vpns, failed_regions = vpn_export.collect_vpn_connections([REGION])
+
+        assert vpns == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_xray_export.py
+++ b/tests/test_exporters/test_xray_export.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Tests for xray_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto: moto's X-Ray backend requires the optional ``aws_xray_sdk``
+package, which is not a project dependency (StratusScan keeps runtime deps
+minimal per the CloudShell-first design principle in CLAUDE.md) and is not
+installed in this environment. ``@mock_aws`` cannot be used for X-Ray here,
+so these tests monkeypatch ``utils.get_boto3_client`` with a lightweight fake
+client instead of exercising real botocore/moto plumbing.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import xray_export  # noqa: E402
+from xray_export import _scan_sampling_rules_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakeXrayClient:
+    """
+    Stand-in for the boto3 X-Ray client.
+
+    moto's xray backend requires ``aws_xray_sdk`` (not installed / not a
+    project dependency), so ``get_sampling_rules`` is stubbed directly rather
+    than mocked via ``@mock_aws``.
+    """
+
+    def __init__(self, rule_records=None, error=None):
+        self._rule_records = rule_records or []
+        self._error = error
+
+    def get_sampling_rules(self, **kwargs):
+        if self._error is not None:
+            raise self._error
+        return {"SamplingRuleRecords": self._rule_records}
+
+
+def _rule_record(name):
+    return {
+        "SamplingRule": {
+            "RuleName": name,
+            "RuleARN": f"arn:aws:xray:{REGION}:123456789012:sampling-rule/{name}",
+            "Priority": 1000,
+            "FixedRate": 0.05,
+            "ReservoirSize": 1,
+            "ServiceName": "*",
+            "ServiceType": "*",
+            "Host": "*",
+            "HTTPMethod": "*",
+            "URLPath": "*",
+            "ResourceARN": "*",
+            "Version": 1,
+        },
+        "CreatedAt": "N/A",
+        "ModifiedAt": "N/A",
+    }
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently lost
+    data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One sampling rule that fails to process must not discard the whole region."""
+        fake_client = _FakeXrayClient(
+            rule_records=[_rule_record("good-rule"), _rule_record("bad-rule")]
+        )
+        monkeypatch.setattr(xray_export.utils, "get_boto3_client", lambda *a, **k: fake_client)
+
+        original = xray_export._build_sampling_rule_row
+
+        def raise_for_bad(rule_record, region):
+            if rule_record["SamplingRule"]["RuleName"] == "bad-rule":
+                raise KeyError("SomeUnexpectedField")
+            return original(rule_record, region)
+
+        monkeypatch.setattr(xray_export, "_build_sampling_rule_row", raise_for_bad)
+
+        rows = _scan_sampling_rules_region(REGION)
+
+        names = {row["Rule Name"] for row in rows}
+        assert "good-rule" in names, "healthy sampling rule was lost when a sibling failed"
+        assert "bad-rule" not in names, "malformed sampling rule should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "GetSamplingRules",
+            )
+
+        monkeypatch.setattr(xray_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_sampling_rules_region(REGION)
+
+    def test_collect_sampling_rules_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "GetSamplingRules",
+            )
+
+        monkeypatch.setattr(xray_export, "_scan_sampling_rules_region", boom)
+
+        rules, failed_regions = xray_export.collect_sampling_rules([REGION])
+
+        assert rules == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -79,6 +79,8 @@ _EXCLUDED = {
     #   verifiedpermissions:ListPolicyStores-> 404 "Not yet implemented"
     #   servicecatalog:SearchProductsAsAdmin-> NotImplementedError
     #   controltower:ListLandingZones       -> 404 "Not yet implemented"
+    #   rekognition:DescribeProjects        -> NotImplementedError
+    #   xray:GetSamplingRules               -> 404 "Not yet implemented"
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -95,6 +97,8 @@ _EXCLUDED = {
     "verifiedpermissions_export.py",
     "service_catalog_export.py",
     "controltower_export.py",
+    "rekognition_export.py",
+    "xray_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **Final Tier-3 (PARTIAL) phase — Batch K: networking & misc (8 exporters). This completes the entire 96-exporter silent-collection-failure sweep.**

| Exporter | Type | Slug |
|---|---|---|
| nacl | multi-region | `nacl` |
| vpn | multi-region | `vpn` |
| ses | multi-region | `ses` |
| ses_pinpoint | multi-region | `ses-pinpoint` |
| rekognition | multi-region | `rekognition` |
| xray | multi-region | `xray` |
| network_manager | account-scope | `network-manager` |
| route53 | account-scope | `route53` |

Primary scope collector RAISES on error → surfaced failures → per-item `_build_*_row` guard → marker + `sys.exit(1)`; genuine-empty stays exit 0. KeyError sites guarded (`app['ApplicationId']`, `network['GlobalNetworkId']`, tag subscripts).

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite. **Batch-K suites: 37 passed. Full suite: 1152 passed, 2 skipped.** `ruff check .` clean (py39 floor).

## test_smoke.py exclusions
`rekognition`, `xray` added to `_EXCLUDED` — genuine moto gaps (rekognition:DescribeProjects NotImplementedError; xray:GetSamplingRules 404, confirmed unimplemented even with `aws_xray_sdk` present). The other 6 pass smoke.

## Sweep complete
All 96 exporters (Tier-1: 12, Tier-2: 36, Tier-3: 48) now surface collection failures — `*-FAILED-*.txt` marker + non-zero exit — instead of silently losing data into an empty result. Closes the blast-radius work in #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)