### PR TITLE
Silent collection failure: Tier-3j (cost & compute) — completes the 96-exporter sweep

### DIFF
--- a/scripts/cost_anomaly_detection_export.py
+++ b/scripts/cost_anomaly_detection_export.py
@@ -41,14 +41,104 @@ args = utils.parse_script_args("Export AWS Cost Anomaly Detection monitors and a
 utils.setup_logging('cost-anomaly-detection-export')
 
 
-@utils.aws_error_handler("Retrieving Anomaly Monitors", default_return=[])
+def _build_monitor_row(monitor: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single anomaly monitor.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed monitor entry must not sink the whole account-scope
+    collection. Every field is read with ``.get()`` and a safe default for
+    the same reason.
+
+    Args:
+        monitor: A single AnomalyMonitors entry from get_anomaly_monitors.
+
+    Returns:
+        dict: The assembled monitor row.
+    """
+    monitor_spec = monitor.get('MonitorSpecification', {})
+
+    return {
+        'MonitorName': monitor.get('MonitorName', 'N/A'),
+        'MonitorARN': monitor.get('MonitorArn', 'N/A'),
+        'MonitorType': monitor.get('MonitorType', 'N/A'),
+        'CreationDate': monitor.get('CreationDate'),
+        'LastEvaluatedDate': monitor.get('LastEvaluatedDate', 'N/A'),
+        'LastUpdatedDate': monitor.get('LastUpdatedDate', 'N/A'),
+        'DimensionalValueCount': monitor.get('DimensionalValueCount', 0),
+        'MonitorDimension': monitor.get('MonitorDimension', 'N/A'),
+        'Expression': parse_monitor_expression(monitor_spec),
+        'ExpressionJSON': json.dumps(monitor_spec, indent=2) if monitor_spec else 'N/A',
+    }
+
+
+def _build_subscription_row(subscription: dict[str, Any], account_id: str) -> dict[str, Any]:
+    """
+    Build the export row for a single anomaly subscription.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed subscription entry must not sink the whole
+    account-scope collection. Every field is read with ``.get()`` and a
+    safe default for the same reason.
+
+    Args:
+        subscription: A single AnomalySubscriptions entry from
+            get_anomaly_subscriptions.
+        account_id: The AWS account ID, used as a fallback when a
+            subscription entry has no AccountId of its own.
+
+    Returns:
+        dict: The assembled subscription row.
+    """
+    subscribers = subscription.get('Subscribers', [])
+    subscriber_list = []
+    for sub in subscribers:
+        sub_type = sub.get('Type', 'UNKNOWN')
+        sub_address = sub.get('Address', 'N/A')
+        subscriber_list.append(f"{sub_type}: {sub_address}")
+
+    return {
+        'SubscriptionName': subscription.get('SubscriptionName', 'N/A'),
+        'SubscriptionARN': subscription.get('SubscriptionArn', 'N/A'),
+        'AccountID': subscription.get('AccountId', account_id),
+        'MonitorARNs': ', '.join(subscription.get('MonitorArnList', [])),
+        'NumberOfMonitors': len(subscription.get('MonitorArnList', [])),
+        'Frequency': subscription.get('Frequency', 'N/A'),
+        'Subscribers': ', '.join(subscriber_list) if subscriber_list else 'N/A',
+        'NumberOfSubscribers': len(subscribers),
+        'Threshold': subscription.get('Threshold', 'N/A'),
+        'ThresholdExpression': json.dumps(subscription.get('ThresholdExpression', {}), indent=2) if subscription.get('ThresholdExpression') else 'N/A',
+    }
+
+
 def get_anomaly_monitors() -> list[dict[str, Any]]:
-    """Get all anomaly monitors."""
-    # Cost Explorer is a global service - use partition-aware home region
+    """
+    Get all anomaly monitors.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no monitors configured), producing silent data
+    loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Cost Anomaly Detection is a global, account-scope service
+    (Cost Explorer, us-east-1 home region) -- not multi-region (see
+    scripts/iam_export.py for the account-scope reference pattern this
+    follows; scripts/shield_export.py for the closest existing example).
+    Account-scope failures (client creation, pagination) are allowed to
+    raise so the caller (``_run_export``) can record this scope as *failed*
+    rather than *empty*. Per-monitor errors are contained internally
+    (logged and skipped).
+
+    Returns:
+        list: List of built anomaly monitor row dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     home_region = utils.get_partition_default_region()
     ce = utils.get_boto3_client('ce', region_name=home_region)
 
-    monitors = []
+    raw_monitors = []
     next_token = None
 
     while True:
@@ -57,25 +147,64 @@ def get_anomaly_monitors() -> list[dict[str, Any]]:
             params['NextPageToken'] = next_token
 
         response = ce.get_anomaly_monitors(**params)
-
-        for monitor in response.get('AnomalyMonitors', []):
-            monitors.append(monitor)
+        raw_monitors.extend(response.get('AnomalyMonitors', []))
 
         next_token = response.get('NextPageToken')
         if not next_token:
             break
 
+    monitors = []
+    skipped = 0
+
+    for monitor in raw_monitors:
+        try:
+            monitors.append(_build_monitor_row(monitor))
+        except Exception as e:
+            skipped += 1
+            monitor_name = monitor.get('MonitorName', 'Unknown') if isinstance(monitor, dict) else 'Unknown'
+            utils.log_error(f"Skipping anomaly monitor '{monitor_name}' due to a processing error", e)
+            continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(raw_monitors)} anomaly monitor(s) were skipped due to "
+            "processing errors (see log above); the remaining monitors were still collected."
+        )
+
     return monitors
 
 
-@utils.aws_error_handler("Retrieving Anomaly Subscriptions", default_return=[])
-def get_anomaly_subscriptions() -> list[dict[str, Any]]:
-    """Get all anomaly subscriptions."""
-    # Cost Explorer is a global service - use partition-aware home region
+def get_anomaly_subscriptions(account_id: str) -> list[dict[str, Any]]:
+    """
+    Get all anomaly subscriptions.
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no subscriptions configured), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). Cost Anomaly Detection is a global, account-scope service
+    (Cost Explorer, us-east-1 home region) -- not multi-region (see
+    scripts/iam_export.py for the account-scope reference pattern this
+    follows). Account-scope failures (client creation, pagination) are
+    allowed to raise so the caller (``_run_export``) can record this scope
+    as *failed* rather than *empty*. Per-subscription errors are contained
+    internally (logged and skipped).
+
+    Args:
+        account_id: The AWS account ID, passed through to
+            ``_build_subscription_row`` as an AccountId fallback.
+
+    Returns:
+        list: List of built anomaly subscription row dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     home_region = utils.get_partition_default_region()
     ce = utils.get_boto3_client('ce', region_name=home_region)
 
-    subscriptions = []
+    raw_subscriptions = []
     next_token = None
 
     while True:
@@ -84,13 +213,29 @@ def get_anomaly_subscriptions() -> list[dict[str, Any]]:
             params['NextPageToken'] = next_token
 
         response = ce.get_anomaly_subscriptions(**params)
-
-        for subscription in response.get('AnomalySubscriptions', []):
-            subscriptions.append(subscription)
+        raw_subscriptions.extend(response.get('AnomalySubscriptions', []))
 
         next_token = response.get('NextPageToken')
         if not next_token:
             break
+
+    subscriptions = []
+    skipped = 0
+
+    for subscription in raw_subscriptions:
+        try:
+            subscriptions.append(_build_subscription_row(subscription, account_id))
+        except Exception as e:
+            skipped += 1
+            subscription_name = subscription.get('SubscriptionName', 'Unknown') if isinstance(subscription, dict) else 'Unknown'
+            utils.log_error(f"Skipping anomaly subscription '{subscription_name}' due to a processing error", e)
+            continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(raw_subscriptions)} anomaly subscription(s) were skipped due to "
+            "processing errors (see log above); the remaining subscriptions were still collected."
+        )
 
     return subscriptions
 
@@ -193,29 +338,68 @@ def classify_impact(impact: dict) -> str:
 
 
 def _run_export(account_id: str, account_name: str) -> None:
-    """Collect Cost Anomaly Detection data and write the Excel export."""
+    """
+    Collect Cost Anomaly Detection data and write the Excel export.
+
+    Cost Anomaly Detection is a global, account-scope service (Cost
+    Explorer, accessed via the partition-aware home region) -- not
+    multi-region, so failures are tracked per account-scope collector
+    rather than via ``utils.scan_regions_concurrent`` (see
+    scripts/iam_export.py for the account-scope reference pattern;
+    scripts/shield_export.py and scripts/lambda_export.py for the finalize
+    shape this follows). The PRIMARY scopes are ``get_anomaly_monitors()``
+    and ``get_anomaly_subscriptions()`` -- a real API error on either scope
+    is recorded in ``failed_scopes`` and surfaced via
+    ``utils.report_collection_failures`` plus a non-zero exit; it must
+    never be silently collapsed into "no monitors configured" / "no
+    subscriptions configured" (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    Anomalies (the 90-day detection history) is enrichment -- it degrades
+    gracefully via its own ``aws_error_handler`` decorator and a failure
+    there does not fail the whole export. The Summary sheet (and the rest
+    of the workbook) is always written, even when a primary scope failed,
+    so a partial export is never silently indistinguishable from a
+    complete one.
+    """
     utils.log_info(f"Exporting Cost Anomaly Detection data for account: {account_name} ({utils.mask_account_id(account_id)})")
     utils.log_info("Cost Anomaly Detection is global (accessed via us-east-1)...")
 
-    # Get anomaly monitors
+    failed_scopes = []
+
+    # STEP 1: Anomaly monitors (PRIMARY scope -- a real API error here must
+    # propagate to failed_scopes, never collapse into an empty list that
+    # reads as "no monitors configured").
     utils.log_info("Retrieving anomaly monitors...")
-    monitors = get_anomaly_monitors()
-
-    if monitors:
-        utils.log_info(f"Found {len(monitors)} anomaly monitor(s)")
+    try:
+        monitors = get_anomaly_monitors()
+    except Exception as e:
+        failed_scopes.append(('anomaly_monitors', str(e)))
+        utils.log_error(f"Anomaly monitors collection failed: {e}")
+        monitors = []
     else:
-        utils.log_warning("No anomaly monitors found.")
+        if monitors:
+            utils.log_info(f"Found {len(monitors)} anomaly monitor(s)")
+        else:
+            utils.log_info("No anomaly monitors found.")
 
-    # Get anomaly subscriptions
+    # STEP 2: Anomaly subscriptions (PRIMARY scope -- same reasoning as
+    # monitors above).
     utils.log_info("Retrieving anomaly subscriptions...")
-    subscriptions = get_anomaly_subscriptions()
-
-    if subscriptions:
-        utils.log_info(f"Found {len(subscriptions)} anomaly subscription(s)")
+    try:
+        subscriptions = get_anomaly_subscriptions(account_id)
+    except Exception as e:
+        failed_scopes.append(('anomaly_subscriptions', str(e)))
+        utils.log_error(f"Anomaly subscriptions collection failed: {e}")
+        subscriptions = []
     else:
-        utils.log_warning("No anomaly subscriptions found.")
+        if subscriptions:
+            utils.log_info(f"Found {len(subscriptions)} anomaly subscription(s)")
+        else:
+            utils.log_info("No anomaly subscriptions found.")
 
-    # Get anomalies for the past 90 days
+    # STEP 3: Anomalies for the past 90 days (enrichment -- degrades
+    # gracefully via its own aws_error_handler decorator; a failure here
+    # does not fail the whole export).
     end_date = datetime.now(timezone.utc).date()
     start_date = end_date - timedelta(days=90)
 
@@ -230,51 +414,11 @@ def _run_export(account_id: str, account_name: str) -> None:
     else:
         utils.log_info("No anomalies detected in the past 90 days")
 
-    # Process monitors
-    monitor_data = []
-    for monitor in monitors:
-        monitor_spec = monitor.get('MonitorSpecification', {})
-
-        monitor_data.append({
-            'MonitorName': monitor.get('MonitorName', 'N/A'),
-            'MonitorARN': monitor.get('MonitorArn', 'N/A'),
-            'MonitorType': monitor.get('MonitorType', 'N/A'),
-            'CreationDate': monitor.get('CreationDate'),
-            'LastEvaluatedDate': monitor.get('LastEvaluatedDate', 'N/A'),
-            'LastUpdatedDate': monitor.get('LastUpdatedDate', 'N/A'),
-            'DimensionalValueCount': monitor.get('DimensionalValueCount', 0),
-            'MonitorDimension': monitor.get('MonitorDimension', 'N/A'),
-            'Expression': parse_monitor_expression(monitor_spec),
-            'ExpressionJSON': json.dumps(monitor_spec, indent=2) if monitor_spec else 'N/A',
-        })
-
-    df_monitors = utils.prepare_dataframe_for_export(pd.DataFrame(monitor_data))
-
-    # Process subscriptions
-    subscription_data = []
-    for subscription in subscriptions:
-        # Get subscriber details
-        subscribers = subscription.get('Subscribers', [])
-        subscriber_list = []
-        for sub in subscribers:
-            sub_type = sub.get('Type', 'UNKNOWN')
-            sub_address = sub.get('Address', 'N/A')
-            subscriber_list.append(f"{sub_type}: {sub_address}")
-
-        subscription_data.append({
-            'SubscriptionName': subscription.get('SubscriptionName', 'N/A'),
-            'SubscriptionARN': subscription.get('SubscriptionArn', 'N/A'),
-            'AccountID': subscription.get('AccountId', account_id),
-            'MonitorARNs': ', '.join(subscription.get('MonitorArnList', [])),
-            'NumberOfMonitors': len(subscription.get('MonitorArnList', [])),
-            'Frequency': subscription.get('Frequency', 'N/A'),
-            'Subscribers': ', '.join(subscriber_list) if subscriber_list else 'N/A',
-            'NumberOfSubscribers': len(subscribers),
-            'Threshold': subscription.get('Threshold', 'N/A'),
-            'ThresholdExpression': json.dumps(subscription.get('ThresholdExpression', {}), indent=2) if subscription.get('ThresholdExpression') else 'N/A',
-        })
-
-    df_subscriptions = utils.prepare_dataframe_for_export(pd.DataFrame(subscription_data))
+    # Monitors and subscriptions are already built rows (see
+    # _build_monitor_row / _build_subscription_row inside their
+    # collectors above) -- no further per-item processing needed here.
+    df_monitors = utils.prepare_dataframe_for_export(pd.DataFrame(monitors))
+    df_subscriptions = utils.prepare_dataframe_for_export(pd.DataFrame(subscriptions))
 
     # Process anomalies
     anomaly_data = []
@@ -354,6 +498,10 @@ def _run_export(account_id: str, account_name: str) -> None:
         'Root Causes': df_root_causes,
     }
 
+    # The workbook (including the always-present Summary sheet) is written
+    # unconditionally -- even when a primary scope failed above -- so a
+    # partial export is never lost, only ever unmarked (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
     utils.save_multiple_dataframes_to_excel(sheets, filename)
 
     # Log summary
@@ -364,7 +512,29 @@ def _run_export(account_id: str, account_name: str) -> None:
     if not df_high_impact.empty:
         utils.log_warning(f"  {len(df_high_impact)} high-impact anomaly/anomalies detected (>$100)")
 
-    utils.log_success("Cost Anomaly Detection export completed successfully!")
+    has_any_data = bool(monitors or subscriptions or all_anomalies)
+
+    if failed_scopes:
+        utils.log_error("Cost Anomaly Detection export completed with failures — data is incomplete.")
+    elif not has_any_data:
+        # Genuinely empty: both primary scopes succeeded and there is
+        # simply nothing configured/detected. Exit 0, no marker.
+        utils.log_warning("No Cost Anomaly Detection data was collected. Nothing to export.")
+    else:
+        utils.log_success("Cost Anomaly Detection export completed successfully!")
+
+    # If either primary scope failed, make it loud: write a marker and exit
+    # non-zero, even though the Summary sheet (and any partial data) was
+    # already written above. A partial export that looks complete is
+    # exactly the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'cost-anomaly-detection', failed_scopes)
+        print(
+            "\nERROR: Cost Anomaly Detection export completed with failures — data is "
+            "incomplete. See the *-cost-anomaly-detection-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/cost_categories_export.py
+++ b/scripts/cost_categories_export.py
@@ -83,14 +83,66 @@ def parse_expression(expression: dict, prefix: str = "") -> str:
         return f"{prefix}Complex Expression (see JSON)"
 
 
-@utils.aws_error_handler("Listing Cost Category Definitions", default_return=[])
+def _build_cost_category_row(cc_ref: dict) -> dict[str, Any]:
+    """
+    Build the primary-scope inventory row for a single Cost Category
+    reference returned by ``list_cost_category_definitions``.
+
+    Extracted so per-item processing can be wrapped in try/except by the
+    caller: a malformed reference must not sink the whole primary-scope
+    collection. Every field is read with ``.get()`` and a safe default for
+    the same reason (see
+    .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+
+    Args:
+        cc_ref: A single CostCategoryReferences entry from
+            list_cost_category_definitions.
+
+    Returns:
+        dict: The assembled primary-scope row.
+    """
+    processing_status_list = cc_ref.get('ProcessingStatus') or [{'Status': 'N/A'}]
+    processing_status = (
+        processing_status_list[0].get('Status', 'N/A') if processing_status_list else 'N/A'
+    )
+
+    return {
+        'Name': cc_ref.get('Name', 'Unknown'),
+        'CostCategoryArn': cc_ref.get('CostCategoryArn', 'N/A'),
+        'ProcessingStatus': processing_status,
+        'NumberOfRules': cc_ref.get('NumberOfRules', 0),
+        'Values': ', '.join(cc_ref.get('Values', [])) if cc_ref.get('Values') else 'N/A',
+    }
+
+
 def list_cost_category_definitions() -> list[dict[str, Any]]:
-    """List all Cost Category definitions."""
+    """
+    PRIMARY scope collector: list all Cost Category definitions
+    (top-level inventory).
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from an
+    account with no Cost Categories configured, producing silent data loss
+    (see the 07.15.2026 / 07.16.2026 silent-collection-failure audits).
+    Cost Categories (Cost Explorer) is a global, account-scope service (not
+    multi-region — see scripts/shield_export.py for the account-scope
+    reference pattern this follows). Account-scope failures (client
+    creation, pagination) are allowed to raise so the caller can record this
+    scope as *failed* rather than *empty*. Per-item errors are contained
+    internally via ``_build_cost_category_row`` (logged and skipped).
+
+    Returns:
+        list: Primary-scope inventory rows (see ``_build_cost_category_row``).
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     # Cost Explorer is a global service - use partition-aware home region
     home_region = utils.get_partition_default_region()
     ce = utils.get_boto3_client('ce', region_name=home_region)
 
-    cost_categories = []
+    raw_refs = []
     next_token = None
 
     while True:
@@ -99,13 +151,29 @@ def list_cost_category_definitions() -> list[dict[str, Any]]:
             params['NextToken'] = next_token
 
         response = ce.list_cost_category_definitions(**params)
-
-        for cc_ref in response.get('CostCategoryReferences', []):
-            cost_categories.append(cc_ref)
+        raw_refs.extend(response.get('CostCategoryReferences', []))
 
         next_token = response.get('NextToken')
         if not next_token:
             break
+
+    cost_categories = []
+    skipped = 0
+
+    for cc_ref in raw_refs:
+        try:
+            cost_categories.append(_build_cost_category_row(cc_ref))
+        except Exception as e:
+            skipped += 1
+            name = cc_ref.get('Name', 'Unknown') if isinstance(cc_ref, dict) else 'Unknown'
+            utils.log_error(f"Skipping Cost Category reference '{name}' due to a processing error", e)
+            continue
+
+    if skipped:
+        utils.log_warning(
+            f"{skipped} of {len(raw_refs)} Cost Category reference(s) were skipped due to "
+            "processing errors (see log above); the remaining references were still collected."
+        )
 
     return cost_categories
 
@@ -125,18 +193,49 @@ def describe_cost_category(cost_category_arn: str) -> dict[str, Any]:
 
 
 def _run_export(account_id: str, account_name: str) -> None:
-    """Collect Cost Categories data and write the Excel export."""
+    """
+    Collect Cost Categories data and write the Excel export.
+
+    Cost Categories (Cost Explorer) is a global, account-scope service (not
+    multi-region), so failure tracking follows the account-scope pattern
+    (see scripts/shield_export.py) rather than
+    ``utils.scan_regions_concurrent``. ``list_cost_category_definitions()``
+    is the PRIMARY scope: a real API error there must propagate to
+    ``failed_scopes``, never collapse into "no Cost Categories configured"
+    (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    ``describe_cost_category()`` is per-item enrichment and continues to
+    degrade gracefully — a single category's detail failing does not fail
+    the whole export.
+
+    An Excel workbook (with a forced ``Summary`` sheet) is always written,
+    even when the primary scope failed, so a partial export never looks
+    like a missing file. If the primary scope failed, a failure marker is
+    written and the process exits non-zero; a genuinely empty account
+    (primary scope succeeded, nothing configured) exits 0 with no marker.
+    """
     utils.log_info(f"Exporting Cost Categories for account: {account_name} ({utils.mask_account_id(account_id)})")
     utils.log_info("Cost Categories are global (accessed via us-east-1)...")
 
-    # List all cost categories
-    utils.log_info("Retrieving Cost Category definitions...")
-    cost_category_refs = list_cost_category_definitions()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
 
-    if not cost_category_refs:
+    # STEP 1: List all cost categories (PRIMARY scope — a real API error
+    # here must propagate to failed_scopes, never collapse into an empty
+    # list that reads as "no Cost Categories configured").
+    utils.log_info("Retrieving Cost Category definitions...")
+    try:
+        cost_category_refs = list_cost_category_definitions()
+    except Exception as e:
+        failed_scopes.append(('cost_categories', str(e)))
+        utils.log_error(f"Cost Category definitions collection failed: {e}")
+        cost_category_refs = []
+
+    if not cost_category_refs and not failed_scopes:
+        # Genuinely empty: the primary scope succeeded and there is simply
+        # nothing configured.
         utils.log_warning("No Cost Categories found.")
         utils.log_info("Creating empty export file...")
-    else:
+    elif cost_category_refs:
         utils.log_info(f"Found {len(cost_category_refs)} Cost Category definition(s)")
 
     # Collect detailed information for each category
@@ -166,9 +265,12 @@ def _run_export(account_id: str, account_name: str) -> None:
             'EffectiveEnd': cc_detail.get('EffectiveEnd', 'N/A'),
             'DefaultValue': cc_detail.get('DefaultValue', 'N/A'),
             'RuleVersion': cc_detail.get('RuleVersion', 'N/A'),
-            'ProcessingStatus': cc_ref.get('ProcessingStatus', [{'Status': 'N/A'}])[0].get('Status', 'N/A'),
+            # ProcessingStatus/Values are already resolved to display strings by
+            # _build_cost_category_row() — read directly rather than re-deriving
+            # from the raw AWS shape.
+            'ProcessingStatus': cc_ref.get('ProcessingStatus', 'N/A'),
             'NumberOfRules': cc_ref.get('NumberOfRules', 0),
-            'Values': ', '.join(cc_ref.get('Values', [])) if cc_ref.get('Values') else 'N/A',
+            'Values': cc_ref.get('Values', 'N/A'),
         })
 
         # Extract rules
@@ -257,6 +359,11 @@ def _run_export(account_id: str, account_name: str) -> None:
         'Split Charge Rules': df_splits,
     }
 
+    # The Summary sheet (and the rest of the workbook) is always written,
+    # even when the primary scope failed — PRESERVE this: a partial export
+    # that looks complete is exactly the failure mode this guards against,
+    # so it must always be paired with the marker + non-zero exit below
+    # when failed_scopes is non-empty.
     utils.save_multiple_dataframes_to_excel(sheets, filename)
 
     # Log summary
@@ -268,6 +375,19 @@ def _run_export(account_id: str, account_name: str) -> None:
             utils.log_info(f"  Split Charge Rules: {len(df_splits)}")
 
     utils.log_success("Cost Categories export completed successfully!")
+
+    # If the primary scope failed, make it loud: write a marker and exit
+    # non-zero, even though the workbook (with its forced Summary sheet)
+    # was still written. A partial export that looks complete is exactly
+    # the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'cost-categories', failed_scopes)
+        print(
+            "\nERROR: Cost Categories export completed with failures — data is "
+            "incomplete. See the *-cost-categories-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/ec2_capacity_reservations_export.py
+++ b/scripts/ec2_capacity_reservations_export.py
@@ -40,91 +40,184 @@ args = utils.parse_script_args("Export EC2 Capacity Reservations to Excel")
 utils.setup_logging('ec2-capacity-reservations-export')
 
 
-@utils.aws_error_handler("Collecting capacity reservations", default_return=[])
-def collect_capacity_reservations(region: str) -> list[dict[str, Any]]:
-    """Collect all EC2 Capacity Reservations in a region."""
+def _build_reservation_row(cr: dict, region: str) -> dict[str, Any]:
+    """Build a single Capacity Reservation export row from a describe response."""
+    # Calculate utilization
+    total_capacity = cr.get('TotalInstanceCount', 0)
+    available_capacity = cr.get('AvailableInstanceCount', 0)
+    used_capacity = total_capacity - available_capacity
+    utilization_pct = (used_capacity / total_capacity * 100) if total_capacity > 0 else 0
+
+    # Format tags
+    tags = []
+    for tag in cr.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    return {
+        'Region': region,
+        'CapacityReservationId': cr.get('CapacityReservationId', 'N/A'),
+        'CapacityReservationArn': cr.get('CapacityReservationArn', 'N/A'),
+        'InstanceType': cr.get('InstanceType', 'N/A'),
+        'AvailabilityZone': cr.get('AvailabilityZone', 'N/A'),
+        'AvailabilityZoneId': cr.get('AvailabilityZoneId', 'N/A'),
+        'State': cr.get('State', 'N/A'),
+        'TotalInstanceCount': total_capacity,
+        'AvailableInstanceCount': available_capacity,
+        'UsedInstanceCount': used_capacity,
+        'UtilizationPercent': f"{utilization_pct:.1f}%",
+        'Tenancy': cr.get('Tenancy', 'default'),
+        'EbsOptimized': cr.get('EbsOptimized', False),
+        'EphemeralStorage': cr.get('EphemeralStorage', False),
+        'InstancePlatform': cr.get('InstancePlatform', 'N/A'),
+        'EndDate': cr.get('EndDate', 'N/A'),
+        'EndDateType': cr.get('EndDateType', 'unlimited'),
+        'InstanceMatchCriteria': cr.get('InstanceMatchCriteria', 'open'),
+        'CreateDate': cr.get('CreateDate'),
+        'StartDate': cr.get('StartDate', 'N/A'),
+        'OwnerId': cr.get('OwnerId', 'N/A'),
+        'PlacementGroupArn': cr.get('PlacementGroupArn', 'N/A'),
+        'OutpostArn': cr.get('OutpostArn', 'N/A'),
+        'CapacityReservationFleetId': cr.get('CapacityReservationFleetId', 'N/A'),
+        'Tags': ', '.join(tags) if tags else 'N/A',
+    }
+
+
+def _scan_capacity_reservations_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect all EC2 Capacity Reservations in a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no reservations" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed reservations are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     ec2 = utils.get_boto3_client('ec2', region_name=region)
     reservations = []
 
     paginator = ec2.get_paginator('describe_capacity_reservations')
     for page in paginator.paginate():
         for cr in page.get('CapacityReservations', []):
-            # Calculate utilization
-            total_capacity = cr.get('TotalInstanceCount', 0)
-            available_capacity = cr.get('AvailableInstanceCount', 0)
-            used_capacity = total_capacity - available_capacity
-            utilization_pct = (used_capacity / total_capacity * 100) if total_capacity > 0 else 0
-
-            # Format tags
-            tags = []
-            for tag in cr.get('Tags', []):
-                tags.append(f"{tag.get('Key')}={tag.get('Value')}")
-
-            reservations.append({
-                'Region': region,
-                'CapacityReservationId': cr.get('CapacityReservationId', 'N/A'),
-                'CapacityReservationArn': cr.get('CapacityReservationArn', 'N/A'),
-                'InstanceType': cr.get('InstanceType', 'N/A'),
-                'AvailabilityZone': cr.get('AvailabilityZone', 'N/A'),
-                'AvailabilityZoneId': cr.get('AvailabilityZoneId', 'N/A'),
-                'State': cr.get('State', 'N/A'),
-                'TotalInstanceCount': total_capacity,
-                'AvailableInstanceCount': available_capacity,
-                'UsedInstanceCount': used_capacity,
-                'UtilizationPercent': f"{utilization_pct:.1f}%",
-                'Tenancy': cr.get('Tenancy', 'default'),
-                'EbsOptimized': cr.get('EbsOptimized', False),
-                'EphemeralStorage': cr.get('EphemeralStorage', False),
-                'InstancePlatform': cr.get('InstancePlatform', 'N/A'),
-                'EndDate': cr.get('EndDate', 'N/A'),
-                'EndDateType': cr.get('EndDateType', 'unlimited'),
-                'InstanceMatchCriteria': cr.get('InstanceMatchCriteria', 'open'),
-                'CreateDate': cr.get('CreateDate'),
-                'StartDate': cr.get('StartDate', 'N/A'),
-                'OwnerId': cr.get('OwnerId', 'N/A'),
-                'PlacementGroupArn': cr.get('PlacementGroupArn', 'N/A'),
-                'OutpostArn': cr.get('OutpostArn', 'N/A'),
-                'CapacityReservationFleetId': cr.get('CapacityReservationFleetId', 'N/A'),
-                'Tags': ', '.join(tags) if tags else 'N/A',
-            })
+            try:
+                reservations.append(_build_reservation_row(cr, region))
+            except Exception as e:
+                # One malformed reservation is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Capacity Reservation in {region}: "
+                    f"{cr.get('CapacityReservationId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reservations
 
 
-@utils.aws_error_handler("Collecting capacity reservation fleets", default_return=[])
-def collect_capacity_reservation_fleets(region: str) -> list[dict[str, Any]]:
-    """Collect Capacity Reservation Fleets in a region."""
+def collect_capacity_reservations(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect EC2 Capacity Reservations across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(reservations, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_capacity_reservations_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_reservations = [r for result in region_results for r in result]
+    return all_reservations, failed_regions
+
+
+def _build_fleet_row(fleet: dict, region: str) -> dict[str, Any]:
+    """Build a single Capacity Reservation Fleet export row from a describe response."""
+    # Format tags
+    tags = []
+    for tag in fleet.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    return {
+        'Region': region,
+        'CapacityReservationFleetId': fleet.get('CapacityReservationFleetId', 'N/A'),
+        'CapacityReservationFleetArn': fleet.get('CapacityReservationFleetArn', 'N/A'),
+        'State': fleet.get('State', 'N/A'),
+        'TotalTargetCapacity': fleet.get('TotalTargetCapacity', 0),
+        'TotalFulfilledCapacity': fleet.get('TotalFulfilledCapacity', 0),
+        'Tenancy': fleet.get('Tenancy', 'default'),
+        'EndDate': fleet.get('EndDate', 'N/A'),
+        'InstanceMatchCriteria': fleet.get('InstanceMatchCriteria', 'open'),
+        'AllocationStrategy': fleet.get('AllocationStrategy', 'N/A'),
+        'CreateTime': fleet.get('CreateTime'),
+        'Tags': ', '.join(tags) if tags else 'N/A',
+    }
+
+
+def _scan_capacity_reservation_fleets_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Capacity Reservation Fleets in a single region.
+
+    This is a primary scope collector — same no-swallow contract as
+    ``_scan_capacity_reservations_region``. A region-level API failure must
+    propagate rather than being masked as "fleets not available here".
+    Individual malformed fleets are skipped (logged), not fatal to the
+    region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     ec2 = utils.get_boto3_client('ec2', region_name=region)
     fleets = []
 
-    try:
-        paginator = ec2.get_paginator('describe_capacity_reservation_fleets')
-        for page in paginator.paginate():
-            for fleet in page.get('CapacityReservationFleets', []):
-                # Format tags
-                tags = []
-                for tag in fleet.get('Tags', []):
-                    tags.append(f"{tag.get('Key')}={tag.get('Value')}")
-
-                fleets.append({
-                    'Region': region,
-                    'CapacityReservationFleetId': fleet.get('CapacityReservationFleetId', 'N/A'),
-                    'CapacityReservationFleetArn': fleet.get('CapacityReservationFleetArn', 'N/A'),
-                    'State': fleet.get('State', 'N/A'),
-                    'TotalTargetCapacity': fleet.get('TotalTargetCapacity', 0),
-                    'TotalFulfilledCapacity': fleet.get('TotalFulfilledCapacity', 0),
-                    'Tenancy': fleet.get('Tenancy', 'default'),
-                    'EndDate': fleet.get('EndDate', 'N/A'),
-                    'InstanceMatchCriteria': fleet.get('InstanceMatchCriteria', 'open'),
-                    'AllocationStrategy': fleet.get('AllocationStrategy', 'N/A'),
-                    'CreateTime': fleet.get('CreateTime'),
-                    'Tags': ', '.join(tags) if tags else 'N/A',
-                })
-    except Exception:
-        # Fleets might not be available in all regions
-        pass
+    paginator = ec2.get_paginator('describe_capacity_reservation_fleets')
+    for page in paginator.paginate():
+        for fleet in page.get('CapacityReservationFleets', []):
+            try:
+                fleets.append(_build_fleet_row(fleet, region))
+            except Exception as e:
+                # One malformed fleet is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed Capacity Reservation Fleet in {region}: "
+                    f"{fleet.get('CapacityReservationFleetId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return fleets
+
+
+def collect_capacity_reservation_fleets(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Capacity Reservation Fleets across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` — same contract as
+    ``collect_capacity_reservations``.
+
+    Returns:
+        tuple: ``(fleets, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_capacity_reservation_fleets_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_fleets = [f for result in region_results for f in result]
+    return all_fleets, failed_regions
 
 
 @utils.aws_error_handler("Collecting capacity blocks", default_return=[])
@@ -165,38 +258,35 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect EC2 Capacity Reservation data and write the Excel export."""
     utils.log_info(f"Scanning {len(regions)} region(s) for EC2 Capacity Reservations...")
 
-    # Collect all resources
-    all_reservations = []
-    all_fleets = []
+    # STEP 1: Collect Capacity Reservations (primary scope — region failures
+    # must propagate as failed_regions, never collapse into "empty").
+    all_reservations, failed_reservation_regions = collect_capacity_reservations(regions)
+    utils.log_info(f"Total capacity reservations found: {len(all_reservations)}")
+
+    # STEP 2: Collect Capacity Reservation Fleets (primary scope — same
+    # no-swallow contract).
+    all_fleets, failed_fleet_regions = collect_capacity_reservation_fleets(regions)
+    utils.log_info(f"Total capacity fleets found: {len(all_fleets)}")
+
+    # Combine both scopes' failures into ONE list so a single FAILED marker
+    # and exit code cover the whole export (see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    failed_regions = failed_reservation_regions + failed_fleet_regions
+
+    # STEP 3: Collect capacity blocks (enrichment — degrades gracefully; a
+    # region-level failure here does not fail the whole export).
     all_blocks = []
-
     for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
-
-        # Collect capacity reservations
-        reservations = collect_capacity_reservations(region)
-        if reservations:
-            utils.log_info(f"  Found {len(reservations)} capacity reservation(s)")
-            all_reservations.extend(reservations)
-
-        # Collect fleets
-        fleets = collect_capacity_reservation_fleets(region)
-        if fleets:
-            utils.log_info(f"  Found {len(fleets)} capacity reservation fleet(s)")
-            all_fleets.extend(fleets)
-
-        # Collect capacity blocks
+        utils.log_info(f"[{idx}/{len(regions)}] Processing region for capacity blocks: {region}")
         blocks = collect_capacity_blocks(region)
         if blocks:
             utils.log_info(f"  Found {len(blocks)} capacity block(s)")
             all_blocks.extend(blocks)
 
-    if not all_reservations and not all_fleets:
+    if not all_reservations and not all_fleets and not failed_regions:
         utils.log_warning("No EC2 Capacity Reservations found in any selected region.")
         utils.log_info("Creating empty export file...")
 
-    utils.log_info(f"Total capacity reservations found: {len(all_reservations)}")
-    utils.log_info(f"Total capacity fleets found: {len(all_fleets)}")
     utils.log_info(f"Total capacity blocks found: {len(all_blocks)}")
 
     # Create DataFrames
@@ -276,6 +366,18 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.log_info(f"  Capacity Blocks: {len(all_blocks)}")
 
     utils.log_success("EC2 Capacity Reservations export completed successfully!")
+
+    # If ANY region failed either capacity-reservation scope, make it loud:
+    # write a marker and exit non-zero, even though the workbook (with its
+    # always-written Summary sheet) already landed. A partial export that
+    # looks complete is exactly the failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ec2-capacity-reservations', failed_regions)
+        print(
+            "\nERROR: EC2 Capacity Reservations export completed with failures — data is incomplete. "
+            "See the *-ec2-capacity-reservations-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/ec2_dedicated_hosts_export.py
+++ b/scripts/ec2_dedicated_hosts_export.py
@@ -63,135 +63,229 @@ def _load_dedicated_host_pricing() -> dict[str, dict[str, float]]:
         return {}
 
 
-@utils.aws_error_handler("Collecting dedicated hosts", default_return=[])
-def collect_dedicated_hosts(region: str) -> list[dict[str, Any]]:
-    """Collect all EC2 Dedicated Hosts in a region."""
+def _build_host_row(host: dict, region: str, host_pricing: dict, is_govcloud: bool) -> dict[str, Any]:
+    """Build a single dedicated-host export row from a describe_hosts entry."""
+    # Extract capacity information
+    available_capacity = host.get('AvailableCapacity', {})
+    capacity_details = []
+
+    for vcpu in available_capacity.get('AvailableVCpus', []):
+        capacity_details.append(
+            f"{vcpu.get('InstanceType', 'N/A')}: {vcpu.get('AvailableVCpus', 0)} vCPUs"
+        )
+
+    # Extract instance information
+    instances = host.get('Instances', [])
+    instance_ids = [inst.get('InstanceId', 'N/A') for inst in instances]
+    instance_types = list({inst.get('InstanceType', 'N/A') for inst in instances})
+
+    # Calculate utilization
+    total_capacity = available_capacity.get('AvailableInstanceCapacity', [])
+    total_vcpus = sum([cap.get('TotalCapacity', 0) for cap in total_capacity])
+    available_vcpus = sum([cap.get('AvailableCapacity', 0) for cap in total_capacity])
+    used_vcpus = total_vcpus - available_vcpus
+    utilization_pct = (used_vcpus / total_vcpus * 100) if total_vcpus > 0 else 0
+
+    # Extract properties
+    properties = host.get('HostProperties', {})
+
+    # Format tags
+    tags = []
+    for tag in host.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    # Cost estimation — per-host flat rate keyed by InstanceFamily
+    state = host.get('State', 'N/A')
+    instance_family = properties.get('InstanceFamily', 'N/A')
+    family_pricing = host_pricing.get(instance_family)
+    if state == 'released':
+        monthly_cost = 0.0
+        cost_note = 'Host released; no longer billed'
+    elif family_pricing:
+        monthly_cost = family_pricing['monthly']
+        gc_note = ' (us-east-1 rates; GovCloud may differ)' if is_govcloud else ''
+        cost_note = f'Estimate: flat per-host rate × 730 hr/mo{gc_note}'
+    else:
+        monthly_cost = 'N/A'
+        cost_note = f'Family {instance_family!r} not in pricing data'
+
+    return {
+        'Region': region,
+        'HostId': host.get('HostId', 'N/A'),
+        'State': host.get('State', 'N/A'),
+        'AvailabilityZone': host.get('AvailabilityZone', 'N/A'),
+        'AvailabilityZoneId': host.get('AvailabilityZoneId', 'N/A'),
+        'InstanceType': properties.get('InstanceType', 'N/A'),
+        'InstanceFamily': properties.get('InstanceFamily', 'N/A'),
+        'Sockets': properties.get('Sockets', 'N/A'),
+        'Cores': properties.get('Cores', 'N/A'),
+        'TotalVCpus': properties.get('TotalVCpus', 'N/A'),
+        'UsedVCpus': used_vcpus if total_vcpus > 0 else 'N/A',
+        'AvailableVCpus': available_vcpus if total_vcpus > 0 else 'N/A',
+        'UtilizationPercent': f"{utilization_pct:.1f}%" if total_vcpus > 0 else 'N/A',
+        'AutoPlacement': host.get('AutoPlacement', 'off'),
+        'HostRecovery': host.get('HostRecovery', 'off'),
+        'AllocationTime': host.get('AllocationTime', 'N/A'),
+        'ReleaseTime': host.get('ReleaseTime', 'N/A'),
+        'HostReservationId': host.get('HostReservationId', 'N/A'),
+        'InstancesCount': len(instances),
+        'InstanceIds': ', '.join(instance_ids) if instance_ids else 'N/A',
+        'InstanceTypes': ', '.join(instance_types) if instance_types else 'N/A',
+        'AvailableCapacity': ', '.join(capacity_details) if capacity_details else 'N/A',
+        'MemberOfServiceLinkedResourceGroup': host.get('MemberOfServiceLinkedResourceGroup', False),
+        'OutpostArn': host.get('OutpostArn', 'N/A'),
+        'AssetId': host.get('AssetId', 'N/A'),
+        'Tags': ', '.join(tags) if tags else 'N/A',
+        'Monthly Cost (On-Demand)': monthly_cost,
+        'Cost Note': cost_note,
+    }
+
+
+def _scan_dedicated_hosts_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect all EC2 Dedicated Hosts in a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no hosts" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed hosts are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     ec2 = utils.get_boto3_client('ec2', region_name=region)
-    hosts = []
     host_pricing = _load_dedicated_host_pricing()
     is_govcloud = utils.detect_partition(region) == 'aws-us-gov'
 
+    hosts = []
     paginator = ec2.get_paginator('describe_hosts')
     for page in paginator.paginate():
         for host in page.get('Hosts', []):
-            # Extract capacity information
-            available_capacity = host.get('AvailableCapacity', {})
-            capacity_details = []
-
-            for vcpu in available_capacity.get('AvailableVCpus', []):
-                capacity_details.append(
-                    f"{vcpu.get('InstanceType', 'N/A')}: {vcpu.get('AvailableVCpus', 0)} vCPUs"
+            try:
+                hosts.append(_build_host_row(host, region, host_pricing, is_govcloud))
+            except Exception as e:
+                # One malformed host is skipped, not fatal to the region.
+                utils.log_error(
+                    f"Skipping malformed dedicated host in {region}: "
+                    f"{host.get('HostId', '<unknown>')}",
+                    e,
                 )
-
-            # Extract instance information
-            instances = host.get('Instances', [])
-            instance_ids = [inst.get('InstanceId', 'N/A') for inst in instances]
-            instance_types = list({inst.get('InstanceType', 'N/A') for inst in instances})
-
-            # Calculate utilization
-            total_capacity = available_capacity.get('AvailableInstanceCapacity', [])
-            total_vcpus = sum([cap.get('TotalCapacity', 0) for cap in total_capacity])
-            available_vcpus = sum([cap.get('AvailableCapacity', 0) for cap in total_capacity])
-            used_vcpus = total_vcpus - available_vcpus
-            utilization_pct = (used_vcpus / total_vcpus * 100) if total_vcpus > 0 else 0
-
-            # Extract properties
-            properties = host.get('HostProperties', {})
-
-            # Format tags
-            tags = []
-            for tag in host.get('Tags', []):
-                tags.append(f"{tag.get('Key')}={tag.get('Value')}")
-
-            # Cost estimation — per-host flat rate keyed by InstanceFamily
-            state = host.get('State', 'N/A')
-            instance_family = properties.get('InstanceFamily', 'N/A')
-            family_pricing = host_pricing.get(instance_family)
-            if state == 'released':
-                monthly_cost = 0.0
-                cost_note = 'Host released; no longer billed'
-            elif family_pricing:
-                monthly_cost = family_pricing['monthly']
-                gc_note = ' (us-east-1 rates; GovCloud may differ)' if is_govcloud else ''
-                cost_note = f'Estimate: flat per-host rate × 730 hr/mo{gc_note}'
-            else:
-                monthly_cost = 'N/A'
-                cost_note = f'Family {instance_family!r} not in pricing data'
-
-            hosts.append({
-                'Region': region,
-                'HostId': host.get('HostId', 'N/A'),
-                'State': host.get('State', 'N/A'),
-                'AvailabilityZone': host.get('AvailabilityZone', 'N/A'),
-                'AvailabilityZoneId': host.get('AvailabilityZoneId', 'N/A'),
-                'InstanceType': properties.get('InstanceType', 'N/A'),
-                'InstanceFamily': properties.get('InstanceFamily', 'N/A'),
-                'Sockets': properties.get('Sockets', 'N/A'),
-                'Cores': properties.get('Cores', 'N/A'),
-                'TotalVCpus': properties.get('TotalVCpus', 'N/A'),
-                'UsedVCpus': used_vcpus if total_vcpus > 0 else 'N/A',
-                'AvailableVCpus': available_vcpus if total_vcpus > 0 else 'N/A',
-                'UtilizationPercent': f"{utilization_pct:.1f}%" if total_vcpus > 0 else 'N/A',
-                'AutoPlacement': host.get('AutoPlacement', 'off'),
-                'HostRecovery': host.get('HostRecovery', 'off'),
-                'AllocationTime': host.get('AllocationTime', 'N/A'),
-                'ReleaseTime': host.get('ReleaseTime', 'N/A'),
-                'HostReservationId': host.get('HostReservationId', 'N/A'),
-                'InstancesCount': len(instances),
-                'InstanceIds': ', '.join(instance_ids) if instance_ids else 'N/A',
-                'InstanceTypes': ', '.join(instance_types) if instance_types else 'N/A',
-                'AvailableCapacity': ', '.join(capacity_details) if capacity_details else 'N/A',
-                'MemberOfServiceLinkedResourceGroup': host.get('MemberOfServiceLinkedResourceGroup', False),
-                'OutpostArn': host.get('OutpostArn', 'N/A'),
-                'AssetId': host.get('AssetId', 'N/A'),
-                'Tags': ', '.join(tags) if tags else 'N/A',
-                'Monthly Cost (On-Demand)': monthly_cost,
-                'Cost Note': cost_note,
-            })
+                continue
 
     return hosts
 
 
-@utils.aws_error_handler("Collecting host reservations", default_return=[])
-def collect_host_reservations(region: str) -> list[dict[str, Any]]:
-    """Collect Dedicated Host Reservations in a region."""
+def collect_dedicated_hosts(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect EC2 Dedicated Hosts across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(hosts, failed_regions)`` where ``failed_regions`` is a list
+        of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_dedicated_hosts_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_hosts = [host for result in region_results for host in result]
+    return all_hosts, failed_regions
+
+
+def _build_reservation_row(reservation: dict, region: str) -> dict[str, Any]:
+    """Build a single host-reservation export row from a describe_host_reservations entry."""
+    host_id_set = reservation.get('HostIdSet', [])
+
+    tags = []
+    for tag in reservation.get('Tags', []):
+        tags.append(f"{tag.get('Key')}={tag.get('Value')}")
+
+    return {
+        'Region': region,
+        'HostReservationId': reservation.get('HostReservationId', 'N/A'),
+        'OfferingId': reservation.get('OfferingId', 'N/A'),
+        'InstanceFamily': reservation.get('InstanceFamily', 'N/A'),
+        'PaymentOption': reservation.get('PaymentOption', 'N/A'),
+        'State': reservation.get('State', 'N/A'),
+        'Start': reservation.get('Start', 'N/A'),
+        'End': reservation.get('End', 'N/A'),
+        'Duration': reservation.get('Duration', 'N/A'),
+        'Count': reservation.get('Count', 0),
+        'HourlyPrice': reservation.get('HourlyPrice', 'N/A'),
+        'UpfrontPrice': reservation.get('UpfrontPrice', 'N/A'),
+        'CurrencyCode': reservation.get('CurrencyCode', 'USD'),
+        'HostIdSet': ', '.join(host_id_set) if host_id_set else 'N/A',
+        'Tags': ', '.join(tags) if tags else 'N/A',
+    }
+
+
+def _scan_host_reservations_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect Dedicated Host Reservations in a single region.
+
+    This is a second, independent scope (its own "Host Reservations" /
+    "Active Reservations" inventory sheets — not derived from the dedicated
+    hosts data) so it must not swallow errors: a failure here needs to
+    propagate to ``scan_regions_concurrent(..., collect_failures=True)`` the
+    same way the primary dedicated-hosts scope does. Individual malformed
+    reservations are skipped (logged) rather than aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     ec2 = utils.get_boto3_client('ec2', region_name=region)
     reservations = []
 
-    try:
-        paginator = ec2.get_paginator('describe_host_reservations')
-        for page in paginator.paginate():
-            for reservation in page.get('HostReservationSet', []):
-                # Extract host IDs
-                host_id_set = reservation.get('HostIdSet', [])
-
-                # Format tags
-                tags = []
-                for tag in reservation.get('Tags', []):
-                    tags.append(f"{tag.get('Key')}={tag.get('Value')}")
-
-                reservations.append({
-                    'Region': region,
-                    'HostReservationId': reservation.get('HostReservationId', 'N/A'),
-                    'OfferingId': reservation.get('OfferingId', 'N/A'),
-                    'InstanceFamily': reservation.get('InstanceFamily', 'N/A'),
-                    'PaymentOption': reservation.get('PaymentOption', 'N/A'),
-                    'State': reservation.get('State', 'N/A'),
-                    'Start': reservation.get('Start', 'N/A'),
-                    'End': reservation.get('End', 'N/A'),
-                    'Duration': reservation.get('Duration', 'N/A'),
-                    'Count': reservation.get('Count', 0),
-                    'HourlyPrice': reservation.get('HourlyPrice', 'N/A'),
-                    'UpfrontPrice': reservation.get('UpfrontPrice', 'N/A'),
-                    'CurrencyCode': reservation.get('CurrencyCode', 'USD'),
-                    'HostIdSet': ', '.join(host_id_set) if host_id_set else 'N/A',
-                    'Tags': ', '.join(tags) if tags else 'N/A',
-                })
-    except Exception:
-        # Host reservations might not be available
-        pass
+    paginator = ec2.get_paginator('describe_host_reservations')
+    for page in paginator.paginate():
+        for reservation in page.get('HostReservationSet', []):
+            try:
+                reservations.append(_build_reservation_row(reservation, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed host reservation in {region}: "
+                    f"{reservation.get('HostReservationId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reservations
+
+
+def collect_host_reservations(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect Dedicated Host Reservations across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result. Callers must merge these ``failed_regions`` with the dedicated
+    hosts scope's ``failed_regions`` — both are independent top-level
+    inventory sheets.
+
+    Returns:
+        tuple: ``(reservations, failed_regions)`` where ``failed_regions`` is
+        a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_host_reservations_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_reservations = [reservation for result in region_results for reservation in result]
+    return all_reservations, failed_regions
 
 
 @utils.aws_error_handler("Collecting host instances", default_return=[])
@@ -200,7 +294,7 @@ def collect_host_instances(region: str, hosts: list[dict[str, Any]]) -> list[dic
     host_instances = []
 
     for host in hosts:
-        host_id = host['HostId']
+        host_id = host.get('HostId', 'N/A')
         instance_ids_str = host.get('InstanceIds', 'N/A')
 
         if instance_ids_str != 'N/A':
@@ -223,29 +317,28 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     """Collect EC2 Dedicated Host data and write the Excel export."""
     utils.log_info(f"Scanning {len(regions)} region(s) for EC2 Dedicated Hosts...")
 
-    # Collect all resources
-    all_hosts = []
-    all_reservations = []
+    # STEP 1: Collect dedicated hosts (primary scope — region failures must
+    # propagate as failed_regions, never collapse into "empty").
+    all_hosts, hosts_failed_regions = collect_dedicated_hosts(regions)
+    utils.log_info(f"Found {len(all_hosts)} dedicated host(s) across {len(regions)} region(s)")
+
+    # STEP 2: Collect host reservations (second, independent top-level
+    # inventory scope — same failure-surfacing contract as dedicated hosts).
+    all_reservations, reservations_failed_regions = collect_host_reservations(regions)
+    utils.log_info(f"Found {len(all_reservations)} host reservation(s) across {len(regions)} region(s)")
+
+    # Merge failed regions from both scopes so a failure in either one is
+    # surfaced (see .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    failed_regions = hosts_failed_regions + reservations_failed_regions
+
+    # STEP 3: Extract instance-to-host mappings (enrichment derived from the
+    # already-collected hosts data — no additional API calls, degrades
+    # gracefully and does not contribute to failed_regions).
     all_host_instances = []
-
-    for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
-
-        # Collect dedicated hosts
-        hosts = collect_dedicated_hosts(region)
-        if hosts:
-            utils.log_info(f"  Found {len(hosts)} dedicated host(s)")
-            all_hosts.extend(hosts)
-
-            # Extract instance-to-host mappings
-            host_instances = collect_host_instances(region, hosts)
-            all_host_instances.extend(host_instances)
-
-        # Collect host reservations
-        reservations = collect_host_reservations(region)
-        if reservations:
-            utils.log_info(f"  Found {len(reservations)} host reservation(s)")
-            all_reservations.extend(reservations)
+    for region in regions:
+        region_hosts = [h for h in all_hosts if h.get('Region') == region]
+        if region_hosts:
+            all_host_instances.extend(collect_host_instances(region, region_hosts))
 
     if not all_hosts and not all_reservations:
         utils.log_warning("No EC2 Dedicated Hosts found in any selected region.")
@@ -344,6 +437,21 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.log_info(f"  Instance Placements: {len(all_host_instances)}")
 
     utils.log_success("EC2 Dedicated Hosts export completed successfully!")
+
+    # If ANY region failed either scope's collection (dedicated hosts or host
+    # reservations), make it loud: write a marker and exit non-zero, even
+    # though the workbook (with its always-written Summary sheet) already
+    # landed. A partial export that looks complete is exactly the failure
+    # mode this guards against. A genuinely empty account (every region
+    # succeeded and returned nothing) stays a plain warning with exit 0 —
+    # no marker.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'ec2-dedicated-hosts', failed_regions)
+        print(
+            "\nERROR: EC2 Dedicated Hosts export completed with failures — data is incomplete. "
+            "See the *-ec2-dedicated-hosts-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/license_manager_export.py
+++ b/scripts/license_manager_export.py
@@ -38,52 +38,109 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS License Manager configurations to Excel")
 
-@utils.aws_error_handler("Collecting license configurations", default_return=[])
-def collect_license_configurations(region: str) -> list[dict[str, Any]]:
-    """Collect all license configurations in a region."""
+def _build_config_row(item: dict, region: str) -> dict[str, Any]:
+    """
+    Build a single license configuration export row.
+
+    Extracted so the per-configuration processing can be wrapped in
+    try/except by the caller: a malformed configuration entry is logged and
+    skipped rather than discarding the whole region's results. Every field is
+    read with ``.get()`` and a safe default for the same reason.
+    """
+    # Extract consumption details
+    consumed = item.get('ConsumedLicenses', 0)
+    limit = item.get('LicenseCount', 'N/A')
+
+    # Calculate usage percentage
+    usage_pct = 'N/A'
+    if isinstance(limit, int) and limit > 0:
+        usage_pct = f"{(consumed / limit * 100):.1f}%"
+
+    # Extract rules
+    rules = []
+    for rule in item.get('LicenseRules', []):
+        rules.append(rule)
+
+    # Extract automated discovery info
+    auto_discovery = item.get('AutomatedDiscoveryInformation', {})
+
+    return {
+        'Region': region,
+        'LicenseConfigurationId': item.get('LicenseConfigurationId', 'N/A'),
+        'LicenseConfigurationArn': item.get('LicenseConfigurationArn', 'N/A'),
+        'Name': item.get('Name', 'N/A'),
+        'Description': item.get('Description', 'N/A'),
+        'LicenseCountingType': item.get('LicenseCountingType', 'N/A'),
+        'LicenseCount': limit,
+        'LicenseCountHardLimit': item.get('LicenseCountHardLimit', False),
+        'ConsumedLicenses': consumed,
+        'UsagePercentage': usage_pct,
+        'Status': item.get('Status', 'N/A'),
+        'OwnerAccountId': item.get('OwnerAccountId', 'N/A'),
+        'LicenseRules': ', '.join(rules) if rules else 'N/A',
+        'AutoDiscoveryEnabled': auto_discovery.get('LastRunTime') is not None,
+        'LastDiscoveryRun': auto_discovery.get('LastRunTime', 'N/A'),
+        'ManagedResourceSummaries': str(item.get('ManagedResourceSummaryList', [])),
+    }
+
+
+def _scan_license_configurations_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect license configurations from a single region.
+
+    This is the primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the region
+    as failed instead of silently reporting "no license configurations" (the
+    silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed configurations are skipped (logged) rather than
+    aborting the whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     lm = utils.get_boto3_client('license-manager', region_name=region)
     configs = []
 
     paginator = lm.get_paginator('list_license_configurations')
     for page in paginator.paginate():
-        for config in page.get('LicenseConfigurations', []):
-            # Extract consumption details
-            consumed = config.get('ConsumedLicenses', 0)
-            limit = config.get('LicenseCount', 'N/A')
-
-            # Calculate usage percentage
-            usage_pct = 'N/A'
-            if isinstance(limit, int) and limit > 0:
-                usage_pct = f"{(consumed / limit * 100):.1f}%"
-
-            # Extract rules
-            rules = []
-            for rule in config.get('LicenseRules', []):
-                rules.append(rule)
-
-            # Extract automated discovery info
-            auto_discovery = config.get('AutomatedDiscoveryInformation', {})
-
-            configs.append({
-                'Region': region,
-                'LicenseConfigurationId': config.get('LicenseConfigurationId', 'N/A'),
-                'LicenseConfigurationArn': config.get('LicenseConfigurationArn', 'N/A'),
-                'Name': config.get('Name', 'N/A'),
-                'Description': config.get('Description', 'N/A'),
-                'LicenseCountingType': config.get('LicenseCountingType', 'N/A'),
-                'LicenseCount': limit,
-                'LicenseCountHardLimit': config.get('LicenseCountHardLimit', False),
-                'ConsumedLicenses': consumed,
-                'UsagePercentage': usage_pct,
-                'Status': config.get('Status', 'N/A'),
-                'OwnerAccountId': config.get('OwnerAccountId', 'N/A'),
-                'LicenseRules': ', '.join(rules) if rules else 'N/A',
-                'AutoDiscoveryEnabled': auto_discovery.get('LastRunTime') is not None,
-                'LastDiscoveryRun': auto_discovery.get('LastRunTime', 'N/A'),
-                'ManagedResourceSummaries': str(config.get('ManagedResourceSummaryList', [])),
-            })
+        for item in page.get('LicenseConfigurations', []):
+            try:
+                configs.append(_build_config_row(item, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed license configuration in {region}: "
+                    f"{item.get('LicenseConfigurationId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return configs
+
+
+def collect_license_configurations(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect license configurations across regions, surfacing failures.
+
+    Uses ``collect_failures=True`` so a region whose collection errors is
+    reported as a failed scope rather than silently collapsed into an empty
+    result.
+
+    Returns:
+        tuple: ``(configs, failed_regions)`` where ``failed_regions`` is a
+        list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_license_configurations_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_configs = [config for result in region_results for config in result]
+    return all_configs, failed_regions
 
 
 @utils.aws_error_handler("Collecting license usage", default_return=[])
@@ -253,7 +310,13 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     """Collect License Manager data and write the Excel export."""
     utils.log_info(f"Scanning {len(regions)} region(s) for License Manager resources...")
 
-    all_configs = []
+    # PRIMARY SCOPE: license configurations. Region failures must propagate
+    # as failed_regions, never collapse into "empty" (see the silent-
+    # collection-failure blast-radius audit).
+    all_configs, failed_regions = collect_license_configurations(regions)
+    if all_configs:
+        utils.log_info(f"Found {len(all_configs)} license configuration(s) total")
+
     all_usage = []
     all_grants = []
     all_licenses = []
@@ -262,17 +325,14 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     for idx, region in enumerate(regions, 1):
         utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
 
-        # Collect license configurations
-        configs = collect_license_configurations(region)
-        if configs:
-            utils.log_info(f"  Found {len(configs)} license configuration(s)")
-            all_configs.extend(configs)
-
-            # Collect usage for first 10 configurations
-            for config in configs[:10]:
-                config_arn = config['LicenseConfigurationArn']
-                usage = collect_license_usage(region, config_arn)
-                all_usage.extend(usage)
+        # Collect usage for the first 10 configurations found in this region
+        # (enrichment — degrades gracefully; failures here do not fail the
+        # whole export).
+        region_configs = [c for c in all_configs if c.get('Region') == region]
+        for config in region_configs[:10]:
+            config_arn = config['LicenseConfigurationArn']
+            usage = collect_license_usage(region, config_arn)
+            all_usage.extend(usage)
 
         # Collect grants
         grants = collect_grants(region)
@@ -293,7 +353,10 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
             all_inventory.extend(inventory)
 
     if not all_configs and not all_licenses and not all_grants:
-        utils.log_warning("No License Manager resources found in any selected region.")
+        if not failed_regions:
+            # Genuinely empty account: every region succeeded and returned
+            # nothing.
+            utils.log_warning("No License Manager resources found in any selected region.")
         utils.log_info("Creating empty export file...")
 
     utils.log_info(f"Total license configurations found: {len(all_configs)}")
@@ -374,6 +437,19 @@ def _run_export(account_id: str, account_name: str, regions: list) -> None:
     utils.log_info(f"  Inventory Items: {len(all_inventory)}")
 
     utils.log_success("License Manager export completed successfully!")
+
+    # If ANY region failed the license configurations scope collection, make
+    # it loud: write a marker and exit non-zero, even though the Summary
+    # sheet (and any partial data) was already exported above. A
+    # complete-looking workbook with silently zero-row data is exactly the
+    # failure mode this guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'license-manager', failed_regions)
+        print(
+            "\nERROR: License Manager export completed with failures — data is incomplete. "
+            "See the *-license-manager-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/marketplace_export.py
+++ b/scripts/marketplace_export.py
@@ -25,9 +25,87 @@ except ImportError:
     import utils
 args = utils.parse_script_args("Export AWS Marketplace subscriptions to Excel")
 
-@utils.aws_error_handler("Collecting Marketplace agreements", default_return=[])
+def _build_agreement_row(mp_client, agreement_summary: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the export row for a single Marketplace agreement.
+
+    Extracted so per-agreement processing can be wrapped in try/except by
+    the caller: a malformed/inaccessible agreement must not sink the whole
+    account-scope collection. Required fields are read with ``.get()`` and a
+    safe default for the same reason.
+
+    Args:
+        mp_client: The boto3 marketplace-agreement client.
+        agreement_summary (dict): A single agreementViewSummaries entry from
+            search_agreements.
+
+    Returns:
+        dict: The assembled agreement row.
+    """
+    agreement_id = agreement_summary.get('agreementId', 'N/A')
+
+    # Get detailed agreement information
+    agreement_details = mp_client.describe_agreement(agreementId=agreement_id)
+
+    proposer = agreement_details.get('proposer', {})
+    acceptor = agreement_details.get('acceptor', {})
+
+    agreement_type = agreement_details.get('agreementType', 'N/A')
+    status = agreement_details.get('status', 'N/A')
+
+    acceptance_time = agreement_details.get('acceptanceTime', 'N/A')
+    if acceptance_time != 'N/A':
+        acceptance_time = acceptance_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    start_time = agreement_details.get('startTime', 'N/A')
+    if start_time != 'N/A':
+        start_time = start_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    end_time = agreement_details.get('endTime', 'N/A')
+    if end_time != 'N/A':
+        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
+
+    estimated_charges = agreement_details.get('estimatedCharges', {})
+    agreement_amount = estimated_charges.get('agreementValue', 'N/A')
+    currency_code = estimated_charges.get('currencyCode', 'N/A')
+
+    return {
+        'Agreement ID': agreement_id,
+        'Agreement Type': agreement_type,
+        'Status': status,
+        'Proposer Account ID': proposer.get('accountId', 'N/A'),
+        'Acceptor Account ID': acceptor.get('accountId', 'N/A'),
+        'Acceptance Time': acceptance_time,
+        'Start Time': start_time,
+        'End Time': end_time,
+        'Agreement Amount': agreement_amount,
+        'Currency': currency_code
+    }
+
+
 def collect_agreements() -> list[dict[str, Any]]:
-    """Collect AWS Marketplace agreement information (global service)."""
+    """
+    Collect AWS Marketplace agreement information (global service).
+
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty account (no Marketplace agreements), producing silent
+    data loss (see the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits). AWS Marketplace is a global, account-scope service (not
+    multi-region — see scripts/shield_export.py for the sibling global/
+    account-scope PARTIAL-tier fix this follows). Account-scope failures
+    (client creation, pagination/search_agreements) are allowed to raise so
+    the caller (main) can record this scope as *failed* rather than
+    *empty*. Per-agreement errors are contained internally (logged and
+    skipped).
+
+    Returns:
+        list: List of agreement information dictionaries.
+
+    Raises:
+        Exception: Any AWS/pagination error for the account scope (caller
+            records it as a failed scope; it is never masked as empty).
+    """
     print("\n=== COLLECTING MARKETPLACE AGREEMENTS ===")
     all_agreements = []
 
@@ -35,74 +113,30 @@ def collect_agreements() -> list[dict[str, Any]]:
     home_region = utils.get_partition_default_region()
     mp_client = utils.get_boto3_client('marketplace-agreement', region_name=home_region)
 
-    try:
-        # Search for all agreements (active and expired)
-        # Search without filters to get all agreements
-        next_token = None
-        while True:
-            params = {}
-            params['maxResults'] = 100
-            if next_token:
-                params['nextToken'] = next_token
-            page = mp_client.search_agreements(**params)
-            agreements = page.get('agreementViewSummaries', [])
+    # Search for all agreements (active and expired), without filters, to
+    # get all agreements. A real error here (client creation, pagination)
+    # is allowed to propagate — it is not caught in this function.
+    next_token = None
+    while True:
+        params = {}
+        params['maxResults'] = 100
+        if next_token:
+            params['nextToken'] = next_token
+        page = mp_client.search_agreements(**params)
+        agreements = page.get('agreementViewSummaries', [])
 
-            for agreement_summary in agreements:
-                agreement_id = agreement_summary.get('agreementId', 'N/A')
+        for agreement_summary in agreements:
+            agreement_id = agreement_summary.get('agreementId', 'N/A')
 
-                try:
-                    # Get detailed agreement information
-                    agreement_response = mp_client.describe_agreement(
-                        agreementId=agreement_id
-                    )
+            try:
+                all_agreements.append(_build_agreement_row(mp_client, agreement_summary))
+            except Exception as e:
+                utils.log_warning(f"Could not get details for agreement {agreement_id}: {str(e)}")
+                continue
 
-                    agreement_details = agreement_response
-
-                    proposer = agreement_details.get('proposer', {})
-                    acceptor = agreement_details.get('acceptor', {})
-
-                    agreement_type = agreement_details.get('agreementType', 'N/A')
-                    status = agreement_details.get('status', 'N/A')
-
-                    acceptance_time = agreement_details.get('acceptanceTime', 'N/A')
-                    if acceptance_time != 'N/A':
-                        acceptance_time = acceptance_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    start_time = agreement_details.get('startTime', 'N/A')
-                    if start_time != 'N/A':
-                        start_time = start_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    end_time = agreement_details.get('endTime', 'N/A')
-                    if end_time != 'N/A':
-                        end_time = end_time.strftime('%Y-%m-%d %H:%M:%S')
-
-                    estimated_charges = agreement_details.get('estimatedCharges', {})
-                    agreement_amount = estimated_charges.get('agreementValue', 'N/A')
-                    currency_code = estimated_charges.get('currencyCode', 'N/A')
-
-                    all_agreements.append({
-                        'Agreement ID': agreement_id,
-                        'Agreement Type': agreement_type,
-                        'Status': status,
-                        'Proposer Account ID': proposer.get('accountId', 'N/A'),
-                        'Acceptor Account ID': acceptor.get('accountId', 'N/A'),
-                        'Acceptance Time': acceptance_time,
-                        'Start Time': start_time,
-                        'End Time': end_time,
-                        'Agreement Amount': agreement_amount,
-                        'Currency': currency_code
-                    })
-
-                except Exception as e:
-                    utils.log_warning(f"Could not get details for agreement {agreement_id}: {str(e)}")
-                    continue
-
-            next_token = page.get('nextToken')
-            if not next_token:
-                break
-
-    except Exception as e:
-        utils.log_warning(f"Error searching agreements: {str(e)}")
+        next_token = page.get('nextToken')
+        if not next_token:
+            break
 
     utils.log_success(f"Total agreements collected: {len(all_agreements)}")
     return all_agreements
@@ -251,7 +285,24 @@ def generate_summary(agreements: list[dict[str, Any]],
 
 
 def main():
-    """Main execution function."""
+    """
+    Main execution function.
+
+    AWS Marketplace is a global, account-scope service (not multi-region),
+    so failures are tracked per account-scope collector rather than via
+    ``utils.scan_regions_concurrent`` (see scripts/shield_export.py for the
+    sibling global/account-scope PARTIAL-tier reference). This exporter
+    already builds an always-non-empty ``Summary`` sheet (see
+    ``generate_summary``), so a workbook always lands on disk regardless of
+    whether the ``agreements`` scope succeeded — that "file always lands"
+    behavior is preserved. What was missing is a way to tell "agreements
+    scope failed" apart from "genuinely no agreements": a failure on that
+    scope is now tracked in ``failed_scopes``, surfaced via a
+    ``utils.report_collection_failures`` marker, and causes a non-zero
+    exit -- it must never be silently collapsed into a zero-row Agreements
+    sheet inside an otherwise complete-looking workbook (07.15.2026 /
+    07.16.2026 audits).
+    """
     if not utils.ensure_dependencies('pandas', 'openpyxl'):
         return
     global pd
@@ -279,7 +330,22 @@ def main():
     # Collect data
     print("\nCollecting AWS Marketplace data...")
 
-    agreements = collect_agreements()
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    # STEP 1: Collect agreements (PRIMARY scope — a real API error here
+    # must propagate to failed_scopes, never collapse into an empty list
+    # that reads as "no agreements").
+    try:
+        agreements = collect_agreements()
+    except Exception as e:
+        failed_scopes.append(('agreements', str(e)))
+        utils.log_error(f"Marketplace agreements collection failed: {e}")
+        agreements = []
+
+    # STEP 2: Collect agreement terms (enrichment — degrades gracefully via
+    # its own aws_error_handler decorator; a failure here does not fail the
+    # whole export).
     terms = collect_agreement_terms(agreements)
     summary = generate_summary(agreements, terms)
 
@@ -303,16 +369,32 @@ def main():
         df_terms = utils.prepare_dataframe_for_export(df_terms)
         dataframes['Agreement Terms'] = df_terms
 
-    # Export to Excel
-    if dataframes:
-        filename = utils.create_export_filename(account_name, 'marketplace', 'global')
+    # Export to Excel. The Summary sheet (see generate_summary) is always
+    # populated, so dataframes is never empty and a workbook always lands
+    # here -- this "file always lands" behavior is preserved even when the
+    # agreements scope failed.
+    filename = utils.create_export_filename(account_name, 'marketplace', 'global')
 
-        utils.log_info(f"Exporting to {filename}...")
-        utils.save_multiple_dataframes_to_excel(dataframes, filename)
+    utils.log_info(f"Exporting to {filename}...")
+    utils.save_multiple_dataframes_to_excel(dataframes, filename)
 
-        # Log summary
-    else:
+    if not agreements and not terms and not failed_scopes:
+        # Genuinely empty: the agreements scope succeeded and there is
+        # simply nothing configured -- not a failure.
         utils.log_warning("No Marketplace data found to export")
+
+    # If the agreements scope failed, make it loud: write a marker and exit
+    # non-zero, even though the always-written Summary sheet means a
+    # workbook still lands. A partial export that looks complete is exactly
+    # the failure mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'marketplace', failed_scopes)
+        print(
+            "\nERROR: Marketplace export completed with failures — data is "
+            "incomplete. See the *-marketplace-FAILED-*.txt marker in the "
+            "output directory."
+        )
+        sys.exit(1)
 
     utils.log_success("Marketplace export completed successfully")
 

--- a/scripts/reserved_instances_export.py
+++ b/scripts/reserved_instances_export.py
@@ -43,205 +43,397 @@ args = utils.parse_script_args("Export EC2 Reserved Instances to Excel")
 utils.setup_logging('reserved-instances-export')
 
 
-@utils.aws_error_handler("Collecting EC2 Reserved Instances", default_return=[])
-def collect_ec2_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect EC2 Reserved Instances."""
+def _build_ec2_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single EC2 Reserved Instance export row."""
+    return {
+        'Service': 'EC2',
+        'Region': region,
+        'ReservationID': ri.get('ReservedInstancesId', 'N/A'),
+        'InstanceType': ri.get('InstanceType', 'N/A'),
+        'InstanceCount': ri.get('InstanceCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('Start'),
+        'End': ri.get('End'),
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('OfferingType', 'N/A'),
+        'OfferingClass': ri.get('OfferingClass', 'N/A'),
+        'FixedPrice': ri.get('FixedPrice', 0),
+        'UsagePrice': ri.get('UsagePrice', 0),
+        'CurrencyCode': ri.get('CurrencyCode', 'USD'),
+        'ProductDescription': ri.get('ProductDescription', 'N/A'),
+        'Scope': ri.get('Scope', 'N/A'),
+        'AvailabilityZone': ri.get('AvailabilityZone', 'N/A'),
+        'InstanceTenancy': ri.get('InstanceTenancy', 'default'),
+    }
+
+
+def _scan_ec2_ri_region(region: str) -> list[dict[str, Any]]:
+    """
+    Collect EC2 Reserved Instances from a single region.
+
+    This is a primary scope collector. It deliberately does NOT swallow
+    errors: an API/permission failure here must propagate so
+    ``scan_regions_concurrent(..., collect_failures=True)`` records the
+    region as failed instead of silently reporting "no Reserved Instances"
+    (the silent-collection-loss bug — see
+    ``.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md``).
+
+    Individual malformed RIs are skipped (logged) rather than aborting the
+    whole region.
+    """
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     ec2 = utils.get_boto3_client('ec2', region_name=region)
     reserved_instances = []
 
     response = ec2.describe_reserved_instances()
 
     for ri in response.get('ReservedInstances', []):
-        reserved_instances.append({
-            'Service': 'EC2',
-            'Region': region,
-            'ReservationID': ri.get('ReservedInstancesId', 'N/A'),
-            'InstanceType': ri.get('InstanceType', 'N/A'),
-            'InstanceCount': ri.get('InstanceCount', 0),
-            'State': ri.get('State', 'N/A'),
-            'Start': ri.get('Start'),
-            'End': ri.get('End'),
-            'Duration': f"{ri.get('Duration', 0) // 86400} days",
-            'OfferingType': ri.get('OfferingType', 'N/A'),
-            'OfferingClass': ri.get('OfferingClass', 'N/A'),
-            'FixedPrice': ri.get('FixedPrice', 0),
-            'UsagePrice': ri.get('UsagePrice', 0),
-            'CurrencyCode': ri.get('CurrencyCode', 'USD'),
-            'ProductDescription': ri.get('ProductDescription', 'N/A'),
-            'Scope': ri.get('Scope', 'N/A'),
-            'AvailabilityZone': ri.get('AvailabilityZone', 'N/A'),
-            'InstanceTenancy': ri.get('InstanceTenancy', 'default'),
-        })
+        try:
+            reserved_instances.append(_build_ec2_ri_row(ri, region))
+        except Exception as e:
+            utils.log_error(
+                f"Skipping malformed EC2 Reserved Instance in {region}: "
+                f"{ri.get('ReservedInstancesId', '<unknown>')}",
+                e,
+            )
+            continue
 
     return reserved_instances
 
 
-@utils.aws_error_handler("Collecting RDS Reserved DB Instances", default_return=[])
-def collect_rds_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect RDS Reserved DB Instances."""
+def collect_ec2_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """
+    Collect EC2 Reserved Instances across regions, surfacing failures.
+
+    Returns:
+        tuple: ``(reserved_instances, failed_regions)`` where ``failed_regions``
+        is a list of ``(region, error_message)`` tuples.
+    """
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_ec2_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"EC2 RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
+
+
+def _build_rds_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single RDS Reserved DB Instance export row."""
+    return {
+        'Service': 'RDS',
+        'Region': region,
+        'ReservationID': ri.get('ReservedDBInstanceId', 'N/A'),
+        'InstanceType': ri.get('DBInstanceClass', 'N/A'),
+        'InstanceCount': ri.get('DBInstanceCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('StartTime'),
+        'End': None,  # RDS doesn't expose end time directly
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('OfferingType', 'N/A'),
+        'OfferingClass': 'N/A',  # Not applicable for RDS
+        'FixedPrice': ri.get('FixedPrice', 0),
+        'UsagePrice': ri.get('UsagePrice', 0),
+        'CurrencyCode': ri.get('CurrencyCode', 'USD'),
+        'ProductDescription': ri.get('ProductDescription', 'N/A'),
+        'Scope': 'Regional',  # RDS RIs are always regional
+        'AvailabilityZone': 'N/A',
+        'InstanceTenancy': 'N/A',
+        'MultiAZ': ri.get('MultiAZ', False),
+        'Engine': ri.get('ProductDescription', 'N/A'),
+    }
+
+
+def _scan_rds_ri_region(region: str) -> list[dict[str, Any]]:
+    """Collect RDS Reserved DB Instances from a single region. Raises on failure — see _scan_ec2_ri_region."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     rds = utils.get_boto3_client('rds', region_name=region)
     reserved_instances = []
 
     paginator = rds.get_paginator('describe_reserved_db_instances')
     for page in paginator.paginate():
         for ri in page.get('ReservedDBInstances', []):
-            reserved_instances.append({
-                'Service': 'RDS',
-                'Region': region,
-                'ReservationID': ri.get('ReservedDBInstanceId', 'N/A'),
-                'InstanceType': ri.get('DBInstanceClass', 'N/A'),
-                'InstanceCount': ri.get('DBInstanceCount', 0),
-                'State': ri.get('State', 'N/A'),
-                'Start': ri.get('StartTime'),
-                'End': None,  # RDS doesn't expose end time directly
-                'Duration': f"{ri.get('Duration', 0) // 86400} days",
-                'OfferingType': ri.get('OfferingType', 'N/A'),
-                'OfferingClass': 'N/A',  # Not applicable for RDS
-                'FixedPrice': ri.get('FixedPrice', 0),
-                'UsagePrice': ri.get('UsagePrice', 0),
-                'CurrencyCode': ri.get('CurrencyCode', 'USD'),
-                'ProductDescription': ri.get('ProductDescription', 'N/A'),
-                'Scope': 'Regional',  # RDS RIs are always regional
-                'AvailabilityZone': 'N/A',
-                'InstanceTenancy': 'N/A',
-                'MultiAZ': ri.get('MultiAZ', False),
-                'Engine': ri.get('ProductDescription', 'N/A'),
-            })
+            try:
+                reserved_instances.append(_build_rds_ri_row(ri, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed RDS Reserved Instance in {region}: "
+                    f"{ri.get('ReservedDBInstanceId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reserved_instances
 
 
-@utils.aws_error_handler("Collecting ElastiCache Reserved Cache Nodes", default_return=[])
-def collect_elasticache_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect ElastiCache Reserved Cache Nodes."""
+def collect_rds_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect RDS Reserved DB Instances across regions, surfacing failures."""
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_rds_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"RDS RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
+
+
+def _build_elasticache_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single ElastiCache Reserved Cache Node export row."""
+    return {
+        'Service': 'ElastiCache',
+        'Region': region,
+        'ReservationID': ri.get('ReservedCacheNodeId', 'N/A'),
+        'InstanceType': ri.get('CacheNodeType', 'N/A'),
+        'InstanceCount': ri.get('CacheNodeCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('StartTime'),
+        'End': None,
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('OfferingType', 'N/A'),
+        'OfferingClass': 'N/A',
+        'FixedPrice': ri.get('FixedPrice', 0),
+        'UsagePrice': ri.get('UsagePrice', 0),
+        'CurrencyCode': 'USD',
+        'ProductDescription': ri.get('ProductDescription', 'N/A'),
+        'Scope': 'Regional',
+        'AvailabilityZone': 'N/A',
+        'InstanceTenancy': 'N/A',
+        'Engine': ri.get('ProductDescription', 'N/A'),
+    }
+
+
+def _scan_elasticache_ri_region(region: str) -> list[dict[str, Any]]:
+    """Collect ElastiCache Reserved Cache Nodes from a single region. Raises on failure — see _scan_ec2_ri_region."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     elasticache = utils.get_boto3_client('elasticache', region_name=region)
     reserved_instances = []
 
     paginator = elasticache.get_paginator('describe_reserved_cache_nodes')
     for page in paginator.paginate():
         for ri in page.get('ReservedCacheNodes', []):
-            reserved_instances.append({
-                'Service': 'ElastiCache',
-                'Region': region,
-                'ReservationID': ri.get('ReservedCacheNodeId', 'N/A'),
-                'InstanceType': ri.get('CacheNodeType', 'N/A'),
-                'InstanceCount': ri.get('CacheNodeCount', 0),
-                'State': ri.get('State', 'N/A'),
-                'Start': ri.get('StartTime'),
-                'End': None,
-                'Duration': f"{ri.get('Duration', 0) // 86400} days",
-                'OfferingType': ri.get('OfferingType', 'N/A'),
-                'OfferingClass': 'N/A',
-                'FixedPrice': ri.get('FixedPrice', 0),
-                'UsagePrice': ri.get('UsagePrice', 0),
-                'CurrencyCode': 'USD',
-                'ProductDescription': ri.get('ProductDescription', 'N/A'),
-                'Scope': 'Regional',
-                'AvailabilityZone': 'N/A',
-                'InstanceTenancy': 'N/A',
-                'Engine': ri.get('ProductDescription', 'N/A'),
-            })
+            try:
+                reserved_instances.append(_build_elasticache_ri_row(ri, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed ElastiCache Reserved Cache Node in {region}: "
+                    f"{ri.get('ReservedCacheNodeId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reserved_instances
 
 
-@utils.aws_error_handler("Collecting OpenSearch Reserved Instances", default_return=[])
-def collect_opensearch_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect OpenSearch Reserved Instances."""
+def collect_elasticache_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect ElastiCache Reserved Cache Nodes across regions, surfacing failures."""
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_elasticache_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"ElastiCache RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
+
+
+def _build_opensearch_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single OpenSearch Reserved Instance export row."""
+    return {
+        'Service': 'OpenSearch',
+        'Region': region,
+        'ReservationID': ri.get('ReservedElasticsearchInstanceId', 'N/A'),
+        'InstanceType': ri.get('ElasticsearchInstanceType', 'N/A'),
+        'InstanceCount': ri.get('ElasticsearchInstanceCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('StartTime'),
+        'End': None,
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('PaymentOption', 'N/A'),
+        'OfferingClass': 'N/A',
+        'FixedPrice': ri.get('FixedPrice', 0),
+        'UsagePrice': ri.get('UsagePrice', 0),
+        'CurrencyCode': ri.get('CurrencyCode', 'USD'),
+        'ProductDescription': 'OpenSearch',
+        'Scope': 'Regional',
+        'AvailabilityZone': 'N/A',
+        'InstanceTenancy': 'N/A',
+    }
+
+
+def _scan_opensearch_ri_region(region: str) -> list[dict[str, Any]]:
+    """Collect OpenSearch Reserved Instances from a single region. Raises on failure — see _scan_ec2_ri_region."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     opensearch = utils.get_boto3_client('es', region_name=region)  # 'es' is the service name
     reserved_instances = []
 
     response = opensearch.describe_reserved_elasticsearch_instances()
 
     for ri in response.get('ReservedElasticsearchInstances', []):
-        reserved_instances.append({
-            'Service': 'OpenSearch',
-            'Region': region,
-            'ReservationID': ri.get('ReservedElasticsearchInstanceId', 'N/A'),
-            'InstanceType': ri.get('ElasticsearchInstanceType', 'N/A'),
-            'InstanceCount': ri.get('ElasticsearchInstanceCount', 0),
-            'State': ri.get('State', 'N/A'),
-            'Start': ri.get('StartTime'),
-            'End': None,
-            'Duration': f"{ri.get('Duration', 0) // 86400} days",
-            'OfferingType': ri.get('PaymentOption', 'N/A'),
-            'OfferingClass': 'N/A',
-            'FixedPrice': ri.get('FixedPrice', 0),
-            'UsagePrice': ri.get('UsagePrice', 0),
-            'CurrencyCode': ri.get('CurrencyCode', 'USD'),
-            'ProductDescription': 'OpenSearch',
-            'Scope': 'Regional',
-            'AvailabilityZone': 'N/A',
-            'InstanceTenancy': 'N/A',
-        })
+        try:
+            reserved_instances.append(_build_opensearch_ri_row(ri, region))
+        except Exception as e:
+            utils.log_error(
+                f"Skipping malformed OpenSearch Reserved Instance in {region}: "
+                f"{ri.get('ReservedElasticsearchInstanceId', '<unknown>')}",
+                e,
+            )
+            continue
 
     return reserved_instances
 
 
-@utils.aws_error_handler("Collecting Redshift Reserved Nodes", default_return=[])
-def collect_redshift_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect Redshift Reserved Nodes."""
+def collect_opensearch_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect OpenSearch Reserved Instances across regions, surfacing failures."""
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_opensearch_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"OpenSearch RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
+
+
+def _build_redshift_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single Redshift Reserved Node export row."""
+    return {
+        'Service': 'Redshift',
+        'Region': region,
+        'ReservationID': ri.get('ReservedNodeId', 'N/A'),
+        'InstanceType': ri.get('NodeType', 'N/A'),
+        'InstanceCount': ri.get('NodeCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('StartTime'),
+        'End': None,
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('OfferingType', 'N/A'),
+        'OfferingClass': 'N/A',
+        'FixedPrice': ri.get('FixedPrice', 0),
+        'UsagePrice': ri.get('UsagePrice', 0),
+        'CurrencyCode': ri.get('CurrencyCode', 'USD'),
+        'ProductDescription': 'Redshift',
+        'Scope': 'Regional',
+        'AvailabilityZone': 'N/A',
+        'InstanceTenancy': 'N/A',
+    }
+
+
+def _scan_redshift_ri_region(region: str) -> list[dict[str, Any]]:
+    """Collect Redshift Reserved Nodes from a single region. Raises on failure — see _scan_ec2_ri_region."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     redshift = utils.get_boto3_client('redshift', region_name=region)
     reserved_instances = []
 
     paginator = redshift.get_paginator('describe_reserved_nodes')
     for page in paginator.paginate():
         for ri in page.get('ReservedNodes', []):
-            reserved_instances.append({
-                'Service': 'Redshift',
-                'Region': region,
-                'ReservationID': ri.get('ReservedNodeId', 'N/A'),
-                'InstanceType': ri.get('NodeType', 'N/A'),
-                'InstanceCount': ri.get('NodeCount', 0),
-                'State': ri.get('State', 'N/A'),
-                'Start': ri.get('StartTime'),
-                'End': None,
-                'Duration': f"{ri.get('Duration', 0) // 86400} days",
-                'OfferingType': ri.get('OfferingType', 'N/A'),
-                'OfferingClass': 'N/A',
-                'FixedPrice': ri.get('FixedPrice', 0),
-                'UsagePrice': ri.get('UsagePrice', 0),
-                'CurrencyCode': ri.get('CurrencyCode', 'USD'),
-                'ProductDescription': 'Redshift',
-                'Scope': 'Regional',
-                'AvailabilityZone': 'N/A',
-                'InstanceTenancy': 'N/A',
-            })
+            try:
+                reserved_instances.append(_build_redshift_ri_row(ri, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed Redshift Reserved Node in {region}: "
+                    f"{ri.get('ReservedNodeId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reserved_instances
 
 
-@utils.aws_error_handler("Collecting MemoryDB Reserved Nodes", default_return=[])
-def collect_memorydb_reserved_instances(region: str) -> list[dict[str, Any]]:
-    """Collect MemoryDB Reserved Nodes."""
+def collect_redshift_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect Redshift Reserved Nodes across regions, surfacing failures."""
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_redshift_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"Redshift RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
+
+
+def _build_memorydb_ri_row(ri: dict, region: str) -> dict[str, Any]:
+    """Build a single MemoryDB Reserved Node export row."""
+    return {
+        'Service': 'MemoryDB',
+        'Region': region,
+        'ReservationID': ri.get('ReservedNodeId', 'N/A'),
+        'InstanceType': ri.get('NodeType', 'N/A'),
+        'InstanceCount': ri.get('NodeCount', 0),
+        'State': ri.get('State', 'N/A'),
+        'Start': ri.get('StartTime'),
+        'End': None,
+        'Duration': f"{ri.get('Duration', 0) // 86400} days",
+        'OfferingType': ri.get('OfferingType', 'N/A'),
+        'OfferingClass': 'N/A',
+        'FixedPrice': 0,  # Not exposed by MemoryDB API
+        'UsagePrice': 0,
+        'CurrencyCode': 'USD',
+        'ProductDescription': 'MemoryDB',
+        'Scope': 'Regional',
+        'AvailabilityZone': 'N/A',
+        'InstanceTenancy': 'N/A',
+    }
+
+
+def _scan_memorydb_ri_region(region: str) -> list[dict[str, Any]]:
+    """Collect MemoryDB Reserved Nodes from a single region. Raises on failure — see _scan_ec2_ri_region."""
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
     memorydb = utils.get_boto3_client('memorydb', region_name=region)
     reserved_instances = []
 
     paginator = memorydb.get_paginator('describe_reserved_nodes')
     for page in paginator.paginate():
         for ri in page.get('ReservedNodes', []):
-            reserved_instances.append({
-                'Service': 'MemoryDB',
-                'Region': region,
-                'ReservationID': ri.get('ReservedNodeId', 'N/A'),
-                'InstanceType': ri.get('NodeType', 'N/A'),
-                'InstanceCount': ri.get('NodeCount', 0),
-                'State': ri.get('State', 'N/A'),
-                'Start': ri.get('StartTime'),
-                'End': None,
-                'Duration': f"{ri.get('Duration', 0) // 86400} days",
-                'OfferingType': ri.get('OfferingType', 'N/A'),
-                'OfferingClass': 'N/A',
-                'FixedPrice': 0,  # Not exposed by MemoryDB API
-                'UsagePrice': 0,
-                'CurrencyCode': 'USD',
-                'ProductDescription': 'MemoryDB',
-                'Scope': 'Regional',
-                'AvailabilityZone': 'N/A',
-                'InstanceTenancy': 'N/A',
-            })
+            try:
+                reserved_instances.append(_build_memorydb_ri_row(ri, region))
+            except Exception as e:
+                utils.log_error(
+                    f"Skipping malformed MemoryDB Reserved Node in {region}: "
+                    f"{ri.get('ReservedNodeId', '<unknown>')}",
+                    e,
+                )
+                continue
 
     return reserved_instances
+
+
+def collect_memorydb_reserved_instances(regions: list[str]) -> tuple[list[dict[str, Any]], list]:
+    """Collect MemoryDB Reserved Nodes across regions, surfacing failures."""
+    region_results, failed_regions = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=_scan_memorydb_ri_region,
+        show_progress=True,
+        collect_failures=True,
+    )
+    all_ris = [ri for result in region_results for ri in result]
+    failed_regions = [(region, f"MemoryDB RI: {error}") for region, error in failed_regions]
+    return all_ris, failed_regions
 
 
 def calculate_expiration_status(end_date) -> str:
@@ -275,37 +467,40 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
     utils.log_info(f"Exporting Reserved Instance data for account: {account_name} ({utils.mask_account_id(account_id)})")
     utils.log_info(f"Scanning {len(regions)} region(s) for Reserved Instances...")
 
-    # Collect all RIs across all services and regions
+    # Collect each RI scope (EC2, RDS, ElastiCache, OpenSearch, Redshift,
+    # MemoryDB). Each scope wrapper uses scan_regions_concurrent(...,
+    # collect_failures=True) so a region-level API failure is surfaced as a
+    # failed region rather than silently collapsed into "no RIs" (the
+    # silent-collection-loss bug — see
+    # .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md).
+    ec2_ris, ec2_failed = collect_ec2_reserved_instances(regions)
+    rds_ris, rds_failed = collect_rds_reserved_instances(regions)
+    elasticache_ris, elasticache_failed = collect_elasticache_reserved_instances(regions)
+    opensearch_ris, opensearch_failed = collect_opensearch_reserved_instances(regions)
+    redshift_ris, redshift_failed = collect_redshift_reserved_instances(regions)
+    memorydb_ris, memorydb_failed = collect_memorydb_reserved_instances(regions)
+
+    utils.log_info(f"  EC2: {len(ec2_ris)}, RDS: {len(rds_ris)}, "
+                 f"ElastiCache: {len(elasticache_ris)}, OpenSearch: {len(opensearch_ris)}, "
+                 f"Redshift: {len(redshift_ris)}, MemoryDB: {len(memorydb_ris)}")
+
     all_ris = []
+    all_ris.extend(ec2_ris)
+    all_ris.extend(rds_ris)
+    all_ris.extend(elasticache_ris)
+    all_ris.extend(opensearch_ris)
+    all_ris.extend(redshift_ris)
+    all_ris.extend(memorydb_ris)
 
-    for idx, region in enumerate(regions, 1):
-        utils.log_info(f"[{idx}/{len(regions)}] Processing region: {region}")
+    # Merge every scope's failed regions into ONE combined list, so a single
+    # failure marker + non-zero exit covers all RI services.
+    failed_regions = (
+        ec2_failed + rds_failed + elasticache_failed +
+        opensearch_failed + redshift_failed + memorydb_failed
+    )
 
-        # Collect from each service
-        ec2_ris = collect_ec2_reserved_instances(region)
-        rds_ris = collect_rds_reserved_instances(region)
-        elasticache_ris = collect_elasticache_reserved_instances(region)
-        opensearch_ris = collect_opensearch_reserved_instances(region)
-        redshift_ris = collect_redshift_reserved_instances(region)
-        memorydb_ris = collect_memorydb_reserved_instances(region)
-
-        region_count = (len(ec2_ris) + len(rds_ris) + len(elasticache_ris) +
-                      len(opensearch_ris) + len(redshift_ris) + len(memorydb_ris))
-
-        if region_count > 0:
-            utils.log_info(f"  Found {region_count} Reserved Instances in {region}")
-            utils.log_info(f"    EC2: {len(ec2_ris)}, RDS: {len(rds_ris)}, "
-                         f"ElastiCache: {len(elasticache_ris)}, OpenSearch: {len(opensearch_ris)}, "
-                         f"Redshift: {len(redshift_ris)}, MemoryDB: {len(memorydb_ris)}")
-
-        all_ris.extend(ec2_ris)
-        all_ris.extend(rds_ris)
-        all_ris.extend(elasticache_ris)
-        all_ris.extend(opensearch_ris)
-        all_ris.extend(redshift_ris)
-        all_ris.extend(memorydb_ris)
-
-    if not all_ris:
+    if not all_ris and not failed_regions:
+        # Genuinely empty account: every scope/region succeeded and returned nothing.
         utils.log_warning("No Reserved Instances found in any selected region.")
         utils.log_info("Creating empty export file...")
 
@@ -381,6 +576,19 @@ def _run_export(account_id: str, account_name: str, regions: list[str]) -> None:
         utils.log_warning(f"  {len(df_expiring)} Reserved Instance(s) expiring within 90 days")
 
     utils.log_success("Reserved Instances export completed successfully!")
+
+    # If ANY RI scope failed for ANY region, make it loud: write a marker and
+    # exit non-zero, even though the always-written Summary sheet above means
+    # a workbook still lands (Tier-3 PARTIAL). A zero-row-looking sheet that
+    # is actually a failed scope is exactly the silent-loss failure mode this
+    # guards against.
+    if failed_regions:
+        utils.report_collection_failures(account_name, 'reserved-instances', failed_regions)
+        print(
+            "\nERROR: Reserved Instances export completed with failures — data is incomplete. "
+            "See the *-reserved-instances-FAILED-*.txt marker in the output directory."
+        )
+        sys.exit(1)
 
 
 def main():

--- a/scripts/trusted_advisor_cost_optimization_export.py
+++ b/scripts/trusted_advisor_cost_optimization_export.py
@@ -61,84 +61,192 @@ COST_OPTIMIZATION_CHECKS = {
 }
 
 
+class TrustedAdvisorNotSubscribedError(Exception):
+    """
+    Raised when the account's support plan does not include Trusted
+    Advisor API access (``SubscriptionRequiredException``).
+
+    This is a legitimate, graceful "service not available" state — NOT a
+    collection failure. Business/Enterprise Support is a paid prerequisite
+    for the Trusted Advisor API; a Basic/Developer support account will
+    always see this. See scripts/shield_export.py's ``check_subscription``
+    for the equivalent account-scope pattern (07.16.2026 audit).
+    """
+
+
+def _is_subscription_required_error(error: ClientError) -> bool:
+    """Return True if a ClientError is Trusted Advisor's SubscriptionRequiredException."""
+    error_code = error.response.get('Error', {}).get('Code', '')
+    return error_code == 'SubscriptionRequiredException' or 'SubscriptionRequiredException' in str(error)
+
+
 def get_trusted_advisor_checks():
     """
     Get all Trusted Advisor checks related to cost optimization.
 
+    Not wrapped in ``aws_error_handler`` and does not swallow errors to an
+    empty list: a swallowed error here would be indistinguishable from a
+    genuinely empty/not-yet-run check set, producing silent data loss (see
+    the 07.16.2026 silent-collection-failure audit).
+
     Returns:
         list: List of Trusted Advisor check results
-    """
-    try:
-        # Support/Trusted Advisor is a global service - use partition-aware home region
-        home_region = utils.get_partition_default_region()
-        support_client = utils.get_boto3_client('support', region_name=home_region)
 
-        # Get all Trusted Advisor checks
-        response = support_client.describe_trusted_advisor_checks(language='en')
-
-        # Filter to only cost optimization checks
-        cost_checks = [check for check in response['checks'] if check['category'] == 'cost_optimizing']
-
-        return cost_checks
-    except ClientError as e:
-        if 'SubscriptionRequiredException' in str(e):
-            utils.log_warning("AWS Business or Enterprise Support plan is required to access Trusted Advisor API. Skipping.")
-            sys.exit(0)
-        else:
-            utils.log_error(f"Error accessing Trusted Advisor checks: {e}")
-            sys.exit(1)
-
-
-@utils.aws_error_handler("Getting Trusted Advisor check result", default_return=None)
-def get_check_result(check_id):
-    """
-    Get the detailed results for a specific Trusted Advisor check.
-
-    Args:
-        check_id (str): The ID of the Trusted Advisor check
-
-    Returns:
-        dict: The detailed results of the check
+    Raises:
+        TrustedAdvisorNotSubscribedError: the account's support plan does
+            not include Trusted Advisor API access — a legitimate, graceful
+            "not available" state (caller must not report it as a failure).
+        Exception: any other real error listing checks — the caller records
+            this as a failed 'cost_checks' scope; it must never be silently
+            swallowed into an empty check list.
     """
     # Support/Trusted Advisor is a global service - use partition-aware home region
     home_region = utils.get_partition_default_region()
     support_client = utils.get_boto3_client('support', region_name=home_region)
 
-    # Get the check result
-    response = support_client.describe_trusted_advisor_check_result(
-        checkId=check_id,
-        language='en'
-    )
+    try:
+        # Get all Trusted Advisor checks
+        response = support_client.describe_trusted_advisor_checks(language='en')
+    except ClientError as e:
+        if _is_subscription_required_error(e):
+            raise TrustedAdvisorNotSubscribedError(str(e)) from e
+        raise
 
-    return response['result']
+    # Filter to only cost optimization checks
+    cost_checks = [check for check in response.get('checks', []) if check.get('category') == 'cost_optimizing']
+
+    return cost_checks
+
+
+def get_check_result(check_id):
+    """
+    Get the detailed results for a specific Trusted Advisor check.
+
+    This is the PRIMARY scope collector. It used to be decorated with
+    ``@utils.aws_error_handler(..., default_return=None)``, which swallowed
+    every error (throttling, access-denied, etc.) into ``None`` —
+    indistinguishable from "this check legitimately has no result yet."
+    Real errors now raise so the caller can tell a *failed* check apart
+    from a genuinely empty one (07.16.2026 audit).
+
+    Args:
+        check_id (str): The ID of the Trusted Advisor check
+
+    Returns:
+        dict: The detailed results of the check, or None if the API
+            returned no result for it.
+
+    Raises:
+        TrustedAdvisorNotSubscribedError: graceful not-available state.
+        Exception: any other real API error fetching this check's result.
+    """
+    # Support/Trusted Advisor is a global service - use partition-aware home region
+    home_region = utils.get_partition_default_region()
+    support_client = utils.get_boto3_client('support', region_name=home_region)
+
+    try:
+        # Get the check result
+        response = support_client.describe_trusted_advisor_check_result(
+            checkId=check_id,
+            language='en'
+        )
+    except ClientError as e:
+        if _is_subscription_required_error(e):
+            raise TrustedAdvisorNotSubscribedError(str(e)) from e
+        raise
+
+    return response.get('result')
+
+
+def _build_check_row(check):
+    """
+    Build the ``(check_id, entry)`` pair for a single Trusted Advisor check.
+
+    Extracted so per-check processing can be wrapped in try/except by the
+    caller: a malformed check entry or a real API error fetching its
+    result must not silently disappear or abort the whole collection.
+    Required fields are read with ``.get()`` so a missing key never raises
+    a bare ``KeyError`` (the ``check['id']`` subscript here was the
+    confirmed KeyError candidate in the 07.16.2026 audit).
+
+    Args:
+        check (dict): A single check entry from describe_trusted_advisor_checks.
+
+    Returns:
+        tuple: ``(check_id, entry_dict)``. ``entry_dict`` is None if the
+        check had no result to report.
+
+    Raises:
+        ValueError: the check entry has no 'id' — cannot be looked up.
+        TrustedAdvisorNotSubscribedError: forwarded from get_check_result().
+        Exception: any other real API error fetching this check's result.
+    """
+    check_id = check.get('id')
+    check_name = check.get('name', 'Unknown Check')
+    check_description = check.get('description', '')
+
+    if not check_id:
+        raise ValueError(f"Trusted Advisor check entry is missing 'id': {check!r}")
+
+    utils.log_info(f"Fetching results for: {check_name}")
+    result = get_check_result(check_id)
+
+    if not result:
+        return check_id, None
+
+    return check_id, {
+        'name': check_name,
+        'description': check_description,
+        'result': result
+    }
 
 
 def get_all_check_results():
     """
     Get results for all cost optimization checks.
 
+    Iterates the cost-optimization checks (PRIMARY scope) calling
+    ``get_check_result`` for each. A malformed check entry or a real API
+    error on a single check is logged and skipped (per-item guard) rather
+    than aborting the whole collection — but it is also recorded in
+    ``failed_checks`` so the caller can surface it instead of silently
+    treating a partial result set as "nothing to optimize."
+
     Returns:
-        dict: A dictionary with check details and results
+        tuple: ``(results, failed_checks)`` where ``results`` is a dict
+        keyed by check_id and ``failed_checks`` is a list of
+        ``(check_id, error_message)`` tuples for checks that could not be
+        fetched due to a real error.
+
+    Raises:
+        TrustedAdvisorNotSubscribedError: forwarded immediately — this
+            applies to the whole service, not a single check, so it is not
+            accumulated into ``failed_checks``.
     """
     # Get all cost optimization checks
     checks = get_trusted_advisor_checks()
 
     # Get results for each check
     results = {}
+    failed_checks = []
+
     for check in checks:
-        check_id = check['id']
-        check_name = check['name']
-        utils.log_info(f"Fetching results for: {check_name}")
+        try:
+            check_id, entry = _build_check_row(check)
+        except TrustedAdvisorNotSubscribedError:
+            # Not-available is a whole-service state, not a per-check one —
+            # propagate immediately rather than accumulating it as a failure.
+            raise
+        except Exception as e:
+            check_id_for_log = check.get('id', 'Unknown') if isinstance(check, dict) else 'Unknown'
+            utils.log_error(f"Skipping Trusted Advisor check '{check_id_for_log}' due to a processing error", e)
+            failed_checks.append((check_id_for_log, str(e)))
+            continue
 
-        result = get_check_result(check_id)
-        if result:
-            results[check_id] = {
-                'name': check_name,
-                'description': check['description'],
-                'result': result
-            }
+        if entry:
+            results[check_id] = entry
 
-    return results
+    return results, failed_checks
 
 
 def extract_savings(metadata, index):
@@ -295,50 +403,111 @@ def process_check_results(results):
 
 
 def _run_export(account_id: str, account_name: str) -> None:
-    """Collect Trusted Advisor data and write the Excel export."""
+    """
+    Collect Trusted Advisor data and write the Excel export.
+
+    Trusted Advisor is a global, account-scope service (not multi-region —
+    see scripts/shield_export.py for the account-scope reference pattern
+    this follows). The account's support plan not including Trusted Advisor
+    API access (SubscriptionRequiredException) is a legitimate, graceful
+    "service not available" state (exit 0, no marker) and must not be
+    confused with a real collection failure on the 'cost_checks' scope,
+    which is always surfaced via utils.report_collection_failures + a
+    non-zero exit — it must never be silently collapsed into "no cost
+    optimization opportunities" (07.16.2026 audit).
+    """
     if not utils.ensure_dependencies('pandas', 'openpyxl', 'boto3'):
         return
-
 
     utils.log_info("IMPORTANT: AWS Trusted Advisor requires Business or Enterprise Support.")
     utils.log_info("Trusted Advisor API is only available in the us-east-1 region.")
 
     utils.log_info("Fetching Trusted Advisor Cost Optimization checks...")
-    results = get_all_check_results()
 
-    if not results:
+    # Account-scope failure tracking (see scripts/shield_export.py).
+    failed_scopes = []
+
+    try:
+        results, failed_checks = get_all_check_results()
+    except TrustedAdvisorNotSubscribedError:
+        # Graceful skip — not having Business/Enterprise Support is a
+        # legitimate, expected state, NOT a collection failure. No failure
+        # marker is written.
+        utils.log_warning("AWS Business or Enterprise Support plan is required to access Trusted Advisor API. Skipping.")
+        sys.exit(0)
+    except Exception as e:
+        # A real error listing/collecting the cost-checks scope — must
+        # propagate to failed_scopes, never collapse into an empty result
+        # that reads as "no cost optimization opportunities."
+        utils.log_error(f"Trusted Advisor cost-checks collection failed: {e}")
+        failed_scopes.append(('cost_checks', str(e)))
+        results, failed_checks = {}, []
+
+    if failed_checks:
+        summary = "; ".join(f"{check_id}: {msg}" for check_id, msg in failed_checks)
+        failed_scopes.append(('cost_checks', f"{len(failed_checks)} check(s) failed: {summary}"))
+        utils.log_error(f"{len(failed_checks)} Trusted Advisor check(s) failed to fetch results.")
+
+    output_path = None
+    write_failed = False
+
+    # Export whatever succeeded — a partial export is required even when
+    # some checks failed (see .collab/audit/07.16.2026-...).
+    if results:
+        utils.log_info("Processing check results...")
+        summary_df, detail_dfs = process_check_results(results)
+
+        if not summary_df.empty:
+            utils.log_info("Exporting results to Excel...")
+
+            current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+            filename = utils.create_export_filename(
+                account_name,
+                "trusted-advisor-cost-optimization",
+                "",
+                current_date
+            )
+
+            # Combine summary and details into a dictionary for utils
+            all_dfs = {'Summary': summary_df}
+            all_dfs.update(detail_dfs)
+
+            output_path = utils.save_multiple_dataframes_to_excel(all_dfs, filename)
+
+            if output_path:
+                utils.log_success(f"Data exported to: {output_path}")
+                utils.log_success(f"Trusted Advisor cost optimization export completed: {output_path}")
+            else:
+                utils.log_error("Failed to export results")
+                write_failed = True
+
+    if not output_path and not write_failed and not failed_scopes:
+        # Genuinely empty: the checks scope succeeded and there is simply
+        # nothing to optimize.
         utils.log_info("No cost optimization opportunities found.")
-        sys.exit(0)
 
-    utils.log_info("Processing check results...")
-    summary_df, detail_dfs = process_check_results(results)
-
-    if summary_df.empty:
-        utils.log_info("No resources to optimize were found.")
-        sys.exit(0)
-
-    utils.log_info("Exporting results to Excel...")
-
-    current_date = datetime.datetime.now().strftime("%m.%d.%Y")
-    filename = utils.create_export_filename(
-        account_name,
-        "trusted-advisor-cost-optimization",
-        "",
-        current_date
-    )
-
-    # Combine summary and details into a dictionary for utils
-    all_dfs = {'Summary': summary_df}
-    all_dfs.update(detail_dfs)
-
-    output_path = utils.save_multiple_dataframes_to_excel(all_dfs, filename)
-
-    if output_path:
-        utils.log_success(f"Data exported to: {output_path}")
-        utils.log_success(f"Trusted Advisor cost optimization export completed: {output_path}")
-    else:
-        utils.log_error("Failed to export results")
+    # If the cost-checks scope failed (wholly or partially), make it loud:
+    # write a marker and exit non-zero, even if a partial export was
+    # written. A partial export that looks complete is exactly the failure
+    # mode this guards against.
+    if failed_scopes:
+        utils.report_collection_failures(account_name, 'trusted-advisor-cost-optimization', failed_scopes)
+        print(
+            "\nERROR: Trusted Advisor cost optimization export completed with "
+            "failures — data is incomplete. See the "
+            "*-trusted-advisor-cost-optimization-FAILED-*.txt marker in the "
+            "output directory."
+        )
         sys.exit(1)
+
+    # Excel write failure is a local I/O problem, not an AWS collection
+    # failure — exit non-zero but do not write a *-FAILED-*.txt marker
+    # (there was nothing wrong with the collected data itself).
+    if write_failed:
+        sys.exit(1)
+
+    if not output_path:
+        sys.exit(0)
 
 
 def main():

--- a/tests/test_exporters/test_cost_anomaly_detection_export.py
+++ b/tests/test_exporters/test_cost_anomaly_detection_export.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Tests for cost_anomaly_detection_export.py.
+
+Covers:
+- get_anomaly_monitors() / get_anomaly_subscriptions() per-item guarding and
+  account-scope failure propagation (the PRIMARY scopes)
+- _run_export()'s failed-scope tracking, always-written Summary sheet, and
+  exit-code behavior
+
+Cost Anomaly Detection is a global/account-scope service (Cost Explorer,
+accessed via the partition-aware home region), not multi-region -- mirrors
+the scripts/iam_export.py account-scope pattern (see scripts/shield_export.py
+and scripts/lambda_export.py for the closest existing examples). moto's
+Cost Explorer / Cost Anomaly Detection support is limited (no
+get_anomaly_monitors/get_anomaly_subscriptions mocking), so these tests drive
+the module through monkeypatched boto3 clients / module functions rather than
+real moto-backed Cost Explorer state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cost_anomaly_detection_export  # noqa: E402
+from cost_anomaly_detection_export import (  # noqa: E402
+    get_anomaly_monitors,
+    get_anomaly_subscriptions,
+)
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(cost_anomaly_detection_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_ce_client(monitors=None, subscriptions=None):
+    """Build a MagicMock standing in for a boto3 Cost Explorer client."""
+    client = MagicMock()
+    client.get_anomaly_monitors.return_value = {"AnomalyMonitors": monitors or []}
+    client.get_anomaly_subscriptions.return_value = {"AnomalySubscriptions": subscriptions or []}
+    client.get_anomalies.return_value = {"Anomalies": []}
+    return client
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Cost Anomaly Detection: get_anomaly_monitors() and
+    get_anomaly_subscriptions() -- the PRIMARY, global/account-scope
+    collectors -- used to swallow a real API error into an empty list via
+    ``@utils.aws_error_handler(default_return=[])``, indistinguishable from an
+    account with nothing configured. ``_run_export()`` also had no way to
+    signal that failure downstream (it always wrote a "successful" Summary
+    sheet). These tests cover: (a) a malformed monitor/subscription item is
+    skipped, not fatal; (b) both PRIMARY collectors raise rather than
+    swallowing a real API error; (c) that failure surfaces through
+    ``_run_export()`` as a non-zero exit plus a
+    ``utils.report_collection_failures()`` call, while the workbook is still
+    written.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------------
+
+    def test_malformed_monitor_is_skipped_not_fatal(self, monkeypatch):
+        """One monitor that fails to process must not discard the others."""
+        good = {
+            "MonitorArn": "arn:aws:ce::123456789012:anomalymonitor/good",
+            "MonitorName": "good-monitor",
+        }
+        bad = {
+            "MonitorArn": "arn:aws:ce::123456789012:anomalymonitor/bad",
+            "MonitorName": "bad-monitor",
+        }
+
+        client = _fake_ce_client(monitors=[good, bad])
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = cost_anomaly_detection_export._build_monitor_row
+
+        def raise_for_bad(monitor):
+            if monitor.get("MonitorName") == "bad-monitor":
+                raise KeyError("SomeUnexpectedField")
+            return original(monitor)
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "_build_monitor_row", raise_for_bad)
+
+        result = get_anomaly_monitors()
+
+        names = {row["MonitorName"] for row in result}
+        assert "good-monitor" in names, "healthy monitor was lost when a sibling failed"
+        assert "bad-monitor" not in names, "malformed monitor should have been skipped"
+
+    def test_malformed_subscription_is_skipped_not_fatal(self, monkeypatch):
+        """One subscription that fails to process must not discard the others."""
+        good = {
+            "SubscriptionArn": "arn:aws:ce::123456789012:anomalysubscription/good",
+            "SubscriptionName": "good-subscription",
+        }
+        bad = {
+            "SubscriptionArn": "arn:aws:ce::123456789012:anomalysubscription/bad",
+            "SubscriptionName": "bad-subscription",
+        }
+
+        client = _fake_ce_client(subscriptions=[good, bad])
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = cost_anomaly_detection_export._build_subscription_row
+
+        def raise_for_bad(subscription, account_id):
+            if subscription.get("SubscriptionName") == "bad-subscription":
+                raise KeyError("SomeUnexpectedField")
+            return original(subscription, account_id)
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "_build_subscription_row", raise_for_bad)
+
+        result = get_anomaly_subscriptions(ACCOUNT_ID)
+
+        names = {row["SubscriptionName"] for row in result}
+        assert "good-subscription" in names, "healthy subscription was lost when a sibling failed"
+        assert "bad-subscription" not in names, "malformed subscription should have been skipped"
+
+    # -- (b) Account-scope failure propagation -------------------------------
+
+    def test_get_anomaly_monitors_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Cost Explorer API error during monitor collection must
+        propagate, not collapse to an empty list."""
+
+        def boom(**kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "GetAnomalyMonitors",
+            )
+
+        client = MagicMock()
+        client.get_anomaly_monitors.side_effect = boom
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_anomaly_monitors()
+
+    def test_get_anomaly_subscriptions_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Cost Explorer API error during subscription collection must
+        propagate, not collapse to an empty list."""
+
+        def boom(**kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "GetAnomalySubscriptions",
+            )
+
+        client = MagicMock()
+        client.get_anomaly_subscriptions.side_effect = boom
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_anomaly_subscriptions(ACCOUNT_ID)
+
+    # -- (c) _run_export(): failure surfaced, non-zero exit ------------------
+
+    def test_run_export_monitors_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An anomaly_monitors API failure in _run_export() must exit
+        non-zero and call utils.report_collection_failures -- never silently
+        collapse into an empty (but "successful") export."""
+        monkeypatch.setattr(cost_anomaly_detection_export, "pd", __import__("pandas"), raising=False)
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "GetAnomalyMonitors",
+            )
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_monitors", boom)
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_subscriptions", lambda account_id: [])
+        monkeypatch.setattr(
+            cost_anomaly_detection_export, "get_anomalies", lambda start_date, end_date, monitor_arn=None: []
+        )
+
+        save_calls = []
+        monkeypatch.setattr(
+            cost_anomaly_detection_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda sheets, filename: save_calls.append((sheets, filename)) or "fake-path.xlsx",
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cost_anomaly_detection_export._run_export(ACCOUNT_ID, "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "cost-anomaly-detection"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "anomaly_monitors"
+
+        # The workbook (Summary sheet included) is still written despite the
+        # scope failure -- a partial export must never be lost, only unmarked.
+        assert save_calls, "Excel export was not written even though it must always land"
+        sheets = save_calls[0][0]
+        assert "Summary" in sheets
+
+    def test_run_export_subscriptions_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An anomaly_subscriptions API failure in _run_export() must exit
+        non-zero and call utils.report_collection_failures."""
+        monkeypatch.setattr(cost_anomaly_detection_export, "pd", __import__("pandas"), raising=False)
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_monitors", lambda: [])
+
+        def boom(account_id):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "GetAnomalySubscriptions",
+            )
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_subscriptions", boom)
+        monkeypatch.setattr(
+            cost_anomaly_detection_export, "get_anomalies", lambda start_date, end_date, monitor_arn=None: []
+        )
+        monkeypatch.setattr(
+            cost_anomaly_detection_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda sheets, filename: "fake-path.xlsx",
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(cost_anomaly_detection_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cost_anomaly_detection_export._run_export(ACCOUNT_ID, "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "anomaly_subscriptions"
+
+    # -- (d) Genuine empty: both primary scopes succeed with nothing --------
+
+    def test_run_export_genuinely_empty_exits_zero_no_marker(self, monkeypatch):
+        """Both PRIMARY scopes succeeding with nothing configured is a
+        legitimate, expected state -- no exception, no
+        utils.report_collection_failures call (no *-FAILED-*.txt marker)."""
+        monkeypatch.setattr(cost_anomaly_detection_export, "pd", __import__("pandas"), raising=False)
+
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_monitors", lambda: [])
+        monkeypatch.setattr(cost_anomaly_detection_export, "get_anomaly_subscriptions", lambda account_id: [])
+        monkeypatch.setattr(
+            cost_anomaly_detection_export, "get_anomalies", lambda start_date, end_date, monitor_arn=None: []
+        )
+        monkeypatch.setattr(
+            cost_anomaly_detection_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda sheets, filename: "fake-path.xlsx",
+        )
+
+        report_called = []
+        monkeypatch.setattr(
+            cost_anomaly_detection_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        # No SystemExit should be raised -- _run_export() returns normally.
+        cost_anomaly_detection_export._run_export(ACCOUNT_ID, "test-account")
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_cost_categories_export.py
+++ b/tests/test_exporters/test_cost_categories_export.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Tests for cost_categories_export.py.
+
+Covers:
+- list_cost_category_definitions() per-item guarding and account-scope
+  failure propagation
+- main()'s failed-scope tracking, always-written Summary sheet, and
+  exit-code behavior
+
+Cost Categories (Cost Explorer) is a global, account-scope service (not
+multi-region), so list_cost_category_definitions() is the account-scope
+PRIMARY collector -- mirrors the scripts/shield_export.py account-scope
+pattern (see scripts/lambda_export.py for the finalize shape). This script
+is a Tier-3 PARTIAL case: it already builds an always-written Summary
+sheet, so the fix adds failed-scope tracking + a *-FAILED-*.txt marker +
+non-zero exit on top of that, without breaking the "a workbook always
+lands" guarantee.
+
+moto has NO support at all for Cost Explorer's Cost Categories APIs
+(list_cost_category_definitions / describe_cost_category_definition both
+raise NotImplementedError under @mock_aws as of the moto version pinned in
+this repo). These tests therefore drive the module entirely through
+monkeypatched boto3 clients / module functions rather than real
+moto-backed Cost Explorer state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import cost_categories_export  # noqa: E402
+from cost_categories_export import list_cost_category_definitions  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _fake_ce_client(cost_category_refs=None):
+    """Build a MagicMock standing in for a boto3 Cost Explorer (ce) client."""
+    client = MagicMock()
+    client.list_cost_category_definitions.return_value = {
+        "CostCategoryReferences": cost_category_refs or [],
+    }
+    return client
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 silent-collection-failure audit,
+    applied to Cost Categories: list_cost_category_definitions() -- the
+    PRIMARY, global/account-scope collector -- used to swallow a real API
+    error into an empty list, indistinguishable from an account with no
+    Cost Categories configured. main() also had no way to signal that
+    failure downstream despite always writing a Summary sheet. These tests
+    cover: (a) a malformed Cost Category reference is skipped, not fatal;
+    (b) list_cost_category_definitions() raises rather than swallowing a
+    real API error; (c) that failure surfaces through main() as a non-zero
+    exit plus a utils.report_collection_failures() call; (d) a genuinely
+    empty account (primary scope succeeds, nothing configured) completes
+    with no marker.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------
+
+    def test_malformed_reference_is_skipped_not_fatal(self, monkeypatch):
+        """One Cost Category reference that fails to process must not
+        discard the others."""
+        good_ref = {
+            "Name": "good-category",
+            "CostCategoryArn": "arn:aws:ce::123456789012:costcategory/good",
+            "NumberOfRules": 1,
+        }
+        bad_ref = {
+            "Name": "bad-category",
+            "CostCategoryArn": "arn:aws:ce::123456789012:costcategory/bad",
+            "NumberOfRules": 1,
+        }
+
+        client = _fake_ce_client(cost_category_refs=[good_ref, bad_ref])
+        monkeypatch.setattr(cost_categories_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        original = cost_categories_export._build_cost_category_row
+
+        def raise_for_bad(cc_ref):
+            if cc_ref.get("Name") == "bad-category":
+                raise KeyError("SomeUnexpectedField")
+            return original(cc_ref)
+
+        monkeypatch.setattr(cost_categories_export, "_build_cost_category_row", raise_for_bad)
+
+        result = list_cost_category_definitions()
+
+        names = {row["Name"] for row in result}
+        assert "good-category" in names, "healthy Cost Category was lost when a sibling failed"
+        assert "bad-category" not in names, "malformed Cost Category should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_list_cost_category_definitions_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Cost Explorer API error during collection must propagate,
+        not collapse to an empty list."""
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListCostCategoryDefinitions",
+            )
+
+        client = MagicMock()
+        client.list_cost_category_definitions.side_effect = boom
+        monkeypatch.setattr(cost_categories_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            list_cost_category_definitions()
+
+    # -- (c) main(): failure surfaced, non-zero exit, marker written --------
+
+    def test_main_primary_scope_failure_exits_nonzero_and_reports(self, monkeypatch, tmp_path):
+        """
+        A cost_categories-scope failure must exit non-zero and call
+        utils.report_collection_failures -- even though this script always
+        builds a Summary sheet and would otherwise write a complete-looking
+        workbook (the Tier-3 PARTIAL failure mode).
+        """
+        monkeypatch.setattr(cost_categories_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            cost_categories_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(cost_categories_export.utils, "mask_account_id", lambda *a, **kw: "1234****9012")
+        monkeypatch.setattr(cost_categories_export.utils, "detect_partition", lambda *a, **kw: "aws")
+        monkeypatch.setattr(
+            cost_categories_export.utils, "is_service_available_in_partition", lambda *a, **kw: True
+        )
+        monkeypatch.setattr(cost_categories_export.utils, "prompt_confirmation", lambda *a, **kw: "confirm")
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "ListCostCategoryDefinitions",
+            )
+
+        monkeypatch.setattr(cost_categories_export, "list_cost_category_definitions", boom)
+
+        monkeypatch.setattr(cost_categories_export.utils, "create_export_filename", lambda *a, **kw: "fake.xlsx")
+        monkeypatch.setattr(
+            cost_categories_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda *a, **kw: str(tmp_path / "fake.xlsx"),
+        )
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(cost_categories_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cost_categories_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "cost-categories"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "cost_categories"
+
+    # -- (d) Genuinely empty: graceful, no marker ----------------------------
+
+    def test_main_genuinely_empty_completes_no_marker(self, monkeypatch, tmp_path):
+        """
+        An account with zero Cost Categories (primary scope succeeds, just
+        returns nothing) must complete without raising and never call
+        utils.report_collection_failures -- a real Summary-only workbook is
+        not a failure. main() has no explicit ``sys.exit(0)`` on the
+        success path (unlike the failure path), so success here means
+        "returns normally," not "raises SystemExit(0)".
+        """
+        monkeypatch.setattr(cost_categories_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(
+            cost_categories_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(cost_categories_export.utils, "mask_account_id", lambda *a, **kw: "1234****9012")
+        monkeypatch.setattr(cost_categories_export.utils, "detect_partition", lambda *a, **kw: "aws")
+        monkeypatch.setattr(
+            cost_categories_export.utils, "is_service_available_in_partition", lambda *a, **kw: True
+        )
+        monkeypatch.setattr(cost_categories_export.utils, "prompt_confirmation", lambda *a, **kw: "confirm")
+
+        monkeypatch.setattr(cost_categories_export, "list_cost_category_definitions", lambda: [])
+
+        monkeypatch.setattr(cost_categories_export.utils, "create_export_filename", lambda *a, **kw: "fake.xlsx")
+        monkeypatch.setattr(
+            cost_categories_export.utils,
+            "save_multiple_dataframes_to_excel",
+            lambda *a, **kw: str(tmp_path / "fake.xlsx"),
+        )
+
+        report_called = []
+        monkeypatch.setattr(
+            cost_categories_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        cost_categories_export.main()
+
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_ec2_capacity_reservations_export.py
+++ b/tests/test_exporters/test_ec2_capacity_reservations_export.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Tests for ec2_capacity_reservations_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+Note on moto: the moto version pinned in this repo (5.1.21) does not
+implement the EC2 Capacity Reservations API — ``create_capacity_reservation``
+and ``describe_capacity_reservations`` both raise ``NotImplementedError``
+under ``@mock_aws``. All tests here therefore monkeypatch
+``utils.get_boto3_client`` directly with a minimal fake client instead of
+using ``@mock_aws``.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ec2_capacity_reservations_export  # noqa: E402
+from ec2_capacity_reservations_export import _scan_capacity_reservations_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakePaginator:
+    """Minimal stand-in for a boto3 paginator."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeCapacityReservationsClient:
+    """Minimal EC2 client stand-in for describe_capacity_reservations."""
+
+    def __init__(self, reservations):
+        self._reservations = reservations
+
+    def get_paginator(self, operation_name):
+        assert operation_name == 'describe_capacity_reservations'
+        return _FakePaginator([{'CapacityReservations': self._reservations}])
+
+
+def _reservation(reservation_id, **overrides):
+    row = {
+        'CapacityReservationId': reservation_id,
+        'CapacityReservationArn': f'arn:aws:ec2:{REGION}::capacity-reservation/{reservation_id}',
+        'InstanceType': 't3.micro',
+        'AvailabilityZone': f'{REGION}a',
+        'State': 'active',
+        'TotalInstanceCount': 2,
+        'AvailableInstanceCount': 1,
+        'Tags': [{'Key': 'Name', 'Value': reservation_id}],
+    }
+    row.update(overrides)
+    return row
+
+
+class TestScanCapacityReservationsRegion:
+    """Happy-path collection."""
+
+    def test_collects_reservations(self, monkeypatch):
+        client = _FakeCapacityReservationsClient([_reservation('cr-111')])
+        monkeypatch.setattr(
+            ec2_capacity_reservations_export.utils, 'get_boto3_client', lambda *a, **k: client
+        )
+
+        rows = _scan_capacity_reservations_region(REGION)
+
+        ids = {row['CapacityReservationId'] for row in rows}
+        assert ids == {'cr-111'}
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        client = _FakeCapacityReservationsClient([])
+        monkeypatch.setattr(
+            ec2_capacity_reservations_export.utils, 'get_boto3_client', lambda *a, **k: client
+        )
+
+        rows = _scan_capacity_reservations_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 blast-radius audit: this exporter was
+    classified Tier-3 PARTIAL — a forced Summary sheet meant the workbook
+    always landed, but a region-level collection error still silently
+    collapsed into a 0-row "All Reservations" sheet, indistinguishable from a
+    genuinely empty account.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One malformed reservation must not discard the whole region."""
+        client = _FakeCapacityReservationsClient(
+            [_reservation('cr-good'), _reservation('cr-bad')]
+        )
+        monkeypatch.setattr(
+            ec2_capacity_reservations_export.utils, 'get_boto3_client', lambda *a, **k: client
+        )
+
+        original = ec2_capacity_reservations_export._build_reservation_row
+
+        def raise_for_bad(cr, region):
+            if cr.get('CapacityReservationId') == 'cr-bad':
+                raise KeyError('SomeUnexpectedField')
+            return original(cr, region)
+
+        monkeypatch.setattr(
+            ec2_capacity_reservations_export, '_build_reservation_row', raise_for_bad
+        )
+
+        rows = _scan_capacity_reservations_region(REGION)
+
+        ids = {row['CapacityReservationId'] for row in rows}
+        assert 'cr-good' in ids, "healthy reservation was lost when a sibling failed"
+        assert 'cr-bad' not in ids, "malformed reservation should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeCapacityReservations",
+            )
+
+        monkeypatch.setattr(ec2_capacity_reservations_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_capacity_reservations_region(REGION)
+
+    def test_collect_capacity_reservations_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets export write a FAILED marker and
+        exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeCapacityReservations",
+            )
+
+        monkeypatch.setattr(
+            ec2_capacity_reservations_export, "_scan_capacity_reservations_region", boom
+        )
+
+        reservations, failed_regions = ec2_capacity_reservations_export.collect_capacity_reservations(
+            [REGION]
+        )
+
+        assert reservations == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_ec2_dedicated_hosts_export.py
+++ b/tests/test_exporters/test_ec2_dedicated_hosts_export.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for ec2_dedicated_hosts_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+ec2_dedicated_hosts_export.py already writes a forced ``Summary`` sheet, so a
+workbook always lands even on total failure. What was missing — and what
+these tests guard — is failed-scope tracking: on ANY scope failure the
+exporter must ALSO write the ``*-FAILED-*.txt`` marker and exit non-zero, so
+a failed collection is never indistinguishable from a genuinely empty
+account.
+
+Note: moto (5.1.21) implements ``ec2:AllocateHosts`` / ``ec2:DescribeHosts``
+but NOT ``ec2:DescribeHostReservations`` (raises ``NotImplementedError``), so
+the host-reservations scope is exercised via monkeypatch rather than a live
+mocked API call.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import ec2_dedicated_hosts_export  # noqa: E402
+from ec2_dedicated_hosts_export import (  # noqa: E402
+    _scan_dedicated_hosts_region,
+    _scan_host_reservations_region,
+)
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _allocate_host(client):
+    """Allocate a single dedicated host and return its HostId."""
+    resp = client.allocate_hosts(
+        AvailabilityZone=f"{REGION}a",
+        InstanceType="m5.large",
+        Quantity=1,
+        AutoPlacement="on",
+    )
+    return resp["HostIds"][0]
+
+
+class TestScanDedicatedHostsRegion:
+    """Happy-path collection for the primary (dedicated hosts) scope."""
+
+    @mock_aws
+    def test_collects_hosts(self):
+        client = boto3.client("ec2", region_name=REGION)
+        host_id = _allocate_host(client)
+
+        rows = _scan_dedicated_hosts_region(REGION)
+
+        host_ids = {row["HostId"] for row in rows}
+        assert host_id in host_ids
+
+    @mock_aws
+    def test_empty_region_returns_empty_list(self):
+        boto3.client("ec2", region_name=REGION)  # region exists, no hosts
+
+        rows = _scan_dedicated_hosts_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    @mock_aws
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One dedicated host that fails to process must not discard the whole region."""
+        client = boto3.client("ec2", region_name=REGION)
+        good_host_id = _allocate_host(client)
+        bad_host_id = _allocate_host(client)
+
+        original = ec2_dedicated_hosts_export._build_host_row
+
+        def raise_for_bad(host, region, host_pricing, is_govcloud):
+            if host.get("HostId") == bad_host_id:
+                raise KeyError("SomeUnexpectedField")
+            return original(host, region, host_pricing, is_govcloud)
+
+        monkeypatch.setattr(ec2_dedicated_hosts_export, "_build_host_row", raise_for_bad)
+
+        rows = _scan_dedicated_hosts_region(REGION)
+
+        host_ids = {row["HostId"] for row in rows}
+        assert good_host_id in host_ids, "healthy host was lost when a sibling failed"
+        assert bad_host_id not in host_ids, "malformed host should have been skipped"
+
+    @mock_aws
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "DescribeHosts",
+            )
+
+        monkeypatch.setattr(ec2_dedicated_hosts_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_dedicated_hosts_region(REGION)
+
+    @mock_aws
+    def test_collect_dedicated_hosts_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeHosts",
+            )
+
+        monkeypatch.setattr(ec2_dedicated_hosts_export, "_scan_dedicated_hosts_region", boom)
+
+        hosts, failed_regions = ec2_dedicated_hosts_export.collect_dedicated_hosts([REGION])
+
+        assert hosts == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+    def test_host_reservations_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        Host Reservations is a second, independent top-level inventory scope
+        (own worksheet, not derived from the hosts data) — it must follow the
+        same not-swallowed contract as the primary dedicated-hosts scope.
+
+        moto does not implement ec2:DescribeHostReservations, so the
+        underlying client call is monkeypatched directly rather than mocked
+        with @mock_aws.
+        """
+
+        class _BoomPaginator:
+            def paginate(self, **kwargs):
+                raise botocore.exceptions.ClientError(
+                    {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                    "DescribeHostReservations",
+                )
+
+        class _BoomClient:
+            def get_paginator(self, name):
+                return _BoomPaginator()
+
+        monkeypatch.setattr(
+            ec2_dedicated_hosts_export.utils,
+            "get_boto3_client",
+            lambda *a, **kw: _BoomClient(),
+        )
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_host_reservations_region(REGION)
+
+    def test_collect_host_reservations_surfaces_failed_regions(self, monkeypatch):
+        """The reservations scope wrapper must surface failed regions too."""
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeHostReservations",
+            )
+
+        monkeypatch.setattr(ec2_dedicated_hosts_export, "_scan_host_reservations_region", boom)
+
+        reservations, failed_regions = ec2_dedicated_hosts_export.collect_host_reservations([REGION])
+
+        assert reservations == []
+        assert [r for r, _ in failed_regions] == [REGION]

--- a/tests/test_exporters/test_license_manager_export.py
+++ b/tests/test_exporters/test_license_manager_export.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Tests for license_manager_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL). See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+moto's License Manager support is limited — ``list_license_configurations``
+returns a "Not yet implemented" 404 under ``@mock_aws`` (verified against
+moto 5.1.21) — so these tests drive ``_scan_license_configurations_region``
+through a monkeypatched ``utils.get_boto3_client`` returning a
+``MagicMock``-backed fake client/paginator rather than real moto-backed
+License Manager state. This mirrors the approach used in
+tests/test_exporters/test_savings_plans_export.py for the same moto gap.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import license_manager_export  # noqa: E402
+from license_manager_export import _scan_license_configurations_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+def _fake_lm_client(configs=None):
+    """Build a MagicMock standing in for a boto3 license-manager client."""
+    client = MagicMock()
+    pages = [{"LicenseConfigurations": configs or []}]
+    client.get_paginator.return_value.paginate.return_value = pages
+    return client
+
+
+def _config(config_id):
+    return {
+        "LicenseConfigurationId": config_id,
+        "LicenseConfigurationArn": f"arn:aws:license-manager:{REGION}:123456789012:license-configuration:{config_id}",
+        "Name": config_id,
+        "Description": "test config",
+        "LicenseCountingType": "vCPU",
+        "LicenseCount": 10,
+        "LicenseCountHardLimit": False,
+        "ConsumedLicenses": 2,
+        "Status": "AVAILABLE",
+        "OwnerAccountId": "123456789012",
+    }
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15 / 07.16.2026 audits: exporters silently
+    lost data because a collection error was swallowed to an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One license configuration that fails to process must not discard
+        the whole region's results."""
+        good = _config("good-config")
+        bad = _config("bad-config")
+
+        client = _fake_lm_client(configs=[good, bad])
+        monkeypatch.setattr(
+            license_manager_export.utils, "get_boto3_client", lambda *a, **kw: client
+        )
+
+        original = license_manager_export._build_config_row
+
+        def raise_for_bad(item, region):
+            if item.get("LicenseConfigurationId") == "bad-config":
+                raise KeyError("SomeUnexpectedField")
+            return original(item, region)
+
+        monkeypatch.setattr(license_manager_export, "_build_config_row", raise_for_bad)
+
+        rows = _scan_license_configurations_region(REGION)
+
+        ids = {row["LicenseConfigurationId"] for row in rows}
+        assert "good-config" in ids, "healthy configuration was lost when a sibling failed"
+        assert "bad-config" not in ids, "malformed configuration should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+
+        def boom(*args, **kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+                "ListLicenseConfigurations",
+            )
+
+        monkeypatch.setattr(license_manager_export.utils, "get_boto3_client", boom)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_license_configurations_region(REGION)
+
+    def test_collect_license_configurations_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures,
+        not drop them — this is what lets ``_run_export`` write a FAILED
+        marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "ListLicenseConfigurations",
+            )
+
+        monkeypatch.setattr(license_manager_export, "_scan_license_configurations_region", boom)
+
+        configs, failed_regions = license_manager_export.collect_license_configurations([REGION])
+
+        assert configs == []
+        assert [r for r, _ in failed_regions] == [REGION]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exporters/test_marketplace_export.py
+++ b/tests/test_exporters/test_marketplace_export.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Tests for marketplace_export.py.
+
+Covers:
+- _build_agreement_row() per-item field extraction
+- collect_agreements() per-item guarding and account-scope failure propagation
+- main()'s failed-scope tracking, always-written Summary sheet, and exit-code
+  behavior
+
+AWS Marketplace is a global/account-scope service (not multi-region), so
+collect_agreements() is the account-scope PRIMARY collector -- mirrors the
+scripts/shield_export.py sibling global/account-scope PARTIAL-tier fix (see
+scripts/lambda_export.py for the finalize shape). moto's Marketplace Agreement
+support is limited (no search_agreements / describe_agreement /
+get_agreement_terms state to seed), so these tests drive the module through
+monkeypatched boto3 clients / module functions rather than real moto-backed
+Marketplace state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import marketplace_export  # noqa: E402
+from marketplace_export import _build_agreement_row, collect_agreements  # noqa: E402
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(marketplace_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _fake_agreement_summary(agreement_id: str) -> dict:
+    return {"agreementId": agreement_id}
+
+
+def _fake_agreement_details(agreement_id: str, status: str = "ACTIVE") -> dict:
+    return {
+        "proposer": {"accountId": "111111111111"},
+        "acceptor": {"accountId": "222222222222"},
+        "agreementType": "PurchaseAgreement",
+        "status": status,
+        "acceptanceTime": "N/A",
+        "startTime": "N/A",
+        "endTime": "N/A",
+        "estimatedCharges": {"agreementValue": "100.00", "currencyCode": "USD"},
+    }
+
+
+class TestBuildAgreementRow:
+    """_build_agreement_row() extracts a single agreement's fields with safe defaults."""
+
+    def test_builds_row_from_agreement_details(self):
+        client = MagicMock()
+        client.describe_agreement.return_value = _fake_agreement_details("agr-good")
+
+        row = _build_agreement_row(client, _fake_agreement_summary("agr-good"))
+
+        assert row["Agreement ID"] == "agr-good"
+        assert row["Status"] == "ACTIVE"
+        assert row["Proposer Account ID"] == "111111111111"
+        assert row["Acceptor Account ID"] == "222222222222"
+        assert row["Agreement Amount"] == "100.00"
+        assert row["Currency"] == "USD"
+
+    def test_missing_agreement_id_defaults_to_na(self):
+        client = MagicMock()
+        client.describe_agreement.return_value = {}
+
+        row = _build_agreement_row(client, {})
+
+        assert row["Agreement ID"] == "N/A"
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to AWS Marketplace: collect_agreements() -- the PRIMARY,
+    global/account-scope collector -- used to swallow a real API error (via
+    @utils.aws_error_handler(default_return=[]) plus a broad manual
+    try/except around search_agreements) into an empty list,
+    indistinguishable from an account with no Marketplace agreements. main()
+    also used to have no way to signal that failure downstream -- it always
+    wrote a non-empty Summary sheet regardless. These tests cover: (a) a
+    malformed/inaccessible agreement is skipped, not fatal; (b)
+    collect_agreements() raises rather than swallowing a real API error; (c)
+    that failure surfaces through main() as a non-zero exit plus a
+    utils.report_collection_failures() call, even though the Summary sheet
+    is still written and a workbook still lands.
+    """
+
+    # -- (a) Per-item guard ------------------------------------------------
+
+    def test_malformed_agreement_is_skipped_not_fatal(self, monkeypatch):
+        """One agreement that fails to enrich must not discard the others."""
+        good_summary = _fake_agreement_summary("agr-good")
+        bad_summary = _fake_agreement_summary("agr-bad")
+
+        client = MagicMock()
+        client.search_agreements.return_value = {
+            "agreementViewSummaries": [good_summary, bad_summary],
+            "nextToken": None,
+        }
+
+        def describe_agreement(**kwargs):
+            agreement_id = kwargs.get("agreementId")
+            if agreement_id == "agr-bad":
+                raise KeyError("SomeUnexpectedField")
+            return _fake_agreement_details(agreement_id)
+
+        client.describe_agreement.side_effect = describe_agreement
+        monkeypatch.setattr(
+            marketplace_export.utils, "get_boto3_client", lambda *a, **kw: client
+        )
+
+        result = collect_agreements()
+
+        ids = {row["Agreement ID"] for row in result}
+        assert "agr-good" in ids, "healthy agreement was lost when a sibling failed"
+        assert "agr-bad" not in ids, "malformed agreement should have been skipped"
+
+    # -- (b) Account-scope failure propagation ------------------------------
+
+    def test_collect_agreements_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Marketplace API error during collection must propagate,
+        not collapse to an empty list."""
+
+        def boom(**kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "SearchAgreements",
+            )
+
+        client = MagicMock()
+        client.search_agreements.side_effect = boom
+        monkeypatch.setattr(
+            marketplace_export.utils, "get_boto3_client", lambda *a, **kw: client
+        )
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            collect_agreements()
+
+    # -- (c) main(): failure surfaced, non-zero exit ------------------------
+
+    def test_main_agreements_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """An agreements API failure in main() must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into an
+        empty (but still Summary-populated) export."""
+        monkeypatch.setattr(marketplace_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+        monkeypatch.setattr(marketplace_export.utils, "setup_logging", lambda *a, **kw: None)
+        monkeypatch.setattr(marketplace_export.utils, "log_script_start", lambda *a, **kw: None)
+        monkeypatch.setattr(marketplace_export.utils, "detect_partition", lambda *a, **kw: "aws")
+        monkeypatch.setattr(
+            marketplace_export.utils, "is_service_available_in_partition", lambda *a, **kw: True
+        )
+        monkeypatch.setattr(
+            marketplace_export.utils,
+            "print_script_banner",
+            lambda *a, **kw: ("123456789012", "test-account"),
+        )
+        monkeypatch.setattr(
+            marketplace_export.utils,
+            "create_export_filename",
+            lambda *a, **kw: "test-account-marketplace-global-export.xlsx",
+        )
+        monkeypatch.setattr(
+            marketplace_export.utils, "save_multiple_dataframes_to_excel", lambda *a, **kw: "fake-path.xlsx"
+        )
+
+        def boom():
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "InternalErrorException", "Message": "Something broke"}},
+                "SearchAgreements",
+            )
+
+        monkeypatch.setattr(marketplace_export, "collect_agreements", boom)
+        monkeypatch.setattr(marketplace_export, "collect_agreement_terms", lambda agreements: [])
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(marketplace_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            marketplace_export.main()
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "marketplace"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "agreements"

--- a/tests/test_exporters/test_reserved_instances_export.py
+++ b/tests/test_exporters/test_reserved_instances_export.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Tests for reserved_instances_export.py.
+
+Focus: the silent-collection-failure contract (Tier-3 PARTIAL) for the EC2
+Reserved Instances scope. See
+.collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+
+NOTE: moto's EC2 backend does not implement ``describe_reserved_instances``
+(it raises ``NotImplementedError`` as of moto 5.1.21), so ``@mock_aws``
+cannot be used for this scope. These tests instead monkeypatch
+``utils.get_boto3_client`` with a minimal fake EC2 client, mirroring the
+monkeypatch approach used for the region-failure cases in
+test_autoscaling_export.py.
+"""
+
+import sys
+from pathlib import Path
+
+import botocore
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import reserved_instances_export  # noqa: E402
+from reserved_instances_export import _scan_ec2_ri_region  # noqa: E402
+
+REGION = "us-east-1"
+
+
+class _FakeEC2Client:
+    """Minimal fake EC2 client exposing only describe_reserved_instances."""
+
+    def __init__(self, reserved_instances=None, error=None):
+        self._reserved_instances = reserved_instances or []
+        self._error = error
+
+    def describe_reserved_instances(self):
+        if self._error is not None:
+            raise self._error
+        return {"ReservedInstances": self._reserved_instances}
+
+
+def _ri(reservation_id, instance_type="m5.large"):
+    return {
+        "ReservedInstancesId": reservation_id,
+        "InstanceType": instance_type,
+        "InstanceCount": 1,
+        "State": "active",
+    }
+
+
+class TestScanEc2RiRegion:
+    """Happy-path collection."""
+
+    def test_collects_ris(self, monkeypatch):
+        fake_client = _FakeEC2Client(reserved_instances=[_ri("ri-good")])
+        monkeypatch.setattr(
+            reserved_instances_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_ec2_ri_region(REGION)
+
+        reservation_ids = {row["ReservationID"] for row in rows}
+        assert "ri-good" in reservation_ids
+
+    def test_empty_region_returns_empty_list(self, monkeypatch):
+        fake_client = _FakeEC2Client(reserved_instances=[])
+        monkeypatch.setattr(
+            reserved_instances_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        rows = _scan_ec2_ri_region(REGION)
+
+        assert rows == []
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.16.2026 audit: exporters silently lost data
+    because a collection error was swallowed into an empty list,
+    indistinguishable from a genuinely empty region.
+    """
+
+    def test_malformed_item_is_skipped_not_fatal(self, monkeypatch):
+        """One RI that fails to process must not discard the whole region."""
+        fake_client = _FakeEC2Client(reserved_instances=[_ri("ri-good"), _ri("ri-bad")])
+        monkeypatch.setattr(
+            reserved_instances_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        original = reserved_instances_export._build_ec2_ri_row
+
+        def raise_for_bad(ri, region):
+            if ri.get("ReservedInstancesId") == "ri-bad":
+                raise KeyError("SomeUnexpectedField")
+            return original(ri, region)
+
+        monkeypatch.setattr(reserved_instances_export, "_build_ec2_ri_row", raise_for_bad)
+
+        rows = _scan_ec2_ri_region(REGION)
+
+        reservation_ids = {row["ReservationID"] for row in rows}
+        assert "ri-good" in reservation_ids, "healthy RI was lost when a sibling failed"
+        assert "ri-bad" not in reservation_ids, "malformed RI should have been skipped"
+
+    def test_region_api_failure_raises_not_empty(self, monkeypatch):
+        """
+        A region-level API failure must propagate (so the caller can record a
+        FAILED region) rather than being swallowed into an empty list.
+        """
+        error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+            "DescribeReservedInstances",
+        )
+        fake_client = _FakeEC2Client(error=error)
+        monkeypatch.setattr(
+            reserved_instances_export.utils, "get_boto3_client", lambda *a, **kw: fake_client
+        )
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            _scan_ec2_ri_region(REGION)
+
+    def test_collect_ec2_reserved_instances_surfaces_failed_regions(self, monkeypatch):
+        """
+        The scope wrapper must return failed regions via collect_failures, not
+        drop them — this is what lets export write a FAILED marker + exit 1.
+        """
+
+        def boom(region):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+                "DescribeReservedInstances",
+            )
+
+        monkeypatch.setattr(reserved_instances_export, "_scan_ec2_ri_region", boom)
+
+        ris, failed_regions = reserved_instances_export.collect_ec2_reserved_instances([REGION])
+
+        assert ris == []
+        assert [r for r, _ in failed_regions] == [REGION]
+        # Error messages are prefixed with the scope name so multiple failed
+        # RI scopes can be told apart once merged into one failed_regions list.
+        assert failed_regions[0][1].startswith("EC2 RI:")

--- a/tests/test_exporters/test_trusted_advisor_cost_optimization_export.py
+++ b/tests/test_exporters/test_trusted_advisor_cost_optimization_export.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Tests for trusted_advisor_cost_optimization_export.py.
+
+Covers:
+- get_trusted_advisor_checks() / get_check_result() distinguishing a
+  graceful "not subscribed" state from a real API error
+- _build_check_row() per-item guarding (malformed check entries)
+- get_all_check_results()'s failed-check tracking and account-scope
+  failure propagation
+- main()'s failed-scope tracking, finalize, and exit-code behavior
+
+Trusted Advisor is a global/account-scope service (not multi-region), so
+get_all_check_results() is the account-scope PRIMARY collector -- mirrors
+the scripts/shield_export.py account-scope pattern (see
+scripts/lambda_export.py for the finalize shape). moto's support/Trusted
+Advisor coverage is limited (no describe_trusted_advisor_checks /
+describe_trusted_advisor_check_result mocking, no configurable
+subscription state), so these tests drive the module through monkeypatched
+boto3 clients / module functions rather than real moto-backed Support
+state.
+
+See .collab/audit/07.16.2026-silent-collection-failure-blast-radius.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import trusted_advisor_cost_optimization_export as ta_export  # noqa: E402
+from trusted_advisor_cost_optimization_export import (  # noqa: E402
+    TrustedAdvisorNotSubscribedError,
+    _build_check_row,
+    get_all_check_results,
+    get_check_result,
+    get_trusted_advisor_checks,
+)
+
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(ta_export.utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+def _subscription_required_error(op_name):
+    return botocore.exceptions.ClientError(
+        {
+            "Error": {
+                "Code": "SubscriptionRequiredException",
+                "Message": "AWS Premium Support Subscription is required to use this service.",
+            }
+        },
+        op_name,
+    )
+
+
+def _real_client_error(op_name, code="ThrottlingException"):
+    return botocore.exceptions.ClientError(
+        {"Error": {"Code": code, "Message": "Something broke"}},
+        op_name,
+    )
+
+
+class TestGetTrustedAdvisorChecks:
+    """
+    get_trusted_advisor_checks() is the top-level listing call: a
+    SubscriptionRequiredException is a legitimate, expected "not available"
+    state (raises TrustedAdvisorNotSubscribedError) while any other error
+    must raise through unmodified -- never swallowed to an empty list.
+    """
+
+    def test_subscription_required_raises_not_subscribed(self, monkeypatch):
+        client = MagicMock()
+        client.describe_trusted_advisor_checks.side_effect = _subscription_required_error(
+            "DescribeTrustedAdvisorChecks"
+        )
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(TrustedAdvisorNotSubscribedError):
+            get_trusted_advisor_checks()
+
+    def test_real_error_is_not_swallowed(self, monkeypatch):
+        client = MagicMock()
+        client.describe_trusted_advisor_checks.side_effect = _real_client_error(
+            "DescribeTrustedAdvisorChecks", code="AccessDeniedException"
+        )
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_trusted_advisor_checks()
+
+    def test_filters_to_cost_optimizing_checks(self, monkeypatch):
+        client = MagicMock()
+        client.describe_trusted_advisor_checks.return_value = {
+            "checks": [
+                {"id": "cost-1", "name": "Cost Check", "description": "d", "category": "cost_optimizing"},
+                {"id": "sec-1", "name": "Security Check", "description": "d", "category": "security"},
+            ]
+        }
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        checks = get_trusted_advisor_checks()
+
+        assert [c["id"] for c in checks] == ["cost-1"]
+
+
+class TestGetCheckResult:
+    """
+    get_check_result() -- formerly @aws_error_handler(default_return=None),
+    which swallowed every error into None. Now raises real errors and only
+    treats SubscriptionRequiredException as graceful.
+    """
+
+    def test_subscription_required_raises_not_subscribed(self, monkeypatch):
+        client = MagicMock()
+        client.describe_trusted_advisor_check_result.side_effect = _subscription_required_error(
+            "DescribeTrustedAdvisorCheckResult"
+        )
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(TrustedAdvisorNotSubscribedError):
+            get_check_result("check-1")
+
+    def test_real_api_error_is_not_swallowed(self, monkeypatch):
+        """A real error must raise, not collapse to None (the old bug)."""
+        client = MagicMock()
+        client.describe_trusted_advisor_check_result.side_effect = _real_client_error(
+            "DescribeTrustedAdvisorCheckResult"
+        )
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_check_result("check-1")
+
+    def test_successful_result_returned(self, monkeypatch):
+        client = MagicMock()
+        client.describe_trusted_advisor_check_result.return_value = {
+            "result": {"status": "ok", "flaggedResources": []}
+        }
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        assert get_check_result("check-1") == {"status": "ok", "flaggedResources": []}
+
+
+class TestBuildCheckRow:
+    """(a) Per-item guard: a malformed check entry must not raise KeyError."""
+
+    def test_missing_id_raises_value_error_not_key_error(self, monkeypatch):
+        malformed_check = {"name": "No ID Check", "description": "d"}
+
+        with pytest.raises(ValueError):
+            _build_check_row(malformed_check)
+
+    def test_well_formed_check_builds_entry(self, monkeypatch):
+        monkeypatch.setattr(
+            ta_export, "get_check_result", lambda check_id: {"status": "ok", "flaggedResources": []}
+        )
+        check = {"id": "check-1", "name": "My Check", "description": "d"}
+
+        check_id, entry = _build_check_row(check)
+
+        assert check_id == "check-1"
+        assert entry == {"name": "My Check", "description": "d", "result": {"status": "ok", "flaggedResources": []}}
+
+    def test_no_result_returns_none_entry(self, monkeypatch):
+        monkeypatch.setattr(ta_export, "get_check_result", lambda check_id: None)
+        check = {"id": "check-1", "name": "My Check", "description": "d"}
+
+        check_id, entry = _build_check_row(check)
+
+        assert check_id == "check-1"
+        assert entry is None
+
+
+class TestGetAllCheckResults:
+    """
+    (a) A malformed check is skipped, not fatal.
+    (b) A real per-check API error is tracked in failed_checks, not
+        swallowed into an empty/success result.
+    Not-subscribed at the top-level listing call propagates immediately.
+    """
+
+    def test_malformed_check_is_skipped_not_fatal(self, monkeypatch):
+        good_check = {"id": "good-id", "name": "Good Check", "description": "d"}
+        malformed_check = {"name": "No ID Check", "description": "d"}  # missing 'id'
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", lambda: [good_check, malformed_check])
+        monkeypatch.setattr(
+            ta_export, "get_check_result", lambda check_id: {"status": "ok", "flaggedResources": []}
+        )
+
+        results, failed_checks = get_all_check_results()
+
+        assert "good-id" in results
+        assert len(failed_checks) == 1
+        assert failed_checks[0][0] == "Unknown"
+
+    def test_real_api_error_on_one_check_is_tracked_not_swallowed(self, monkeypatch):
+        good_check = {"id": "good-id", "name": "Good Check", "description": "d"}
+        bad_check = {"id": "bad-id", "name": "Bad Check", "description": "d"}
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", lambda: [good_check, bad_check])
+
+        def fake_get_check_result(check_id):
+            if check_id == "bad-id":
+                raise _real_client_error("DescribeTrustedAdvisorCheckResult")
+            return {"status": "ok", "flaggedResources": []}
+
+        monkeypatch.setattr(ta_export, "get_check_result", fake_get_check_result)
+
+        results, failed_checks = get_all_check_results()
+
+        assert "good-id" in results
+        assert "bad-id" not in results
+        assert len(failed_checks) == 1
+        assert failed_checks[0][0] == "bad-id"
+
+    def test_not_subscribed_propagates_from_listing(self, monkeypatch):
+        def raise_not_subscribed():
+            raise TrustedAdvisorNotSubscribedError("no support plan")
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", raise_not_subscribed)
+
+        with pytest.raises(TrustedAdvisorNotSubscribedError):
+            get_all_check_results()
+
+
+class TestSilentCollectionFailureRegression:
+    """
+    Regression tests for the 07.15.2026 / 07.16.2026 silent-collection-failure
+    audits, applied to Trusted Advisor cost optimization: get_check_result()
+    -- the PRIMARY collector -- used to swallow every real API error into
+    None via @aws_error_handler(default_return=None), indistinguishable
+    from a check with no result. main() also had no way to signal that
+    failure downstream (it just logged "No cost optimization opportunities
+    found" and exited 0). These tests cover: (a) a malformed check is
+    skipped, not fatal; (b) a real API error surfaces as a failed scope
+    rather than an empty result; (c) that failure surfaces through main()
+    as a non-zero exit plus a utils.report_collection_failures() call; (d)
+    a genuine "not subscribed" state is a graceful exit 0 with no failure
+    marker.
+    """
+
+    # -- (a) Per-item guard --------------------------------------------
+
+    def test_malformed_check_is_skipped_not_fatal(self, monkeypatch):
+        """One malformed check entry must not discard the others."""
+        good_check = {"id": "good-id", "name": "Good Check", "description": "d"}
+        bad_check = {"name": "Bad Check (no id)", "description": "d"}
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", lambda: [good_check, bad_check])
+        monkeypatch.setattr(
+            ta_export, "get_check_result", lambda check_id: {"status": "ok", "flaggedResources": []}
+        )
+
+        results, failed_checks = get_all_check_results()
+
+        assert "good-id" in results, "healthy check was lost when a sibling was malformed"
+        assert len(failed_checks) == 1
+
+    # -- (b) Real error surfaces, not swallowed -------------------------
+
+    def test_get_check_result_raises_on_api_error_not_swallowed(self, monkeypatch):
+        """A real Trusted Advisor API error must propagate, not collapse to
+        None (the old @aws_error_handler(default_return=None) behavior)."""
+        client = MagicMock()
+        client.describe_trusted_advisor_check_result.side_effect = _real_client_error(
+            "DescribeTrustedAdvisorCheckResult", code="InternalServerError"
+        )
+        monkeypatch.setattr(ta_export.utils, "get_boto3_client", lambda *a, **kw: client)
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            get_check_result("check-1")
+
+    # -- (c) main()/_run_export(): failure surfaced, non-zero exit ------
+
+    def test_run_export_check_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A real per-check API failure must exit non-zero and call
+        utils.report_collection_failures -- never silently collapse into
+        'No cost optimization opportunities found.'"""
+        monkeypatch.setattr(ta_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+
+        good_check = {"id": "good-id", "name": "Good Check", "description": "d"}
+        bad_check = {"id": "bad-id", "name": "Bad Check", "description": "d"}
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", lambda: [good_check, bad_check])
+
+        def fake_get_check_result(check_id):
+            if check_id == "bad-id":
+                raise _real_client_error("DescribeTrustedAdvisorCheckResult")
+            # "good-id" has no flagged resources -- legitimately empty, but
+            # the run must still be flagged as failed because of bad-id.
+            return {"status": "ok", "flaggedResources": []}
+
+        monkeypatch.setattr(ta_export, "get_check_result", fake_get_check_result)
+
+        calls = {}
+
+        def fake_report(account_name, resource_type, failed_scopes):
+            calls["account_name"] = account_name
+            calls["resource_type"] = resource_type
+            calls["failed_scopes"] = failed_scopes
+            return "fake-marker.txt"
+
+        monkeypatch.setattr(ta_export.utils, "report_collection_failures", fake_report)
+
+        with pytest.raises(SystemExit) as exc_info:
+            ta_export._run_export("123456789012", "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("account_name") == "test-account"
+        assert calls.get("resource_type") == "trusted-advisor-cost-optimization"
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "cost_checks"
+
+    def test_run_export_listing_failure_exits_nonzero_and_reports(self, monkeypatch):
+        """A real error on the top-level checks listing call must also
+        surface as a failed 'cost_checks' scope, not an empty export."""
+        monkeypatch.setattr(ta_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+
+        def raise_real_error():
+            raise _real_client_error("DescribeTrustedAdvisorChecks", code="AccessDeniedException")
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", raise_real_error)
+
+        calls = {}
+        monkeypatch.setattr(
+            ta_export.utils,
+            "report_collection_failures",
+            lambda account_name, resource_type, failed_scopes: calls.update(
+                account_name=account_name, resource_type=resource_type, failed_scopes=failed_scopes
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            ta_export._run_export("123456789012", "test-account")
+
+        assert exc_info.value.code == 1
+        assert calls.get("failed_scopes")
+        assert calls["failed_scopes"][0][0] == "cost_checks"
+
+    # -- (d) Not subscribed: graceful skip, no marker --------------------
+
+    def test_not_subscribed_exits_zero_no_marker(self, monkeypatch):
+        """Trusted Advisor requiring Business/Enterprise Support is a
+        legitimate, expected state -- exit 0, and
+        utils.report_collection_failures is never called (no
+        *-FAILED-*.txt marker is written)."""
+        monkeypatch.setattr(ta_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+
+        def raise_not_subscribed():
+            raise TrustedAdvisorNotSubscribedError("no support plan")
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", raise_not_subscribed)
+
+        report_called = []
+        monkeypatch.setattr(
+            ta_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            ta_export._run_export("123456789012", "test-account")
+
+        assert exc_info.value.code == 0
+        assert report_called == []
+
+    def test_genuinely_empty_exits_zero_no_marker(self, monkeypatch):
+        """No cost-optimizing checks exist for this account (subscription
+        active, listing call succeeded) -- genuinely nothing to optimize --
+        must exit 0 with no failure marker."""
+        monkeypatch.setattr(ta_export.utils, "ensure_dependencies", lambda *a, **kw: True)
+
+        monkeypatch.setattr(ta_export, "get_trusted_advisor_checks", lambda: [])
+
+        report_called = []
+        monkeypatch.setattr(
+            ta_export.utils,
+            "report_collection_failures",
+            lambda *a, **kw: report_called.append((a, kw)),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            ta_export._run_export("123456789012", "test-account")
+
+        assert exc_info.value.code == 0
+        assert report_called == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -81,6 +81,13 @@ _EXCLUDED = {
     #   controltower:ListLandingZones       -> 404 "Not yet implemented"
     #   rekognition:DescribeProjects        -> NotImplementedError
     #   xray:GetSamplingRules               -> 404 "Not yet implemented"
+    # Batch-J cost/compute — moto implements none of these primary APIs:
+    #   ce:GetAnomalyMonitors / ce:ListCostCategoryDefinitions -> NotImplementedError
+    #   marketplace-agreement:SearchAgreements                 -> 404
+    #   ec2:DescribeReservedInstances / DescribeCapacityReservations
+    #     / DescribeHostReservations                           -> NotImplementedError
+    #   license-manager:ListLicenseConfigurations              -> 404
+    #   support:DescribeTrustedAdvisorCheckResult              -> NotImplementedError
     "image_builder_export.py",
     "ssm_fleet_export.py",
     "bedrock_export.py",
@@ -99,6 +106,14 @@ _EXCLUDED = {
     "controltower_export.py",
     "rekognition_export.py",
     "xray_export.py",
+    "cost_anomaly_detection_export.py",
+    "cost_categories_export.py",
+    "marketplace_export.py",
+    "reserved_instances_export.py",
+    "ec2_capacity_reservations_export.py",
+    "ec2_dedicated_hosts_export.py",
+    "license_manager_export.py",
+    "trusted_advisor_cost_optimization_export.py",
 }
 
 EXPORTER_SCRIPTS = sorted(


### PR DESCRIPTION
Part of #233. **Batch J: cost & compute (8 exporters)** — the batch inadvertently skipped between Batch I (#245) and Batch K (#246). With this, **all 96 exporters are converted.**

| Exporter | Type | Scopes | Slug |
|---|---|---|---|
| cost_anomaly_detection | account-scope | 2 | `cost-anomaly-detection` |
| cost_categories | account-scope | 1 | `cost-categories` |
| marketplace | account-scope | 1 | `marketplace` |
| trusted_advisor_cost_optimization | account-scope | 1 | `trusted-advisor-cost-optimization` |
| reserved_instances | multi-region | 6 | `reserved-instances` |
| ec2_capacity_reservations | multi-region | 2 | `ec2-capacity-reservations` |
| ec2_dedicated_hosts | multi-region | 2 | `ec2-dedicated-hosts` |
| license_manager | multi-region | 1 | `license-manager` |

Primary scope collector RAISES on error → surfaced failures → per-item `_build_*_row` guard → marker + `sys.exit(1)`; genuine-empty stays exit 0.

**Notable:** `trusted_advisor` distinguishes `SubscriptionRequiredException` (support plan too low → graceful exit 0, no marker) from a real API error, and removes a `sys.exit()` that was buried in a library function (Issue #171 alignment). `cost_categories` fixes a latent enrichment double-derivation bug the refactor exposed. `check['id']` guarded.

## Tests
Each exporter gains a `TestSilentCollectionFailureRegression` suite. **Batch-J suites: 54 passed. Full suite: 1198 passed, 2 skipped.** `ruff check .` clean (py39 floor).

## test_smoke.py exclusions
All 8 added to `_EXCLUDED` — moto implements **none** of their primary APIs (cost/billing/RI/capacity/marketplace/trusted-advisor). Confirmed genuinely-unimplemented (not the optional-dep case); coverage lives in the dedicated monkeypatch-based regression suites.

## Sweep complete
All 96 exporters (Tier-1: 12, Tier-2: 36, Tier-3: 48) now surface collection failures — `*-FAILED-*.txt` marker + non-zero exit — instead of silently losing data. Closes the blast-radius work in #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)