### PR TITLE
refactor(cli): single voice — one interaction contract across the whole tool

### DIFF
--- a/advanced_settings.py
+++ b/advanced_settings.py
@@ -92,12 +92,10 @@ def configure_concurrent_scanning():
 
     # Enable/disable concurrent scanning
     enabled_str = 'Yes' if current['concurrent_scanning']['enabled'] else 'No'
-    enabled_input = input(f"\nEnable concurrent scanning? (Y/n) [Current: {enabled_str}]: ").strip().lower()
-
-    if enabled_input == '':
-        enabled = current['concurrent_scanning']['enabled']
-    else:
-        enabled = enabled_input != 'n'
+    enabled = utils.prompt_for_confirmation(
+        f"\nEnable concurrent scanning? [Current: {enabled_str}]",
+        default=current['concurrent_scanning']['enabled'],
+    )
 
     if enabled:
         # Configure max workers
@@ -116,12 +114,10 @@ def configure_concurrent_scanning():
 
         # Fallback on error
         fallback_str = 'Yes' if current['concurrent_scanning']['fallback_on_error'] else 'No'
-        fallback_input = input(f"\nFallback to sequential scanning on errors? (Y/n) [Current: {fallback_str}]: ").strip().lower()
-
-        if fallback_input == '':
-            fallback = current['concurrent_scanning']['fallback_on_error']
-        else:
-            fallback = fallback_input != 'n'
+        fallback = utils.prompt_for_confirmation(
+            f"\nFallback to sequential scanning on errors? [Current: {fallback_str}]",
+            default=current['concurrent_scanning']['fallback_on_error'],
+        )
     else:
         max_workers = current['concurrent_scanning']['max_workers']
         fallback = current['concurrent_scanning']['fallback_on_error']
@@ -204,9 +200,10 @@ def configure_caching():
 
     # Enable/disable caching
     enabled_str = 'Yes' if current['caching']['enabled'] else 'No'
-    enabled_input = input(f"\nEnable caching? (Y/n) [Current: {enabled_str}]: ").strip().lower()
-
-    enabled = current['caching']['enabled'] if enabled_input == '' else enabled_input != 'n'
+    enabled = utils.prompt_for_confirmation(
+        f"\nEnable caching? [Current: {enabled_str}]",
+        default=current['caching']['enabled'],
+    )
 
     if enabled:
         # Cache expiration
@@ -367,14 +364,14 @@ def reset_to_defaults():
     print("  - Caching: Enabled (session-only)")
     print("  - Performance: Default tuning values")
 
-    confirm = input("\nAre you sure you want to reset? (yes/no): ").strip().lower()
+    confirm = utils.prompt_for_confirmation("\nAre you sure you want to reset?", default=False)
 
-    if confirm == 'yes':
+    if confirm:
         defaults = get_default_settings()
         save_settings(defaults)
-        print("\n✓ All settings have been reset to defaults.")
+        print(f"\n{utils.GLYPH_OK} All settings have been reset to defaults.")
     else:
-        print("\n✗ Reset cancelled.")
+        print(f"\n{utils.GLYPH_FAIL} Reset cancelled.")
 
 
 def main():
@@ -386,44 +383,46 @@ def main():
     print("Settings are stored in config.json and apply to all export scripts.")
 
     while True:
-        print("\n" + "="*70)
-        print("MAIN MENU")
-        print("="*70)
-        print("\n[1] View Current Settings")
-        print("[2] Configure Concurrent Scanning")
-        print("[3] Configure Progress Display")
-        print("[4] Configure Caching")
-        print("[5] Configure Performance Tuning")
-        print("[6] Reset to Defaults")
-        print("[0] Exit")
-
-        choice = input("\nSelect option: ").strip()
-
-        if choice == '0':
+        try:
+            choice = utils.prompt_menu(
+                "MAIN MENU",
+                [
+                    "View Current Settings",
+                    "Configure Concurrent Scanning",
+                    "Configure Progress Display",
+                    "Configure Caching",
+                    "Configure Performance Tuning",
+                    "Reset to Defaults",
+                    "Exit",
+                ],
+            )
+        except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
             print("\nExiting advanced settings. Changes have been saved.")
             break
-        elif choice == '1':
+
+        if choice == 1:
             display_current_settings()
-        elif choice == '2':
+        elif choice == 2:
             current = get_current_settings()
             current['concurrent_scanning'] = configure_concurrent_scanning()
             save_settings(current)
-        elif choice == '3':
+        elif choice == 3:
             current = get_current_settings()
             current['progress_display'] = configure_progress_display()
             save_settings(current)
-        elif choice == '4':
+        elif choice == 4:
             current = get_current_settings()
             current['caching'] = configure_caching()
             save_settings(current)
-        elif choice == '5':
+        elif choice == 5:
             current = get_current_settings()
             current['performance'] = configure_performance()
             save_settings(current)
-        elif choice == '6':
+        elif choice == 6:
             reset_to_defaults()
-        else:
-            print("\n  ERROR: Invalid option. Please try again.")
+        elif choice == 7:
+            print("\nExiting advanced settings. Changes have been saved.")
+            break
 
 
 if __name__ == '__main__':

--- a/configure.py
+++ b/configure.py
@@ -691,29 +691,32 @@ def configure_output_settings(config: dict):
             print(f"  S3 bucket:   {bucket}")
             print(f"  S3 prefix:   {prefix}")
         print()
-        print("  [1] Change export format (xlsx/csv)")
-        print("  [2] Change destination (local/s3)")
-        print("  [3] Set S3 bucket")
-        print("  [4] Set S3 prefix")
-        print("  [5] Test S3 connection")
-        print("  [B] Back to main menu")
-
-        choice = input("\nSelect option: ").strip().upper()
-
-        if choice == "1":
-            _set_output_format(config)
-        elif choice == "2":
-            _set_output_destination(config)
-        elif choice == "3":
-            _set_s3_bucket(config)
-        elif choice == "4":
-            _set_s3_prefix(config)
-        elif choice == "5":
-            _run_s3_connectivity_test(config)
-        elif choice in ("B", ""):
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Change export format (xlsx/csv)",
+                    "Change destination (local/s3)",
+                    "Set S3 bucket",
+                    "Set S3 prefix",
+                    "Test S3 connection",
+                ],
+            )
+        except utils.BackSignal:
             return
-        else:
-            print("  ❌ Invalid choice.")
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
+
+        if choice == 1:
+            _set_output_format(config)
+        elif choice == 2:
+            _set_output_destination(config)
+        elif choice == 3:
+            _set_s3_bucket(config)
+        elif choice == 4:
+            _set_s3_prefix(config)
+        elif choice == 5:
+            _run_s3_connectivity_test(config)
 
 
 def config_wizard(config: dict):
@@ -800,8 +803,8 @@ def main_menu_loop(config: dict, config_path: Path):
                 print("SAVE CONFIGURATION")
                 print("═" * 70)
                 display_summary(config)
-                confirm = input("\nSave this configuration? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation("\nSave this configuration?", default=False)
+                if confirm:
                     if save_configuration(config, config_path):
                         print("\n✅ Configuration saved successfully!")
                         print("You can now use StratusScan with your configured settings.")
@@ -821,8 +824,8 @@ def main_menu_loop(config: dict, config_path: Path):
             # Exit without saving
             if _config_modified:
                 print("\n⚠️  WARNING: You have unsaved changes!")
-                confirm = input("Exit without saving? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation("Exit without saving?", default=False)
+                if confirm:
                     print("\n❌ Configuration not saved. Exiting...")
                     return
                 else:
@@ -886,15 +889,17 @@ def manage_account_mappings(config: dict):
         else:
             print("  None configured")
 
-        print("\nOptions:")
-        print("  [A] Add new account")
-        print("  [E] Edit existing account")
-        print("  [D] Delete account")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                ["Add new account", "Edit existing account", "Delete account"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (A/E/D/B): ").strip().upper()
-
-        if choice == 'A':
+        if choice == 1:
             # Fetch current account identity for defaults
             identity = get_aws_identity()
             default_id = identity['account_id'] if identity and identity.get('account_id') != 'Unknown' else ''
@@ -917,8 +922,10 @@ def manage_account_mappings(config: dict):
                     break
                 if validate_account_id(account_id):
                     if account_id in mappings:
-                        overwrite = input(f"Account {account_id} already exists. Overwrite? (y/n): ").lower().strip()
-                        if overwrite != 'y':
+                        overwrite = utils.prompt_for_confirmation(
+                            f"Account {account_id} already exists. Overwrite?", default=False
+                        )
+                        if not overwrite:
                             continue
                     break
                 else:
@@ -936,7 +943,7 @@ def manage_account_mappings(config: dict):
                 else:
                     print("\n❌ Account name cannot be empty")
 
-        elif choice == 'E':
+        elif choice == 2:
             # Edit existing account
             if not mappings:
                 print("\n❌ No accounts to edit")
@@ -959,7 +966,7 @@ def manage_account_mappings(config: dict):
             else:
                 print(f"\n❌ Account {account_id} not found")
 
-        elif choice == 'D':
+        elif choice == 3:
             # Delete account
             if not mappings:
                 print("\n❌ No accounts to delete")
@@ -968,21 +975,16 @@ def manage_account_mappings(config: dict):
 
             account_id = input("\nEnter Account ID to delete: ").strip()
             if account_id in mappings:
-                confirm = input(f"Delete {account_id} ({mappings[account_id]})? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation(
+                    f"Delete {account_id} ({mappings[account_id]})?", default=False
+                )
+                if confirm:
                     del mappings[account_id]
                     config['account_mappings'] = mappings
                     _config_modified = True
                     print(f"\n✅ Deleted: {account_id}")
             else:
                 print(f"\n❌ Account {account_id} not found")
-
-        elif choice == 'B':
-            # Back to main menu
-            return
-
-        else:
-            print("\n❌ Invalid choice. Please select A/E/D/B.")
 
 def configure_default_regions(config: dict):
     """Configure default regions."""
@@ -997,31 +999,34 @@ def configure_default_regions(config: dict):
     print(f"\nCurrent default regions: {', '.join(current_regions) if current_regions else 'None'}")
 
     if is_govcloud:
-        print("\n  1. GovCloud — both regions (us-gov-west-1, us-gov-east-1)")
-        print("  C. Custom — enter regions manually")
-        presets = {"1": ["us-gov-west-1", "us-gov-east-1"]}
+        preset_label = "GovCloud — both regions (us-gov-west-1, us-gov-east-1)"
+        preset_regions = ["us-gov-west-1", "us-gov-east-1"]
     else:
-        print("\n  1. US Standard — us-east-1, us-east-2, us-west-1, us-west-2")
-        print("  C. Custom — enter regions manually")
-        presets = {"1": ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]}
+        preset_label = "US Standard — us-east-1, us-east-2, us-west-1, us-west-2"
+        preset_regions = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
 
     # Validates standard AWS region format: us-east-1, eu-west-2, us-gov-west-1, etc.
     region_pattern = re.compile(r'^[a-z]{2,3}(-[a-z]+)+-\d+$')
 
     while True:
-        choice = input("\nSelect option (1, C for custom, 0 to cancel): ").strip().upper()
-
-        if choice == '0':
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [preset_label, "Custom — enter regions manually"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
             return
 
-        if choice in presets:
-            regions = presets[choice]
+        if choice == 1:
+            regions = preset_regions
             config['default_regions'] = regions
             _config_modified = True
             print(f"\n✅ Default regions set: {', '.join(regions)}")
             break
 
-        elif choice == 'C':
+        elif choice == 2:
             raw = input("  Regions, comma-separated (e.g. eu-west-1,ap-northeast-1): ").strip().lower()
             if not raw:
                 continue
@@ -1043,9 +1048,6 @@ def configure_default_regions(config: dict):
             _config_modified = True
             print(f"\n✅ Default regions set: {', '.join(regions)}")
             break
-
-        else:
-            print("  ❌ Invalid choice. Enter 1, C, or 0.")
 
     input("\nPress Enter to return to menu...")
 
@@ -1080,14 +1082,17 @@ def manage_cross_account_roles(config: dict):
         else:
             print("  None configured")
 
-        print("\nOptions:")
-        print("  [A] Add role")
-        print("  [R] Remove role")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                ["Add role", "Remove role"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (A/R/B): ").strip().upper()
-
-        if choice == 'A':
+        if choice == 1:
             while True:
                 account_id = input("\nEnter target AWS Account ID (12 digits): ").strip()
                 if not account_id:
@@ -1123,7 +1128,7 @@ def manage_cross_account_roles(config: dict):
                 print(f"\n❌ Failed to add role for account {account_id}")
             input("Press Enter to continue...")
 
-        elif choice == 'R':
+        elif choice == 2:
             if not real_roles:
                 print("\n❌ No roles configured to remove")
                 input("Press Enter to continue...")
@@ -1140,10 +1145,10 @@ def manage_cross_account_roles(config: dict):
                 input("Press Enter to continue...")
                 continue
 
-            confirm = input(
-                f"Remove role for {account_id} ({roles[account_id]})? (y/n): "
-            ).lower().strip()
-            if confirm == 'y':
+            confirm = utils.prompt_for_confirmation(
+                f"Remove role for {account_id} ({roles[account_id]})?", default=False
+            )
+            if confirm:
                 if utils.remove_cross_account_role(account_id):
                     del roles[account_id]
                     config['cross_account_roles'] = roles
@@ -1154,12 +1159,6 @@ def manage_cross_account_roles(config: dict):
             else:
                 print("\n↩ Cancelled")
             input("Press Enter to continue...")
-
-        elif choice == 'B':
-            return
-
-        else:
-            print("\n❌ Invalid choice. Please select A, R, or B.")
 
 
 # ============================================================================
@@ -1190,18 +1189,24 @@ def dependency_management_menu():
             input("\nPress Enter to return to menu...")
             return
 
-        print("\nOptions:")
-        print("  [1] Install missing dependencies automatically")
-        print("  [2] Show installation commands for manual installation")
-        print("  [3] Re-check dependencies")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Install missing dependencies automatically",
+                    "Show installation commands for manual installation",
+                    "Re-check dependencies",
+                ],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (1-3, B): ").strip().upper()
-
-        if choice == '1':
+        if choice == 1:
             install_dependencies(_dependency_status['missing_packages'])
             _dependency_status = check_dependencies_silent()
-        elif choice == '2':
+        elif choice == 2:
             print("\n" + "═" * 70)
             print("MANUAL INSTALLATION COMMANDS")
             print("═" * 70)
@@ -1211,14 +1216,9 @@ def dependency_management_menu():
             print("\nAlternatively, install all at once:")
             print(f"pip install {' '.join([p['name'] for p in _dependency_status['missing_packages']])}")
             input("\nPress Enter to continue...")
-        elif choice == '3':
+        elif choice == 3:
             print("\n🔄 Re-checking dependencies...")
             continue
-        elif choice == 'B':
-            return
-        else:
-            print("\n❌ Invalid choice. Please select 1-3 or B.")
-            input("Press Enter to continue...")
 
 def install_dependencies(missing_packages: list[dict]) -> bool:
     """
@@ -1241,9 +1241,11 @@ def install_dependencies(missing_packages: list[dict]) -> bool:
     for package in missing_packages:
         print(f"  - {package['name']} - {package['description']}")
 
-    confirm = input(f"\nInstall these {len(missing_packages)} packages now? (y/n): ").lower().strip()
+    confirm = utils.prompt_for_confirmation(
+        f"\nInstall these {len(missing_packages)} packages now?", default=True
+    )
 
-    if confirm != 'y':
+    if not confirm:
         print("\n❌ Installation cancelled.")
         input("Press Enter to continue...")
         return False
@@ -1304,12 +1306,17 @@ def permissions_management_menu():
         if not identity:
             print("\n❌ No AWS credentials found!")
             print("Please configure your AWS credentials before running StratusScan.")
-            print("\nOptions:")
-            print("  [1] Show credential configuration help")
-            print("  [B] Back to main menu")
+            try:
+                choice = utils.prompt_menu(
+                    "Select an option",
+                    ["Show credential configuration help"],
+                )
+            except utils.BackSignal:
+                return
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                return
 
-            choice = input("\nSelect option (1, B): ").strip().upper()
-            if choice == '1':
+            if choice == 1:
                 print("\n" + "═" * 70)
                 print("AWS CREDENTIALS SETUP")
                 print("═" * 70)
@@ -1322,8 +1329,6 @@ def permissions_management_menu():
                 print("\n3. IAM Role (for EC2 instances)")
                 print("   Attach an IAM role to your EC2 instance")
                 input("\nPress Enter to continue...")
-            elif choice == 'B':
-                return
             continue
 
         print(f"\nAWS Identity: {identity['arn']}")
@@ -1343,26 +1348,27 @@ def permissions_management_menu():
             print(f"\n❌ {_permission_status['required_failed']} required permissions are missing!")
             print("StratusScan scripts may fail without these permissions.")
 
-        print("\nOptions:")
-        print("  [1] Show policy recommendations")
-        print("  [2] View policy file locations")
-        print("  [3] Re-test permissions")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Show policy recommendations",
+                    "View policy file locations",
+                    "Re-test permissions",
+                ],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (1-3, B): ").strip().upper()
-
-        if choice == '1':
+        if choice == 1:
             show_policy_recommendations_brief()
-        elif choice == '2':
+        elif choice == 2:
             show_policy_file_locations()
-        elif choice == '3':
+        elif choice == 3:
             print("\n🔄 Re-testing permissions...")
             continue
-        elif choice == 'B':
-            return
-        else:
-            print("\n❌ Invalid choice. Please select 1-3 or B.")
-            input("Press Enter to continue...")
 
 def show_policy_recommendations_brief():
     """Show brief policy recommendations."""

--- a/configure.py
+++ b/configure.py
@@ -1063,7 +1063,7 @@ def manage_cross_account_roles(config: dict):
     """
     Interactive menu for managing cross-account IAM role mappings.
 
-    Mirrors manage_account_mappings() — [A]dd, [R]emove, [B]ack.
+    Mirrors manage_account_mappings() — numbered Add / Remove menu, b = back.
     Validates role ARN format before delegating to utils.
     """
     global _config_modified

--- a/scripts/_resource_bundle.py
+++ b/scripts/_resource_bundle.py
@@ -80,70 +80,24 @@ def _detect_new_xlsx(
 def prompt_script_selection(
     category_name: str,
     scripts: list[tuple[str, str]],
-):
+) -> list[tuple[str, str]]:
     """
     Present a numbered multi-select menu for script selection.
 
-    Returns a list of selected (display_name, filename) tuples,
-    or the strings 'back' or 'exit'.
+    Returns the list of selected (display_name, filename) tuples. Navigation
+    is handled the single-voice way via utils.prompt_multiselect, which raises
+    BackSignal / ExitToMainSignal / QuitSignal for b / x / q.
     """
     # Auto-run mode: select everything without prompting
     if utils.is_auto_run():
         return list(scripts)
 
-    while True:
-        print(f"\nSELECT {category_name.upper()} TO EXPORT")
-        print("=" * 64)
-        print(f"   0. All  (export all {category_name.lower()})")
-        for i, (name, _) in enumerate(scripts, 1):
-            print(f"  {i:2d}. {name}")
-        print("=" * 64)
-        print("   b. Back    x. Exit")
-        print("=" * 64)
-
-        try:
-            raw = input(
-                "Enter number(s) separated by spaces (e.g. 1  or  1 3 5): "
-            ).strip().lower()
-        except KeyboardInterrupt:
-            print()
-            return 'exit'
-
-        if raw == 'b':
-            return 'back'
-        if raw == 'x':
-            return 'exit'
-        if raw == '0':
-            return list(scripts)
-
-        tokens = raw.split()
-        selected: list[tuple[str, str]] = []
-        seen: set = set()
-        valid = True
-
-        for tok in tokens:
-            try:
-                idx = int(tok)
-                if 1 <= idx <= len(scripts):
-                    if idx not in seen:
-                        selected.append(scripts[idx - 1])
-                        seen.add(idx)
-                else:
-                    print(
-                        f"  Invalid number {tok}. "
-                        f"Enter values between 0 and {len(scripts)}."
-                    )
-                    valid = False
-                    break
-            except ValueError:
-                print(f"  Invalid input '{tok}'. Please enter numbers only.")
-                valid = False
-                break
-
-        if valid and selected:
-            return selected
-        if valid and not selected:
-            print("  No scripts selected. Please enter at least one number.")
+    indices = utils.prompt_multiselect(
+        f"SELECT {category_name.upper()} TO EXPORT",
+        [name for name, _ in scripts],
+        all_label=f"All  (every {category_name.lower()} exporter)",
+    )
+    return [scripts[i - 1] for i in indices]
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +263,7 @@ def print_summary(
     print(f"{'=' * 70}")
 
     for r in results:
-        status = "✓" if r.success else "✗"
+        status = utils.GLYPH_OK if r.success else utils.GLYPH_FAIL
         print(f"  {status} {r.name:<35} {_fmt_duration(r.duration_seconds):>8}")
         if not r.success and r.error:
             print(f"      Error: {r.error}")
@@ -378,13 +332,13 @@ def run_bundle(
 
         # ── Step 2: Script selection ──────────────────────────────────────
         elif step == 2:
-            result = prompt_script_selection(category_name, scripts)
-            if result == 'back':
+            try:
+                selected_scripts = prompt_script_selection(category_name, scripts)
+            except utils.BackSignal:
                 step = 1
                 continue
-            if result == 'exit':
+            except (utils.ExitToMainSignal, utils.QuitSignal):
                 sys.exit(11)
-            selected_scripts = result
             step = 3
 
         # ── Step 3: Confirmation ──────────────────────────────────────────

--- a/scripts/billing_export.py
+++ b/scripts/billing_export.py
@@ -387,23 +387,39 @@ def main():
         if not utils.ensure_dependencies('pandas', 'openpyxl', 'dateutil'):
             sys.exit(1)
 
-        # Get user input for date range
+        # Get user input for date range — fully menu-driven (single-voice):
+        # "Last 12 months" plus the 12 most recent complete months, no free-text.
         if utils.is_auto_run():
             date_input = "last 12"
             _, _, start_date, end_date = validate_date_input(date_input)
         else:
-            while True:
-                date_input = input("\nWould you like the last 12 months (type \"last 12\") or a specific month (ex. \"01-2025\")? ")
-                is_valid, is_year_only, start_date, end_date = validate_date_input(date_input)
-                if is_valid:
-                    date_valid, message, _ = validate_date_range(start_date, end_date)
-                    if date_valid:
-                        break
-                    else:
-                        print(f"Error: {message}")
-                        print("Please try again with a more recent date range.")
-                else:
-                    print("Invalid input format. Please enter either \"last 12\" or a month in format \"MM-YYYY\" (e.g., \"01-2025\").")
+            today = datetime.datetime.now()
+            month_options = []  # (value "MM-YYYY", label "Month YYYY"), most recent first
+            y, m = today.year, today.month
+            for _ in range(12):
+                m -= 1
+                if m == 0:
+                    m, y = 12, y - 1
+                month_options.append(
+                    (f"{m:02d}-{y}", datetime.datetime(y, m, 1).strftime("%B %Y"))
+                )
+
+            menu_labels = ["Last 12 months"] + [label for _, label in month_options]
+            try:
+                choice = utils.prompt_menu("BILLING PERIOD", menu_labels)
+            except utils.BackSignal:
+                sys.exit(10)
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                sys.exit(11)
+
+            date_input = "last 12" if choice == 1 else month_options[choice - 2][0]
+            _, _, start_date, end_date = validate_date_input(date_input)
+
+            # Menu values are always well-formed; still guard the retention range.
+            date_valid, message, _ = validate_date_range(start_date, end_date)
+            if not date_valid:
+                print(f"{utils.GLYPH_FAIL} {message}")
+                sys.exit(1)
 
         # Get billing data
         billing_data = get_billing_data(start_date, end_date)

--- a/scripts/compute_optimizer_export.py
+++ b/scripts/compute_optimizer_export.py
@@ -763,15 +763,19 @@ def main():
             print("  - IAM role (if running on EC2)")
             return
 
-        # Check if Compute Optimizer is enabled
-        print("\n" + "="*70)
-        print("IMPORTANT: AWS Compute Optimizer must be opted-in to get recommendations.")
-        print("Visit the AWS Compute Optimizer console to enable it if not already enabled.")
-        print("="*70)
+        # Check if Compute Optimizer is enabled. This is a courtesy pre-flight
+        # gate for interactive users only — under AUTO_RUN (bundle / --run-all /
+        # --org-scan) we proceed and let the API surface a real failure via the
+        # fail-loud collection path, rather than silently skipping the export.
+        if not utils.is_auto_run():
+            print("\n" + "="*70)
+            print("IMPORTANT: AWS Compute Optimizer must be opted-in to get recommendations.")
+            print("Visit the AWS Compute Optimizer console to enable it if not already enabled.")
+            print("="*70)
 
-        if not utils.prompt_for_confirmation("Have you enabled Compute Optimizer?", default=False):
-            print("Please enable Compute Optimizer first, then run this script again.")
-            return
+            if not utils.prompt_for_confirmation("Have you enabled Compute Optimizer?", default=False):
+                print("Please enable Compute Optimizer first, then run this script again.")
+                return
 
         # Get recommendations for all regions. Region failures across any of
         # the five recommendation scopes are collected into failed_regions

--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -848,7 +848,7 @@ def main():
                 except utils.BackSignal:
                     step = 1
                     continue
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 instance_filter, filter_desc = result
                 step = 3

--- a/scripts/health_export.py
+++ b/scripts/health_export.py
@@ -154,26 +154,33 @@ def _run_export(account_id: str, account_name: str) -> None:
     region = 'us-east-1'
 
     # Ask user for time range
-    utils.log_info("\nSelect time range for health events:")
-    utils.log_info("  1. Last 7 days")
-    utils.log_info("  2. Last 30 days")
-    utils.log_info("  3. Last 90 days")
-    utils.log_info("  4. All events (warning: may be large)")
-
     if utils.is_auto_run():
-        choice = "1"
+        choice = 1
     else:
-        choice = input("\nEnter choice (1-4) [default: 1]: ").strip() or "1"
+        try:
+            choice = utils.prompt_menu(
+                "HEALTH EVENT TIME RANGE",
+                [
+                    "Last 7 days",
+                    "Last 30 days",
+                    "Last 90 days",
+                    "All events  (warning: may be large)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
 
     # Calculate time filter
     now = datetime.utcnow()
-    if choice == "1":
+    if choice == 1:
         start_time = now - timedelta(days=7)
         time_desc = "last 7 days"
-    elif choice == "2":
+    elif choice == 2:
         start_time = now - timedelta(days=30)
         time_desc = "last 30 days"
-    elif choice == "3":
+    elif choice == 3:
         start_time = now - timedelta(days=90)
         time_desc = "last 90 days"
     else:

--- a/scripts/iam_export.py
+++ b/scripts/iam_export.py
@@ -1726,7 +1726,7 @@ def main():
                     )
                 except utils.BackSignal:
                     sys.exit(10)
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 choice = result
                 step = 2
@@ -1745,7 +1745,7 @@ def main():
                     except utils.BackSignal:
                         step = 1
                         continue
-                    except utils.QuitSignal:
+                    except (utils.ExitToMainSignal, utils.QuitSignal):
                         sys.exit(11)
                     include_aws_managed = (result == 2)
                     step = 3

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -2115,7 +2115,7 @@ def main():
                     )
                 except utils.BackSignal:
                     sys.exit(10)
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 choice = result
                 step = 2

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -662,71 +662,37 @@ def main():
         region_input = os.environ.get('AWS_REGION', 'all')
         target_region = None if region_input.lower() == 'all' else region_input
     else:
-        # Interactive mode: Display standardized region selection menu
-        print("\n" + "=" * 68)
-        print("REGION SELECTION")
-        print("=" * 68)
-        print()
-        print("Please select which AWS regions to scan:")
-        print()
-        print("1. Default Regions (recommended for most use cases)")
-        print(f"   └─ {example_regions}")
-        print()
-        print("2. All Available Regions")
-        print("   └─ Scans all regions (slower, more comprehensive)")
-        print()
-        print("3. Specific Region")
-        print("   └─ Choose a single region to scan")
-        print()
-
-        # Get user selection with validation
-        while True:
-            try:
-                selection = input("Enter your selection (1-3): ").strip()
-                selection_int = int(selection)
-                if 1 <= selection_int <= 3:
-                    break
-                else:
-                    print("Please enter a number between 1 and 3.")
-            except ValueError:
-                print("Please enter a valid number (1-3).")
-
-        # Get regions based on selection
+        # Interactive: single-voice region selection. S3 is global, so this is a
+        # single-region FILTER (or all regions) — not the multi-region
+        # utils.prompt_region_selection. prompt_menu gives consistent b/x/q nav.
         all_available_regions = utils.get_partition_regions(partition, all_regions=True)
+        try:
+            region_choice = utils.prompt_menu(
+                "REGION SELECTION",
+                [
+                    "Default Regions   (scan all regions for S3 buckets)",
+                    "All Available Regions",
+                    "Specific Region   (filter to a single region)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
 
-        # Process selection
-        if selection_int == 1:
-            # Default regions - for S3, scan all regions by default
+        if region_choice in (1, 2):
+            # S3 is global — both Default and All scan every region.
             target_region = None
-            utils.log_info("Scanning all regions for S3 buckets")
-        elif selection_int == 2:
-            # All regions
-            target_region = None
-            utils.log_info(f"Scanning all {len(all_available_regions)} AWS regions")
-        else:  # selection_int == 3
-            # Display numbered list of regions
-            print("\n" + "=" * 68)
-            print("AVAILABLE AWS REGIONS")
-            print("=" * 68)
-            print()
-            for idx, region in enumerate(all_available_regions, 1):
-                print(f"{idx:2}. {region}")
-            print()
-
-            # Get region selection with validation
-            while True:
-                try:
-                    region_num = input(f"Enter region number (1-{len(all_available_regions)}): ").strip()
-                    region_idx = int(region_num) - 1
-                    if 0 <= region_idx < len(all_available_regions):
-                        selected_region = all_available_regions[region_idx]
-                        target_region = selected_region
-                        utils.log_info(f"Scanning region: {selected_region}")
-                        break
-                    else:
-                        print(f"Please enter a number between 1 and {len(all_available_regions)}.")
-                except ValueError:
-                    print(f"Please enter a valid number (1-{len(all_available_regions)}).")
+            utils.log_info(f"Scanning all {len(all_available_regions)} AWS regions for S3 buckets")
+        else:
+            try:
+                region_idx = utils.prompt_menu("AVAILABLE AWS REGIONS", all_available_regions)
+            except utils.BackSignal:
+                sys.exit(10)
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                sys.exit(11)
+            target_region = all_available_regions[region_idx - 1]
+            utils.log_info(f"Scanning region: {target_region}")
 
     # Validate region if a specific one was provided
     if target_region and not is_valid_aws_region(target_region):

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -1345,18 +1345,28 @@ Examples:
 
     utils.log_info(f"AWS Account: {account_name} ({utils.mask_account_id(account_id)})")
 
-    # Detect partition for region examples
+    # Region selection — handle back/exit navigation (was previously ignored).
     regions = utils.prompt_region_selection()
+    if regions in ('back', 'exit'):
+        sys.exit(0)
 
     # Prompt for scan mode (skipped in auto-run — defaults to quick)
     if utils.is_auto_run():
         scan_mode = 'quick'
     else:
-        print("\n  Scan Mode:")
-        print("  [1] Quick Scan  — service presence and resource counts")
-        print("  [2] Deep Scan   — counts + asset breakdown (slower)")
-        mode_choice = input("  Enter choice [1]: ").strip() or "1"
-        scan_mode = 'deep' if mode_choice == '2' else 'quick'
+        try:
+            mode_choice = utils.prompt_menu(
+                "SCAN MODE",
+                [
+                    "Quick Scan  — service presence and resource counts",
+                    "Deep Scan   — counts + asset breakdown (slower)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
+        scan_mode = 'deep' if mode_choice == 2 else 'quick'
 
     # Discover services
     print(f"\nScanning {len(regions)} region(s) for services in use ({scan_mode} mode)...")

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -1438,7 +1438,7 @@ Examples:
         print("="*60)
         print("SMART SCAN RECOMMENDATIONS")
         print("="*60)
-        print(f"✓ {recommendation_count} export scripts recommended")
+        print(f"{utils.GLYPH_OK} {recommendation_count} export scripts recommended")
         print("  └─ See 'Recommended Scripts' worksheet in Excel export")
         print()
         always_run = len([r for r in df_recommendations.to_dict('records') if r.get('Priority') == 'Always Run'])

--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -411,8 +411,8 @@ class ScriptExecutor:
 
         # Overall statistics
         print(f"Total Scripts:     {self.total_scripts}")
-        print(f"Successful:        {len(successful)} ✓")
-        print(f"Failed:            {len(failed)} ✗")
+        print(f"Successful:        {len(successful)} {utils.GLYPH_OK}")
+        print(f"Failed:            {len(failed)} {utils.GLYPH_FAIL}")
         print(f"Success Rate:      {(len(successful)/self.total_scripts*100):.1f}%")
         print(f"Total Time:        {total_minutes}m {total_seconds}s")
         print()
@@ -423,7 +423,7 @@ class ScriptExecutor:
             print("-" * 80)
             for result in successful:
                 output_info = f" → {result.output_file}" if result.output_file else ""
-                print(f"  ✓ {result.script:<45} {result.duration_formatted:>8}{output_info}")
+                print(f"  {utils.GLYPH_OK} {result.script:<45} {result.duration_formatted:>8}{output_info}")
             print()
 
         # Show failed scripts with error details
@@ -431,7 +431,7 @@ class ScriptExecutor:
             print("FAILED SCRIPTS:")
             print("-" * 80)
             for result in failed:
-                print(f"  ✗ {result.script:<45} {result.duration_formatted:>8}")
+                print(f"  {utils.GLYPH_FAIL} {result.script:<45} {result.duration_formatted:>8}")
                 if result.error_message:
                     # error_message is already truncated to 100 chars for console;
                     # full text is available in result.full_error_message
@@ -498,7 +498,7 @@ class ScriptExecutor:
                 self.results.append(result)
                 if show_progress:
                     self._show_progress(script_name)
-                    print(f"✗ Script not found: {script_name}")
+                    print(f"{utils.GLYPH_FAIL} Script not found: {script_name}")
                     print()
                 if session is not None:
                     utils.record_scan_result(

--- a/scripts/smart_scan/selector.py
+++ b/scripts/smart_scan/selector.py
@@ -394,7 +394,7 @@ class SmartScanSelector:
                 f.write("=" * 80 + "\n")
 
             print()
-            print(f"✓ Checklist saved to: {filename}")
+            print(f"{utils.GLYPH_OK} Checklist saved to: {filename}")
             print()
             return True
 
@@ -426,7 +426,7 @@ class SmartScanSelector:
                 if selected:
                     # Show confirmation
                     print()
-                    print(f"✓ Selected {len(selected)} script(s)")
+                    print(f"{utils.GLYPH_OK} Selected {len(selected)} script(s)")
                     print()
                     confirm = questionary.confirm(
                         "Proceed with these scripts?", default=True, style=CUSTOM_STYLE
@@ -457,9 +457,46 @@ class SmartScanSelector:
                 return None
 
 
+def _plain_text_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
+    """
+    Plain-text fallback selector for when questionary is unavailable.
+
+    Mirrors the questionary flow's core action — choosing which recommended
+    scripts to run — using the shared utils.prompt_multiselect (stdlib only, so
+    it works in a bare CloudShell session). Returns the selected script set, or
+    None if the user backs out.
+    """
+    all_scripts = sorted(recommendations.get("all_scripts", set()))
+    if not all_scripts:
+        utils.log_warning("No recommended scripts to select.")
+        return None
+
+    stats = recommendations.get("coverage_stats", {})
+    print()
+    print("=" * 64)
+    print("  SMART SCAN — SELECT SCRIPTS TO RUN")
+    print("=" * 64)
+    print(f"  Services discovered: {stats.get('total_services_found', 0)}")
+    print(f"  Scripts recommended: {stats.get('total_scripts_recommended', 0)}")
+
+    try:
+        indices = utils.prompt_multiselect(
+            "RECOMMENDED SCRIPTS",
+            all_scripts,
+            all_label="All recommended scripts",
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
+        return None
+
+    return {all_scripts[i - 1] for i in indices}
+
+
 def interactive_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
     """
     Run interactive script selection.
+
+    Uses questionary's rich UI when available, otherwise falls back to a
+    plain-text multi-select (no silent "run everything" degradation).
 
     Args:
         recommendations: Recommendations dict from analyzer
@@ -468,11 +505,8 @@ def interactive_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
         Set of selected scripts, or None if cancelled
     """
     if not QUESTIONARY_AVAILABLE:
-        utils.log_error(
-            "Interactive selection requires questionary library. "
-            "Install it with: pip install questionary>=2.0.0"
-        )
-        return None
+        utils.log_info("questionary not installed — using plain-text selection.")
+        return _plain_text_select(recommendations)
 
     selector = SmartScanSelector(recommendations)
     return selector.run_interactive()

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -480,7 +480,7 @@ def _print_crosscheck_summary(result: Optional[dict[str, Any]]) -> None:
         if len(not_collected) > 10:
             print(f"      ... and {len(not_collected) - 10} more (see report)")
     else:
-        print("  ✓ Every billed service was discovered.")
+        print(f"  {utils.GLYPH_OK} Every billed service was discovered.")
     if unmapped:
         print(f"  • {len(unmapped)} billed service(s) could not be mapped (see report).")
     print("  ─────────────────────────────────────────────────────────────")

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -68,18 +68,18 @@ except ImportError as exc:
 
 
 def _prompt_scan_mode() -> str:
-    """Prompt user for Quick or Deep scan mode. Exits on b/x."""
-    print()
-    print("  ─── SCAN MODE ───────────────────────────────────────────────")
-    print("  [1] Quick Scan  — discover services, save a report, done")
-    print("  [2] Deep Scan   — discover services, then run export scripts")
-    print("  ─────────────────────────────────────────────────────────────")
-    print("  [B] Back    [X] Exit")
-    print("  ─────────────────────────────────────────────────────────────")
-    choice = input("  Enter choice [1]: ").strip().lower() or "1"
-    if choice in ('b', 'x'):
+    """Prompt user for Quick or Deep scan mode. Exits on b/x/q."""
+    try:
+        choice = utils.prompt_menu(
+            "SCAN MODE",
+            [
+                "Quick Scan  — discover services, save a report, done",
+                "Deep Scan   — discover services, then run export scripts",
+            ],
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
         sys.exit(0)
-    return 'deep' if choice == '2' else 'quick'
+    return 'deep' if choice == 2 else 'quick'
 
 
 def _format_detail(detail: dict[str, int]) -> str:
@@ -616,27 +616,31 @@ def main() -> None:
         return
 
     print()
-    print("  ─── RUN SCRIPTS ─────────────────────────────────────────────")
     print(f"  {n_scripts} export scripts are recommended for this account.")
-    print("  [Y] Run all recommended scripts now")
-    print("  [N] Exit — report saved, run scripts later")
-    print("  [C] Customize — choose specific scripts to run")
-    print("  ─────────────────────────────────────────────────────────────")
-    choice = input("  Enter choice [Y/N/C] (default N): ").strip().upper() or "N"
+    try:
+        gate = utils.prompt_menu(
+            "RUN SCRIPTS",
+            [
+                "Run all recommended scripts now",
+                "Exit — report saved, run scripts later",
+                "Customize — choose specific scripts to run",
+            ],
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
+        utils.log_info("Exiting. Reports saved.")
+        return
 
-    if choice == 'N':
+    if gate == 2:
         utils.log_info("Exiting. Reports saved.")
         return
 
     selected_scripts = recommendations.get('all_scripts', set())
 
-    if choice == 'C':
+    if gate == 3:
+        # interactive_select handles the questionary / plain-text fallback itself.
         try:
-            from smart_scan.selector import QUESTIONARY_AVAILABLE, interactive_select
-            if QUESTIONARY_AVAILABLE:
-                selected_scripts = interactive_select(recommendations) or set()
-            else:
-                utils.log_warning("questionary not installed — running all recommended scripts")
+            from smart_scan.selector import interactive_select
+            selected_scripts = interactive_select(recommendations) or set()
         except ImportError:
             utils.log_warning("Selector unavailable — running all recommended scripts")
 
@@ -658,10 +662,10 @@ def main() -> None:
         prev = interrupted_smart[0]
         n_done = len(prev.get("results", []))
         n_total = len(prev.get("planned", []))
-        ans = input(
-            f"  Resume interrupted smart scan? ({n_done}/{n_total} scripts done) [y/n]: "
-        ).strip().lower()
-        if ans == "y":
+        if utils.prompt_for_confirmation(
+            f"Resume interrupted smart scan? ({n_done}/{n_total} scripts done)",
+            default=False,
+        ):
             utils.resume_scan_session(prev)
             session = prev
             done_keys = {r["key"] for r in prev.get("results", []) if r.get("status") == "success"}

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -207,9 +207,7 @@ def install_dependency(dependency):
         bool: True if installed successfully, False otherwise
     """
     print(f"\nPackage '{dependency}' is required but not installed.")
-    response = input(f"Would you like to install {dependency}? (y/n): ").lower()
-
-    if response == 'y':
+    if utils.prompt_for_confirmation(f"Would you like to install {dependency}?", default=False):
         try:
             import subprocess
             print(f"Installing {dependency}...")
@@ -1006,32 +1004,27 @@ def _show_session_detail(session: dict) -> None:
 def show_scan_history() -> None:
     """Display recent scan sessions and allow drilling into details."""
     sessions = utils.load_scan_sessions(10)
-    SEP = "─" * 70
-    print(f"\nSCAN HISTORY (last {len(sessions)} sessions)")
-    print(SEP)
-
     if not sessions:
+        print("\nSCAN HISTORY")
+        print("─" * 70)
         print("  No scan sessions found.")
         input("\nPress Enter to return...")
         return
 
-    for idx, s in enumerate(sessions, 1):
+    options = []
+    for s in sessions:
         n_done = len(s.get("results", []))
         n_total = len(s.get("planned", []))
         status = s.get("status", "?")
         icon = "✅" if status == "completed" else ("⚠ " if status == "running" else "?")
         ts = s.get("started_at", "")[:16].replace("T", " ")
-        print(f"  [{idx}] {icon} {s.get('label', s.get('scan_type'))} — {n_done}/{n_total} | {ts}")
+        options.append(f"{icon} {s.get('label', s.get('scan_type'))} — {n_done}/{n_total} | {ts}")
 
-    print(SEP)
-    print("  [#] View session details    [B] Back")
-    choice = input("\nSelect: ").strip().upper()
-    if choice == "B" or not choice:
+    try:
+        choice = utils.prompt_menu(f"SCAN HISTORY (last {len(sessions)} sessions)", options)
+    except (BackSignal, ExitToMainSignal, QuitSignal):
         return
-    if choice.isdigit():
-        idx = int(choice) - 1
-        if 0 <= idx < len(sessions):
-            _show_session_detail(sessions[idx])
+    _show_session_detail(sessions[choice - 1])
 
 
 def _resume_org_scan_from_session(session: dict) -> None:
@@ -1072,8 +1065,9 @@ def _resume_org_scan_from_session(session: dict) -> None:
         input("  Press Enter to return to menu...")
         return
 
-    confirm = input(f"\n  Run {script_name} across {n_remaining} remaining account(s)? (y/n): ").strip().lower()
-    if confirm != "y":
+    if not utils.prompt_for_confirmation(
+        f"\n  Run {script_name} across {n_remaining} remaining account(s)?", default=False
+    ):
         return
 
     utils.resume_scan_session(session)
@@ -1137,18 +1131,21 @@ def _startup_interrupted_check() -> None:
     print(f"  {label}")
     print(f"  Started: {ts}  |  Completed: {n_done}/{n_total}")
     print(f"  {SEP}")
-    print("  [Y] Resume now")
-    print("  [N] Skip — go to main menu")
-    print("  [H] View scan history")
     print(f"  {SEP}")
 
-    choice = input("\n  Choice [Y/N/H]: ").strip().upper() or "N"
+    try:
+        choice = utils.prompt_menu(
+            "RESUME INTERRUPTED SCAN?",
+            ["Resume now", "Skip — go to main menu", "View scan history"],
+        )
+    except (BackSignal, ExitToMainSignal, QuitSignal):
+        return
 
-    if choice == "H":
+    if choice == 3:
         show_scan_history()
         return
 
-    if choice != "Y":
+    if choice != 1:
         return
 
     if scan_type == "org-scan":
@@ -1161,7 +1158,7 @@ def _startup_interrupted_check() -> None:
         subprocess.run([sys.executable, str(smart_scan_path)], env=child_env)
         input("\n  Press Enter to return to menu...")
     else:
-        print(f"\n  ❌ Unknown scan type '{scan_type}' — use [H] Scan History to view details.")
+        print(f"\n  ❌ Unknown scan type '{scan_type}' — use Scan History to view details.")
         input("  Press Enter to return to menu...")
 
 

--- a/tests/smart_scan/test_selector.py
+++ b/tests/smart_scan/test_selector.py
@@ -6,6 +6,7 @@ Tests import structure, class instantiation, and method availability.
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -91,3 +92,33 @@ class TestSmartScanSelectorStructure:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestPlainTextFallback:
+    """The no-questionary path must offer a real plain-text selection,
+    not silently degrade to 'run everything' (the pre-fix bug)."""
+
+    SORTED = sorted(MOCK_RECOMMENDATIONS["all_scripts"])
+
+    def test_fallback_returns_selected_subset(self):
+        import utils
+        from smart_scan import selector
+        # sorted(all_scripts): rows 1..N. Pick rows 1 and 3.
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False), \
+             patch.object(utils, "prompt_multiselect", return_value=[1, 3]):
+            result = selector.interactive_select(MOCK_RECOMMENDATIONS)
+        assert result == {self.SORTED[0], self.SORTED[2]}
+
+    def test_fallback_back_returns_none(self):
+        import utils
+        from smart_scan import selector
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False), \
+             patch.object(utils, "prompt_multiselect", side_effect=utils.BackSignal):
+            result = selector.interactive_select(MOCK_RECOMMENDATIONS)
+        assert result is None
+
+    def test_fallback_empty_recommendations_returns_none(self):
+        from smart_scan import selector
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False):
+            result = selector.interactive_select({"all_scripts": set()})
+        assert result is None

--- a/tests/test_exporters/test_resource_bundle.py
+++ b/tests/test_exporters/test_resource_bundle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/_resource_bundle.py — the shared all-in-one bundle driver.
+
+Focus: prompt_script_selection() now delegates to utils.prompt_multiselect
+(single-voice), maps chosen indices back to (display, filename) tuples, and
+propagates the navigation signals (BackSignal / ExitToMainSignal / QuitSignal)
+instead of returning 'back'/'exit' sentinel strings.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+import _resource_bundle as bundle  # noqa: E402
+
+import utils  # noqa: E402
+
+SCRIPTS = [
+    ("Billing Export", "billing_export.py"),
+    ("Budgets Export", "budgets_export.py"),
+    ("Savings Plans Export", "savings_plans_export.py"),
+]
+
+
+class TestPromptScriptSelection:
+    def test_maps_indices_to_tuples(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', return_value=[1, 3]):
+            result = bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        assert result == [SCRIPTS[0], SCRIPTS[2]]
+
+    def test_auto_run_returns_all(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
+        result = bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        assert result == SCRIPTS
+
+    def test_back_signal_propagates(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', side_effect=utils.BackSignal), \
+             pytest.raises(utils.BackSignal):
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+
+    def test_exit_to_main_signal_propagates(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', side_effect=utils.ExitToMainSignal), \
+             pytest.raises(utils.ExitToMainSignal):
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+
+    def test_all_label_passed_through(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', return_value=[1]) as mock_ms:
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        # An explicit All row replaces the old magic 0 = All convention.
+        _, kwargs = mock_ms.call_args
+        assert "all_label" in kwargs and kwargs["all_label"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -336,8 +336,13 @@ class TestPromptMenu:
         with patch('builtins.input', return_value='b'), pytest.raises(utils.BackSignal):
             utils.prompt_menu("TEST MENU", ["Option A"])
 
-    def test_exit_raises_signal(self):
-        with patch('builtins.input', return_value='x'), pytest.raises(utils.QuitSignal):
+    def test_exit_raises_exit_to_main_signal(self):
+        # 'x' = main menu — the single-voice standard (was QuitSignal before).
+        with patch('builtins.input', return_value='x'), pytest.raises(utils.ExitToMainSignal):
+            utils.prompt_menu("TEST MENU", ["Option A"])
+
+    def test_quit_raises_quit_signal(self):
+        with patch('builtins.input', return_value='q'), pytest.raises(utils.QuitSignal):
             utils.prompt_menu("TEST MENU", ["Option A"])
 
     def test_invalid_then_valid(self):
@@ -349,6 +354,22 @@ class TestPromptMenu:
         monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
         result = utils.prompt_menu("TEST MENU", ["Option A", "Option B"])
         assert result == 1
+
+
+class TestNavFooter:
+    """Locks the single-voice navigation footer + interaction constants."""
+
+    def test_full_footer_wording(self):
+        assert utils._nav_footer() == "  b = back  |  x = main menu  |  q = quit"
+
+    def test_footer_includes_only_enabled_keys(self):
+        assert utils._nav_footer(allow_back=False) == "  x = main menu  |  q = quit"
+        assert utils._nav_footer(allow_exit=False, allow_quit=False) == "  b = back"
+
+    def test_constants(self):
+        assert utils.GLYPH_OK == "✅"
+        assert utils.GLYPH_FAIL == "❌"
+        assert utils.MSG_INVALID_SELECTION == "Invalid selection. Please try again."
 
 
 class TestPromptRegionSelectionNew:
@@ -384,6 +405,15 @@ class TestPromptRegionSelectionNew:
     def test_exit_returns_string(self, monkeypatch):
         monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
         with patch('utils.prompt_menu', side_effect=utils.QuitSignal), \
+             patch('utils.get_default_regions', return_value=['us-east-1']), \
+             patch('utils.detect_partition', return_value='aws'):
+            result = utils.prompt_region_selection()
+        assert result == 'exit'
+
+    def test_exit_to_main_returns_string(self, monkeypatch):
+        # 'x' from the region menu surfaces as ExitToMainSignal → 'exit'.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_menu', side_effect=utils.ExitToMainSignal), \
              patch('utils.get_default_regions', return_value=['us-east-1']), \
              patch('utils.detect_partition', return_value='aws'):
             result = utils.prompt_region_selection()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -372,6 +372,63 @@ class TestNavFooter:
         assert utils.MSG_INVALID_SELECTION == "Invalid selection. Please try again."
 
 
+class TestPromptMultiselect:
+    """Tests for prompt_multiselect() — the shared numbered multi-select."""
+
+    OPTS = ["Alpha", "Bravo", "Charlie"]
+
+    def test_single_pick(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='2'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [2]
+
+    def test_multi_pick(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='1 3'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [1, 3]
+
+    def test_dedupe_preserves_order(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='3 1 3'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [3, 1]
+
+    def test_all_row_selects_everything(self, monkeypatch):
+        # With an All row, row 1 = All → returns every option index.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='1'):
+            assert utils.prompt_multiselect("PICK", self.OPTS, all_label="All") == [1, 2, 3]
+
+    def test_all_row_offsets_option_indices(self, monkeypatch):
+        # Row 2 (with All at row 1) maps back to option index 1.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='2 4'):
+            assert utils.prompt_multiselect("PICK", self.OPTS, all_label="All") == [1, 3]
+
+    def test_back_raises_signal(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='b'), pytest.raises(utils.BackSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_exit_raises_exit_to_main(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='x'), pytest.raises(utils.ExitToMainSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_quit_raises_quit(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='q'), pytest.raises(utils.QuitSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_invalid_then_valid(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', side_effect=['z', '9', '2']):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [2]
+
+    def test_auto_run_returns_all(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
+        assert utils.prompt_multiselect("PICK", self.OPTS) == [1, 2, 3]
+
+
 class TestPromptRegionSelectionNew:
     """Tests for the rewritten prompt_region_selection() function."""
 

--- a/utils.py
+++ b/utils.py
@@ -330,6 +330,96 @@ def prompt_menu(
         print(MSG_INVALID_SELECTION)
 
 
+def prompt_multiselect(
+    title: str,
+    options: list[str],
+    all_label: Optional[str] = None,
+    allow_back: bool = True,
+    allow_exit: bool = True,
+    allow_quit: bool = True,
+) -> list[int]:
+    """
+    Present a numbered multi-select menu and return the chosen option indices.
+
+    Numbers are entered space-separated (e.g. ``1 3 5``). When *all_label* is
+    provided it is shown as the first numbered row; selecting it returns every
+    option — this replaces the old magic ``0 = All`` convention so every row is
+    a real, consistently-numbered choice. Navigation follows the single-voice
+    standard: ``b``/``x``/``q`` surface as BackSignal / ExitToMainSignal /
+    QuitSignal.
+
+    Args:
+        title: Menu title displayed above the border.
+        options: Selectable option labels (shown after the optional All row).
+        all_label: If given, adds a leading "select all" row with this label.
+        allow_back / allow_exit / allow_quit: Which navigation keys to offer.
+
+    Returns:
+        list[int]: 1-based indices into *options* (never empty).
+
+    Raises:
+        BackSignal / ExitToMainSignal / QuitSignal per the standard.
+    """
+    if is_auto_run():
+        return list(range(1, len(options) + 1))
+
+    has_all = all_label is not None
+    while True:
+        print(f"\n{title}")
+        print("=" * 64)
+        rows = ([all_label] if has_all else []) + list(options)
+        for i, row in enumerate(rows, 1):
+            print(f"  {i:2d}. {row}")
+        print("-" * 64)
+        if allow_back or allow_exit or allow_quit:
+            print(_nav_footer(allow_back, allow_exit, allow_quit))
+        print("=" * 64)
+
+        try:
+            raw = input(
+                "Enter number(s) separated by spaces (e.g. 1  or  1 3 5): "
+            ).strip().lower()
+        except KeyboardInterrupt:
+            print()
+            if allow_quit:
+                raise QuitSignal from None
+            continue
+
+        if allow_back and raw == 'b':
+            raise BackSignal
+        if allow_exit and raw == 'x':
+            raise ExitToMainSignal
+        if allow_quit and raw == 'q':
+            raise QuitSignal
+
+        tokens = raw.split()
+        if not tokens or not all(t.isdigit() for t in tokens):
+            print(MSG_INVALID_SELECTION)
+            continue
+
+        picks = [int(t) for t in tokens]
+        if any(p < 1 or p > len(rows) for p in picks):
+            print(MSG_INVALID_SELECTION)
+            continue
+
+        # The "All" row (row 1, when present) short-circuits to every option.
+        if has_all and 1 in picks:
+            return list(range(1, len(options) + 1))
+
+        # De-dupe, preserve order, and offset past the All row.
+        offset = 1 if has_all else 0
+        seen: set = set()
+        result: list[int] = []
+        for p in picks:
+            option_index = p - offset
+            if option_index >= 1 and option_index not in seen:
+                seen.add(option_index)
+                result.append(option_index)
+        if result:
+            return result
+        print(MSG_INVALID_SELECTION)
+
+
 def prompt_region_selection(
     service_name: Optional[str] = None,
 ) -> Union[list[str], str]:

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,41 @@ class QuitSignal(Exception):
     """Raised when the user enters 'q' to quit."""
 
 
+# ---------------------------------------------------------------------------
+# Interaction constants — the single-voice standard for every interactive prompt
+# ---------------------------------------------------------------------------
+
+#: Status glyphs. Green check / red x is the tool-wide standard — use these
+#: instead of ✓/✗/ERROR: so status output reads the same everywhere.
+GLYPH_OK = "✅"
+GLYPH_FAIL = "❌"
+
+#: The single invalid-input message for every menu / selection prompt.
+MSG_INVALID_SELECTION = "Invalid selection. Please try again."
+
+
+def _nav_footer(
+    allow_back: bool = True,
+    allow_exit: bool = True,
+    allow_quit: bool = True,
+) -> str:
+    """
+    Build the canonical navigation footer shown beneath interactive menus.
+
+    Returns a single line like ``  b = back  |  x = main menu  |  q = quit``,
+    including only the keys that are enabled. The wording and punctuation here
+    are the single-voice standard — every menu footer routes through this.
+    """
+    parts = []
+    if allow_back:
+        parts.append("b = back")
+    if allow_exit:
+        parts.append("x = main menu")
+    if allow_quit:
+        parts.append("q = quit")
+    return "  " + "  |  ".join(parts)
+
+
 def get_version() -> str:
     """Return the installed package version, or 'dev' if not installed."""
     try:
@@ -231,22 +266,28 @@ def prompt_menu(
     options: list[str],
     allow_back: bool = True,
     allow_exit: bool = True,
+    allow_quit: bool = True,
 ) -> int:
     """
     Display a bordered numbered menu and return the user's choice.
+
+    Navigation follows the single-voice standard: ``b`` = back, ``x`` = main
+    menu, ``q`` = quit — surfaced as BackSignal / ExitToMainSignal / QuitSignal.
 
     Args:
         title: Menu title displayed above the border
         options: List of option strings (displayed as 1..N)
         allow_back: If True, show and accept 'b' to go back (default: True)
-        allow_exit: If True, show and accept 'x' to exit (default: True)
+        allow_exit: If True, show and accept 'x' for the main menu (default: True)
+        allow_quit: If True, show and accept 'q' to quit (default: True)
 
     Returns:
         int 1..N if the user picks a numbered option.
 
     Raises:
         BackSignal: if the user enters 'b' (and allow_back is True).
-        QuitSignal: if the user enters 'x' (and allow_exit is True) or
+        ExitToMainSignal: if the user enters 'x' (and allow_exit is True).
+        QuitSignal: if the user enters 'q' (and allow_quit is True) or
             presses Ctrl-C.
     """
     if is_auto_run():
@@ -257,13 +298,8 @@ def prompt_menu(
     for i, opt in enumerate(options, 1):
         print(f"  {i}. {opt}")
     print("-" * 64)
-    footer_parts = []
-    if allow_back:
-        footer_parts.append("b. Back")
-    if allow_exit:
-        footer_parts.append("x. Exit")
-    if footer_parts:
-        print("  " + "    ".join(footer_parts))
+    if allow_back or allow_exit or allow_quit:
+        print(_nav_footer(allow_back, allow_exit, allow_quit))
     print("=" * 64)
 
     valid = {str(i) for i in range(1, len(options) + 1)}
@@ -271,13 +307,15 @@ def prompt_menu(
         valid.add("b")
     if allow_exit:
         valid.add("x")
+    if allow_quit:
+        valid.add("q")
 
     while True:
         try:
             choice = input("Enter your choice: ").strip().lower()
         except KeyboardInterrupt:
             print()
-            if allow_exit:
+            if allow_quit:
                 raise QuitSignal from None
             continue
 
@@ -285,9 +323,11 @@ def prompt_menu(
             if choice == 'b':
                 raise BackSignal
             if choice == 'x':
+                raise ExitToMainSignal
+            if choice == 'q':
                 raise QuitSignal
             return int(choice)
-        print("Invalid choice. Please try again.")
+        print(MSG_INVALID_SELECTION)
 
 
 def prompt_region_selection(
@@ -342,7 +382,7 @@ def prompt_region_selection(
             choice = prompt_menu("REGION SELECTION", options)
         except BackSignal:
             return 'back'
-        except QuitSignal:
+        except (ExitToMainSignal, QuitSignal):
             return 'exit'
 
         if choice == 1:
@@ -373,7 +413,7 @@ def prompt_region_selection(
                     for i, r in enumerate(available, 1):
                         print(f"  {i:2d}. {r}")
                 print("=" * 64)
-                print("  b. Back    x. Exit")
+                print(_nav_footer())
                 print("=" * 64)
 
                 try:
@@ -386,7 +426,7 @@ def prompt_region_selection(
 
                 if raw == 'b':
                     break  # back to main region menu
-                if raw == 'x':
+                if raw in ('x', 'q'):
                     return 'exit'
 
                 tokens = raw.split()


### PR DESCRIPTION
Brings every interactive surface in StratusScan onto **one voice**: numbered menus, one navigation contract (`b` = back · `x` = main menu · `q` = quit via the signal classes), two-tier confirmations (Enter-to-run review gate + `(y/N)`), `✅`/`❌` status glyphs, and one invalid-input message. Motivated by the "Cost Management menu jumps all over the place" report — the tool was built feature-by-feature and had ~5 competing prompt dialects.

Landed in 6 reviewable phases (one commit each), full suite green throughout (**1274 passed / 2 skipped**).

## Phases
1. **Helpers foundation** (`utils.py`) — fixed the `prompt_menu` `x`=Quit collision (now `x`=ExitToMain, `q`=Quit), added `_nav_footer`, `GLYPH_OK`/`GLYPH_FAIL`/`MSG_INVALID_SELECTION`.
2. **Bundles** — new shared `prompt_multiselect` (explicit "All" row, no magic `0`, real signals) replaces the hand-rolled selector; one driver fixes all 12 all-in-one flows. **This is the Cost Management fix.**
3. **Bespoke exporters** — s3 / health / billing (free-text date → menu) / services_in_use onto the shared helpers.
4. **smart_scan** — scan-mode / run / resume prompts unified; a real plain-text fallback replaces the silent "run everything" degradation.
5. **Config wizards** — `configure.py` submenus + all of `advanced_settings.py`. The rich `configure.py` status dashboard + `[S]/[U]` save model are intentionally kept.
6. **Sweep + docs** — `stratusscan.py` history/resume prompts, standalone glyph drift, and a "Single Voice" design principle.

## Bugs fixed along the way (independent of cosmetics)
- Cost bundle **silently skipped Compute Optimizer** under AUTO_RUN (gate defaulted False).
- smart_scan **ran all recommended scripts** when questionary was absent — now a genuine text multi-select fallback (CloudShell-first).
- services_in_use **ignored** `back`/`exit` at region selection (scanned the sentinel string as a region list).

## Tests
+91 lines in `test_utils.py` (prompt_menu signals, prompt_multiselect, footer/constants), +60 new `test_resource_bundle.py`, +31 in `test_selector.py` (fallback). No behavior regressions; the config wizards have no test suite, so those changes were diff-reviewed + smoke-imported.

## Kept by design
- `configure.py` dashboard + `[S] Save & Exit` / `[U] Exit Without Saving` (status-dashboard, matches `stratusscan.py`'s main menu; flattening loses inline status).
- `[✓]`/`[✗]` log-line prefixes in `log_success`/`log_error` (a deliberate log style, distinct from the `✅/❌` status glyphs).

## Deferred (non-blocking)
Shared validated-numeric helper for `advanced_settings.py`; `[default]` vs `(Enter to keep)` idiom unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)