### PR TITLE
fix(smart-scan): resolve 'Amazon CloudWatch Logs' to cloudwatch_export (closes #191)

### DIFF
--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -108,6 +108,7 @@ SERVICE_ALIASES: dict[str, str] = {
 
     # Management & Governance
     "cloudwatch": "Amazon CloudWatch",
+    "amazon cloudwatch logs": "Amazon CloudWatch",
     "cloudtrail": "AWS CloudTrail",
     "config": "AWS Config",
     "systems manager": "AWS Systems Manager",

--- a/tests/smart_scan/test_mapping.py
+++ b/tests/smart_scan/test_mapping.py
@@ -315,7 +315,6 @@ class TestDiscoveryCatalogResolves:
         "Amazon Timestream",
         "Amazon EMR",
         "Amazon Kinesis",
-        "Amazon CloudWatch Logs",
         "AWS Amplify",
     }
 


### PR DESCRIPTION
## Summary

Salvages the one genuine gap from the now-stale PR #192. Verified against current `dev`: **14 of #192's 15 mappings already landed** (the mixed-case `Amazon EKS`/`Amazon ECS` keys were lowercased and the aliases added via #188). The only real remaining gap was **`Amazon CloudWatch Logs`**.

## The fix

- Add alias `"amazon cloudwatch logs" -> "Amazon CloudWatch"` so the discovery-catalog service resolves to `cloudwatch_export.py`.
- Remove `"Amazon CloudWatch Logs"` from the test's `KNOWN_NO_EXPORTER` allowlist.

## Why it was misclassified

#207/#209 added `Amazon CloudWatch Logs` to `KNOWN_NO_EXPORTER` as a coverage gap — but that's wrong: `cloudwatch_export.py` **already exports log groups** (`_scan_log_groups_region()` -> `describe_log_groups`, and its docstring lists "log groups"). So Logs *is* covered; it was being silently dropped from Deep Scan for no reason.

## Verification

- `Amazon CloudWatch Logs` -> `Amazon CloudWatch` -> `['cloudwatch_export.py']` ✅
- `tests/smart_scan/`: 118 passed, 2 skipped; ruff clean.

Supersedes #192 (recommend closing it as mostly-superseded). Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)