### PR TITLE
chore: remove dead TUI verbiage (README, executor comments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ StratusScanCLI-AWS is in active beta development. The API and output format may 
 | Version | Target | Notes |
 |---|---|---|
 | `0.6.x` | Patch releases | Coverage gaps, pricing data refresh, live-account hardening |
-| `1.0.0` | Planned | Full Textual-based TUI; subprocess output streamed live |
+| `1.0.0` | Planned | Stable API; unattended audit mode — scheduled, cross-account, S3-delivered runs |
 
 ---
 
@@ -443,8 +443,10 @@ StratusScanCLI-AWS uses [Semantic Versioning](https://semver.org/).
 | `0.1.x` | Superseded | Initial relaunch |
 | `0.2.x` | Superseded | Backend stabilization, pricing data v2 |
 | `0.3.x` | Superseded | Smart Scan orchestrator, full API correctness audit |
-| `0.4.x` | Current (Beta) | Cost columns for 14 exporters, pricing JSON overhaul |
-| `1.0.0` | Planned | Textual TUI, stable API |
+| `0.4.x` | Superseded | Cost columns for 14 exporters, pricing JSON overhaul |
+| `0.5.x` | Superseded | Multi-account org-scan, CLI flags, signal-based navigation, export formats |
+| `0.6.x` | Current (Beta) | Fail-loud collection sweep, security hardening, smart-scan discovery |
+| `1.0.0` | Planned | Stable API; unattended audit mode |
 
 ---
 

--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -72,8 +72,8 @@ class ScriptExecutor:
             regions: Regions to pass to subprocesses via STRATUSSCAN_REGIONS.
                      If None, subprocesses use their own configured defaults.
             show_output: When True, stream script stdout to console (prefixed with
-                         two spaces). When False, capture silently — for future TUI
-                         use where the TUI will consume the stream directly.
+                         two spaces). When False, capture silently for a caller
+                         that consumes the stream directly.
         """
         self.scripts = sorted(set(scripts))  # Deduplicate and sort for consistent ordering
 
@@ -635,7 +635,7 @@ def execute_scripts(
         save_log: Whether to save execution log to file
         regions: Regions to pass to subprocesses via STRATUSSCAN_REGIONS
         show_output: When True, stream script stdout to console in real time.
-                     When False, capture silently (for future TUI use).
+                     When False, capture silently for a caller that consumes it.
         session: Optional scan session dict from utils.start_scan_session().
                  When provided, results are persisted to disk after each script.
         skip_scripts: Optional set of script filenames to skip (already


### PR DESCRIPTION
The Textual-based TUI (former v1.0.0 target, #125) is abandoned. This strips all TUI references from tracked repo files:

- **README.md** — roadmap + versioning `1.0.0` rows now read *stable API + unattended audit mode*; refreshed the versioning table's *Current* marker to `0.6.x` (was stale at `0.4.x`).
- **scripts/smart_scan/executor.py** — dropped two "for future TUI use" comments on `show_output`.

Design-principle guidance in CLAUDE.md (gitignored, local) and the TUI framing in issues #125/#169/#170/#171 were cleaned up separately. The #169/#170/#171 refactors keep their standalone rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)